### PR TITLE
Updates from upstream quickstart - CTKey support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
             echo "export CLOUDFRONT_DOMAIN_NAME=\$${CIRCLE_BRANCH//-/_}_CLOUDFRONT_DOMAIN_NAME" >> $BASH_ENV
             echo "export INFRASTRUCTURE_TYPE=\$${CIRCLE_BRANCH//-/_}_INFRASTRUCTURE_TYPE" >> $BASH_ENV
       - run: sudo npm install -g serverless
+      - run: ./.circleci/ctkey.sh
       - run:
           name: deploy
           no_output_timeout: 60m
@@ -86,6 +87,7 @@ jobs:
           TERM: xterm
     steps:
       - checkout
+      - run: ./.circleci/ctkey.sh
       - run:
           name: Run TestCafe suite
           command: |

--- a/.circleci/ctkey.sh
+++ b/.circleci/ctkey.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set +x
+
+if [ -n "$CTKEY_USERNAME" ]; then
+  rm -rf ctkey ctkey.zip
+  curl -O https://ctkey.s3.amazonaws.com/ctkey.zip
+  unzip ctkey.zip -d ctkey
+  mkdir ~/.aws
+  ./ctkey/ctkey-linux savecreds --url=$CTKEY_URL --account=$CTKEY_ACCOUNT_ID --iam-role=$CTKEY_IAM_ROLE --idms=2
+  echo "export AWS_PROFILE=${CTKEY_ACCOUNT_ID}_${CTKEY_IAM_ROLE}" >> $BASH_ENV
+fi


### PR DESCRIPTION
https://github.com/CMSgov/macpro-quickstart-serverless/issues/33
See https://github.com/CMSgov/macpro-quickstart-serverless/pull/37

Allow for cloudtamer service users to use ctkey to auth and deploy to aws