### PR TITLE
OY2-474 Added encryption at rest for attachments

### DIFF
--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -24,7 +24,7 @@ custom:
   s3:
     host: localhost
     directory: /tmp
-    cors: resource/local-cors-policy.xml
+    cors: resources/local-cors-policy.xml
 
 resources:
   Resources:
@@ -46,6 +46,11 @@ resources:
                 - DELETE
                 - HEAD
               MaxAge: 3000
+        #Set at rest encryption
+        BucketEncryption:
+            ServerSideEncryptionConfiguration:
+              - ServerSideEncryptionByDefault:
+                  SSEAlgorithm: AES256
 
   # Print out the name of the bucket that is created
   Outputs:


### PR DESCRIPTION
Changes:
1. Added encryption at rest for attachments

Test:
1. Submit a new SPA with at least one attachment.
2. Login to the AWS console, locate the attachment file and click it in the console.
3. Click on the properties tab and verify that Encryption is set to AES-256.

![image](https://user-images.githubusercontent.com/63804190/95093211-864f5680-06f6-11eb-9c87-a5e3336a74e6.png)
