### PR TITLE
OY2-626 SPA optional attachments match the AC

### DIFF
--- a/services/ui-src/src/changeRequest/Spa.js
+++ b/services/ui-src/src/changeRequest/Spa.js
@@ -18,7 +18,7 @@ export default function SpaRai() {
   const requiredUploads = ["CMS Form 179", "SPA Pages"];
   const optionalUploads = [
     "Cover Letter",
-    "Existing state plan pages",
+    "Existing state plan page(s)",
     "Tribal Consultation",
     "Public Notice",
     "Standard Funding Questions (SFQs)",


### PR DESCRIPTION
Not sure why we had this story.... literally, the only difference was page(s)

Demonstrate that State User can see and attach the following optional attachment types:

Cover Letter

Existing state plan page(s)

Document Demonstrating Good-Faith Tribal Engagement

Tribal Consultation

Public Notice

Standard Funding Questions (SFQs)

Other

https://d12vx724aznve6.cloudfront.net/ 