### PR TITLE
OY2-1059 Change return code to 200

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -138,7 +138,7 @@ resources:
               - CloudFrontDefaultCertificate: true
           CustomErrorResponses:
             - ErrorCode: 403
-              ResponseCode: 403
+              ResponseCode: 200 # Returning a 200 allows the react app to serve the file correctly
               ResponsePagePath: /index.html
           WebACLId:
             Fn::GetAtt:


### PR DESCRIPTION
Changes:
1. Change HTTP return code on missing pages to 200, so the React app can serve all pages without errors.

Test:
1. Login to the SPA form.
2. Open the browser's developer tools and view the network tab.  Clear it if there is anything in it.
3. Access any of the form pages.  Verify that there is no 403 error shown in the network tab.

Test endpoint: https://d2yz0qa96tbx1m.cloudfront.net