### PR TITLE
OY2-1497 Reinstate Placeholder text for SPA and Waiver forms

### DIFF
--- a/services/ui-src/src/changeRequest/Spa.js
+++ b/services/ui-src/src/changeRequest/Spa.js
@@ -183,6 +183,7 @@ export default function Spa() {
           name={FIELD_NAMES.TRANSMITTAL_NUMBER}
           onChange={handleInputChange}
           disabled={isReadOnly}
+          placeholder='AA-20-####'
           value={changeRequest.transmittalNumber}
         ></input>
         {isReadOnly && (

--- a/services/ui-src/src/changeRequest/Waiver.js
+++ b/services/ui-src/src/changeRequest/Waiver.js
@@ -226,6 +226,7 @@ export default function Waiver() {
           name={FIELD_NAMES.TRANSMITTAL_NUMBER}
           onChange={handleInputChange}
           disabled={isReadOnly}
+          placeholder="AA.####.R##.##"
           value={changeRequest.transmittalNumber}
         ></input>
         {isReadOnly && (


### PR DESCRIPTION
Changes:
- Added the placeholder text to SPA ID Field in SPA.js and Waiver Number field in Waiver.js

Test:
- Login to the SPA form.
- Select "Submit New SPA" from Dashboard
- Verify that the placeholder text AA-20-#### is there 
- Select "Submit New Waiver" from Dashboard
- Verify that the placeholder text AA.####.R##.## is there 

https://d2zi65ek804f9s.cloudfront.net

