### PR TITLE
OY2 932 Dashboard Redesign

### DIFF
--- a/services/ui-src/src/containers/Dashboard.js
+++ b/services/ui-src/src/containers/Dashboard.js
@@ -64,32 +64,32 @@ export default function Dashboard() {
       let link = "/" + changeRequest.type + "/" + changeRequest.id;
       switch (changeRequest.type) {
         case CHANGE_REQUEST_TYPES.SPA:
-          title = "SPA " + changeRequest.transmittalNumber;
+          title = "SPA Submission: " + changeRequest.transmittalNumber;
           break;
         case CHANGE_REQUEST_TYPES.WAIVER:
-          title = "Waiver " + changeRequest.transmittalNumber;
+          title = "Waiver Submission: " + changeRequest.transmittalNumber;
           break;
 
         case CHANGE_REQUEST_TYPES.SPA_RAI:
-          title = "RAI for SPA " + changeRequest.transmittalNumber;
+          title = "Response to RAI for SPA Submission: " + changeRequest.transmittalNumber;
           break;
 
         case CHANGE_REQUEST_TYPES.WAIVER_RAI:
-          title = "RAI for Waiver " + changeRequest.transmittalNumber;
+          title = "Response to RAI for Waiver Submission: " + changeRequest.transmittalNumber;
           break;
 
         case CHANGE_REQUEST_TYPES.WAIVER_EXTENSION:
-          title = "Temporary Extension Request for Waiver " + changeRequest.transmittalNumber;
+          title = "Temporary Extension Request for Waiver: " + changeRequest.transmittalNumber;
           break;
 
         default:
-          title = "Unknown record type";
+          title = "Submission type " + changeRequest.type + " needs inclusion in code.";
       }
 
       return (
         <LinkContainer key={changeRequest.id} to={link}>
           <ListGroupItem header={title}>
-            {"Created: " + new Date(changeRequest.createdAt).toLocaleString()}
+            {"Submitted on: " + new Date(changeRequest.createdAt).toLocaleString()}
           </ListGroupItem>
         </LinkContainer>
       );
@@ -145,7 +145,7 @@ export default function Dashboard() {
                   {renderChangeRequestList(changeRequestList)}
                 </ListGroup>
               ) : (
-                  <div className="list-group">You have no submissions yet</div>
+                  <div className="empty-list">You have no submissions yet</div>
                 )}
             </div>
           )}

--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -138,7 +138,7 @@ input[type="file"] {
     @extend .ds-l-sm-col--12;
     @extend .ds-l-col--12;
     @extend .ds-u-align-items--start;
-    @extend .ds-u-padding-left--2;
+    @extend .ds-u-padding-left--4;
   }
   .action-title {
     @extend .ds-l-row;
@@ -155,5 +155,8 @@ input[type="file"] {
     @extend .ds-u-border--1;
     @extend .ds-u-margin--2;
     @extend .ds-u-padding--5;
+  }
+  .list-group-item {
+    @extend .ds-u-text-decoration--none;
   }
 }


### PR DESCRIPTION
PR test link: https://d337kkfrzq6vpf.cloudfront.net/

AC - SPA Form Design: My dashboard page should include a left-hand nav menu of submissions I can make and provide a right-hand at-a-glance view of submissions I’ve made in the past.

![SPA-Waiver_Platform_101520_Page_9](https://user-images.githubusercontent.com/70273267/97461014-b19f1d00-1913-11eb-9aa4-883677295e74.jpg)

Changes:
- Updated Dashboard.js to match structure of page in screenshot
- Updated language on list items to better match screenshot
- NOTE: it was a personal choice to leave the left column links indented slightly and also to keep the IDs in the list items.
- Updated index.scss to manipulate styles to match with screenshot

Tests:
1. Log in to SPA Form
2. Observe Dashboard and compare to screenshot
3. Complete each form type and view the list items created, verifying that they are identified with descriptive language.
4. If you are wanting some “fun” - change the window sizing and see the results.

PR test link: https://d337kkfrzq6vpf.cloudfront.net/