### PR TITLE
OY2-0000 include s3 local set up in documentation

### DIFF
--- a/services/app-api/README.md
+++ b/services/app-api/README.md
@@ -5,15 +5,15 @@
 2. Install the latest Node distribution 
 3. Install NPM globaly
 4. Install serverless globally
+5. Install the serverless s3 offline package by going to [/macstack-spa-submission-form/services/uploads](/macstack-spa-submission-form/services/uploads) and run `npm install`
 
 Install the serverless Dynamo DB offline package by running the following command:
-
 ```
 npm install
 sls dynamodb install
 ```
-Run the software locally by running the following command:
 
+Run the software locally by running the following command:
 ```
 sls offline start --httpPort 3001 
 ```


### PR DESCRIPTION
### Changes
Documentation update to include prerequisite step for ui-src

### Testing / i.e. ensure that the documentation is accurate by:
1. Follow the steps in the /ui-src README for set up
2. Ensure that the access tokens have been re-set. This will ensure that the s3 access tokens are utilizing the set up performed in step 1. Here's the confluence documentation for setting up access tokens: https://qmacbis.atlassian.net/wiki/spaces/MACPRO/pages/1322975233/MACStack+Setup+Development+Environment
3. Ensure that usage of the form when referencing the remote s3 bucket is working by confirming a form with attachments can be successfully submitted and the submitted form’s attachments can be viewed. 