### PR TITLE
Remove Clickable for header box

### DIFF
--- a/services/ui-src/src/components/Header.js
+++ b/services/ui-src/src/components/Header.js
@@ -108,7 +108,7 @@ function Header(props) {
   }
 
   return (
-    <div tabIndex="0">
+    <div>
       {renderUSABar()}
       {renderBrandBar()}
       {renderNavBar()}


### PR DESCRIPTION
Issue: https://qmacbis.atlassian.net/browse/OY2-2618

Changes:
Remove the TabIndex from the Header to disable click action.

Testing:
From the header click on blue or grey area.  Should not show clicked or highlight.

Endpoint: https://d121thlhbp0lam.cloudfront.net/