### PR TITLE
OY2-2798 remove duplicate word in email text

### DIFF
--- a/services/app-api/email-templates/SPAEmailTemplates.js
+++ b/services/app-api/email-templates/SPAEmailTemplates.js
@@ -31,7 +31,7 @@ class SPAEmailTemplates {
         <b>Files</b>:
         ${getLinksHtml(data.uploads)}
       </p>
-      <p><br>If the contents of this email seem seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
+      <p><br>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
       <p>Thank you!</p>
     `;
 

--- a/services/app-api/email-templates/SPARAIEmailTemplates.js
+++ b/services/app-api/email-templates/SPARAIEmailTemplates.js
@@ -30,7 +30,7 @@ class SPARAIEmailTemplates {
             <b>Files</b>:
             ${getLinksHtml(data.uploads)}
         </p>
-        <p><br>If the contents of this email seem seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
+        <p><br>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
         <p>Thank you!</p>
     `;
 

--- a/services/app-api/email-templates/WaiverEmailTemplates.js
+++ b/services/app-api/email-templates/WaiverEmailTemplates.js
@@ -33,7 +33,7 @@ class WaiverEmailTemplates {
             <b>Files</b>:
             ${getLinksHtml(data.uploads)}
         </p>
-        <p><br>If the contents of this email seem seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
+        <p><br>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
         <p>Thank you!</p>
     `;
 

--- a/services/app-api/email-templates/WaiverExtensionEmailTemplates.js
+++ b/services/app-api/email-templates/WaiverExtensionEmailTemplates.js
@@ -31,7 +31,7 @@ class WaiverExtensionEmailTemplates {
             <b>Files</b>:
             ${getLinksHtml(data.uploads)}
         </p>
-        <p><br>If the contents of this email seem seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
+        <p><br>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
         <p>Thank you!</p>
     `;
 

--- a/services/app-api/email-templates/WaiverRAIEmailTemplates.js
+++ b/services/app-api/email-templates/WaiverRAIEmailTemplates.js
@@ -31,7 +31,7 @@ class WaiverRAIEmailTemplates {
             <b>Files</b>:
             ${getLinksHtml(data.uploads)}
         </p>
-        <p><br>If the contents of this email seem seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
+        <p><br>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
         <p>Thank you!</p>
     `;
 


### PR DESCRIPTION
Endpoint: https://d2njjmjej3mk96.cloudfront.net

### Changes
- update text to remove duplicated word ("seem") in emails sent to CMS inbox for each of the 5 submission types

### Test
- verify that email sent to CMS user does not have the duplicated word "seem"