### PR TITLE
OY2 -2785 Add browser recommendation to FAQ

### DIFF
--- a/services/ui-src/src/containers/FAQ.js
+++ b/services/ui-src/src/containers/FAQ.js
@@ -17,13 +17,14 @@ export default class FAQ extends Component {
                     <h3>State Plan Amendments (SPAs)</h3>
                     <h4 id="spa-id-format">What format is used to enter a SPA ID?</h4>
                     <p>Enter the State Plan Amendment transmittal number. Assign consecutive numbers on a calendar year basis (e.g., 20-0001.xxxx, 20-0002.xxxx, etc.).</p>
-                    <p>The Official Submission package SPA ID must follow the format SS-YY-NNNN where:</p>
+                    <p>The Official Submission package SPA ID must follow the format SS-YY-NNNN OR SS-YY-NNNN-xxxx to include:</p>
                     <ul>
                         <li>SS = 2 alpha character (State Abbreviation)</li>
                         <li>YY = 2 numeric digits (Year)</li>
                         <li>NNNN = 4 numeric digits (Serial number)</li>
+                        <li>xxxx = OPTIONAL 4 character alpha/numeric modifier (Suffix)</li>
                     </ul>
-                    <p> SPA ID may OPTIONALLY include a hyphen then a 4 character alpha/numeric modifier (Suffix), resulting in the optional layout of SS-YY-NNNN-xxxx.</p>
+
                     <h4>What attachments do we need to submit a new SPA?</h4>
                     <p>SPA submission requirements can be found in regulation&nbsp;
                 <a href="https://www.ecfr.gov/cgi-bin/text-idx?SID=7d639b87112e05a57ff40731d647bd05&mc=true&node=se42.4.430_112&rgn=div8" target="_blank" rel="noopener" >42 C.F.R. §430.12.</a>.  Required attachments for form completion are:</p>


### PR DESCRIPTION
EndPoint: https://dbos7fgd3p56j.cloudfront.net
Story: https://qmacbis.atlassian.net/browse/OY2-2785

Changes:
- updated FAQ text to include question/answer about supported browsers
- updated FAQ text to identify SPA ID -xxxx section as optional
- verified with team that the About page ACs could be ignored.

Test:
1. access site, verify FAQ page has new content
2. login to site, verify content is still there

EndPoint: https://dbos7fgd3p56j.cloudfront.net