### PR TITLE
OY2-3657 Updated file size limit

### DIFF
--- a/services/ui-src/src/components/FileUploader.js
+++ b/services/ui-src/src/components/FileUploader.js
@@ -264,7 +264,7 @@ export default class FileUploader extends Component {
 
     return (
       <div>
-        <p className="req-message">Maximum file size of 50MB.</p>
+        <p className="req-message">Maximum file size of {config.MAX_ATTACHMENT_SIZE_MB} MB.</p>
         <p className="req-message">
           <span className="required-mark">*</span> indicates required
           attachment.

--- a/services/ui-src/src/utils/config.js
+++ b/services/ui-src/src/utils/config.js
@@ -1,5 +1,5 @@
 export default {
-    MAX_ATTACHMENT_SIZE_MB: 50,
+    MAX_ATTACHMENT_SIZE_MB: 80,
     ALLOW_DEV_LOGIN: window._env_.ALLOW_DEV_LOGIN,
     s3: {
         REGION: window._env_.S3_ATTACHMENTS_BUCKET_REGION,


### PR DESCRIPTION
Changes:
1. Changes size limit to 80MB as requested
2. Fixed text to use variable instead of hard coded number.

Test:
1. Login to the form and start filling out a change request.
2. Try to attach a file that is less than 80MB, but more than 50MB and verify that it can be attached.
3. Try to attach a file larger than 80MB and verify it cannot be attached.