### PR TITLE
OY2 3723 update email text

### DIFF
--- a/services/app-api/changeRequest/SPA.js
+++ b/services/app-api/changeRequest/SPA.js
@@ -72,7 +72,8 @@ getCMSEmail(data) {
         <b>Files</b>:
         ${getLinksHtml(data.uploads)}
       </p>
-      <p><br>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
+      <br>
+      <p>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
       <p>Thank you!</p>
     `;
 

--- a/services/app-api/changeRequest/SPARAI.js
+++ b/services/app-api/changeRequest/SPARAI.js
@@ -71,7 +71,8 @@ async fieldsValid(data) {
             <b>Files</b>:
             ${getLinksHtml(data.uploads)}
         </p>
-        <p><br>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
+        <br>
+        <p>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
         <p>Thank you!</p>
     `;
 
@@ -100,8 +101,8 @@ async fieldsValid(data) {
         <p>
             <b>Summary</b>:<br>
             ${data.summary}
-            <br>
         </p>
+        <br>
         <p>
             This response confirms the receipt of your State Plan Amendment (SPA or your response to a SPA Request for Additional Information (RAI)). 
             You can expect a formal response to your submittal to be issued within 90 days. To calculate the 90th day, please count the date of receipt 

--- a/services/app-api/changeRequest/Waiver.js
+++ b/services/app-api/changeRequest/Waiver.js
@@ -114,7 +114,8 @@ async fieldsValid(data) {
             <b>Files</b>:
             ${getLinksHtml(data.uploads)}
         </p>
-        <p><br>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
+        <br>
+        <p>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
         <p>Thank you!</p>
     `;
 
@@ -144,8 +145,8 @@ async fieldsValid(data) {
         <p>
             <b>Summary</b>:<br>
             ${data.summary}
-            <br>
         </p>
+        <br>
         <p>
             This response confirms the receipt of your Waiver request or your response to a Waiver Request for Additional Information (RAI)). 
             You can expect a formal response to your submittal to be issued within 90 days, before ${getCMSDateFormat(data.ninetyDayClockEnd)}.

--- a/services/app-api/changeRequest/WaiverExtension.js
+++ b/services/app-api/changeRequest/WaiverExtension.js
@@ -69,7 +69,8 @@ class WaiverExtension {
             <b>Files</b>:
             ${getLinksHtml(data.uploads)}
         </p>
-        <p><br>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
+        <br>
+        <p>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
         <p>Thank you!</p>
     `;
 
@@ -100,8 +101,8 @@ class WaiverExtension {
         <p>
             <b>Summary</b>:<br>
             ${data.summary}
-            <br>
         </p>
+        <br>
         <p>
             This mailbox is for the submittal of Section 1915(b) and 1915(c) non-web-based Waivers, 
             responses to Requests for Additional Information (RAI), and extension requests on Waivers only. 

--- a/services/app-api/changeRequest/WaiverRAI.js
+++ b/services/app-api/changeRequest/WaiverRAI.js
@@ -69,7 +69,8 @@ class WaiverRAI {
             <b>Files</b>:
             ${getLinksHtml(data.uploads)}
         </p>
-        <p><br>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
+        <br>
+        <p>If the contents of this email seem suspicious, do not open them, and instead forward this email to <a href="mailto:SPAM@cms.hhs.gov">SPAM@cms.hhs.gov</a>.</p>
         <p>Thank you!</p>
     `;
 
@@ -100,8 +101,8 @@ class WaiverRAI {
         <p>
             <b>Summary</b>:<br>
             ${data.summary}
-            <br>
         </p>
+        <br>
         <p>
             This response confirms the receipt of your Waiver request or your response to a Waiver Request for Additional Information (RAI)). 
             You can expect a formal response to your submittal to be issued within 90 days. To calculate the 90th day, please count the date of receipt 


### PR DESCRIPTION
EndPoint: https://d2locuqcerm1sq.cloudfront.net
Story: https://qmacbis.atlassian.net/browse/OY2-3725

Changes:
- Updated text of State User emails to match: https://qmacbis.atlassian.net/wiki/spaces/MACPRO/pages/1521647691/SPA+Portal+Emails
- moved the \<br\> tag from the interior of the \<p\> to a place outside.  This should help mark the change in sections without causing future formatting issues (yes, I ended up with the break in the wrong place when I cut n pasted something :) )

Test:
1. Log into endpoint: https://d2locuqcerm1sq.cloudfront.net
2. Submit to each form
3. Check email and verify that State User email text matches text in 
https://qmacbis.atlassian.net/wiki/spaces/MACPRO/pages/1521647691/SPA+Portal+Emails

