### PR TITLE
Temp disable bigmac write - fix Boolean check

### DIFF
--- a/services/stream-functions/serverless.yml
+++ b/services/stream-functions/serverless.yml
@@ -73,7 +73,6 @@ functions:
     role: LamdaSourceDynamoToMskRole
     environment:
       BOOTSTRAP_BROKER_STRING_TLS: ${self:custom.bootstrapBrokerStringTls}
-      SHOULD_WRITE_SOURCE_TO_MSK: false
     maximumRetryAttempts: 2
     vpc:
       securityGroupIds:


### PR DESCRIPTION
As @berryd revealed, the shouldWriteSourceToMsk variable needs an explicit typecast to Boolean.