### PR TITLE
Adding maintainability badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[macstack-spa-submission-form](https://github.com/CMSgov/macstack-spa-submission-form) [![Maintainability](https://api.codeclimate.com/v1/badges/4ad566f3e59e2a003451/maintainability)](https://codeclimate.com/repos/60413fbab8e5b05d5101a9f6/maintainability)
+
 # macstack-spa-submission-form
 #
 


### PR DESCRIPTION
The purpose of this PR is to add in a maintainability build badge to the macstack-spa-submission-form repository. The badge is located within the README.md and is pointing to the main integration branch which is develop. Clicking on the badge itself will take an individual out to code climate in which they can investigate all identified issues.

For more on code climate maintainability please reference :
https://docs.codeclimate.com/docs/maintainability