### PR TITLE
OY2-5196 update profile text

### DIFF
--- a/services/ui-src/src/containers/FAQ.js
+++ b/services/ui-src/src/containers/FAQ.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PageTitleBar from "../components/PageTitleBar";
+import { helpDeskContact } from "../libs/helpDeskContact";
 
 const FAQ = () => {
   
@@ -11,11 +12,11 @@ const FAQ = () => {
       <div className="form-card">
         <h2>Help Desk Contact Information</h2>
         <p>
-            For assistance, please email the MACPro Help Desk at{" "}
-            <a href="mailto:MACPro_HelpDesk@cms.hhs.gov">
-              MACPro_HelpDesk@cms.hhs.gov
-            </a>{" "}
-            or call (833) 228-2540.
+          For assistance, please email the MACPro Help Desk at{" "}
+          <a href={`mailto:${helpDeskContact.email}`}>
+            {helpDeskContact.email}
+          </a>{" "}
+          or call {helpDeskContact.phone}.
         </p>
         <h2>Frequently Asked Questions</h2>
         <h4>What browsers can I use to access the system?</h4>
@@ -109,8 +110,10 @@ const FAQ = () => {
         <h4>What should we do if we don’t receive a confirmation email?</h4>
         <p>
           Refresh your inbox, check your SPAM filters, then contact the MACPro
-          Help Desk (MACPro_HelpDesk@cms.hhs.gov or call (833) 228-2540 or
-          contact your state lead.
+          Help Desk <a href={`mailto:${helpDeskContact.email}`}>
+            {helpDeskContact.email}
+          </a>{" "}
+          or call {helpDeskContact.phone} or contact your state lead.
         </p>
         <h4>Is this considered the official state submission?</h4>
         <p>

--- a/services/ui-src/src/containers/UserPage.js
+++ b/services/ui-src/src/containers/UserPage.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Review } from "@cmsgov/design-system";
 import { useAppContext } from "../libs/contextLib";
 import { userTypes } from "../libs/userTypes";
+import { helpDeskContact } from "../libs/helpDeskContact";
 import PageTitleBar from "../components/PageTitleBar";
 
 /**
@@ -39,10 +40,10 @@ const UserPage = () => {
           name and email cannot be edited in OneMAC. It can be changed in your
           IDM profile. If you have questions, please contact the MACPro Help
           Desk at{" "}
-          <a href="mailto:MACPro_HelpDesk@cms.hhs.gov">
-            MACPro_HelpDesk@cms.hhs.gov
+          <a href={`mailto:${helpDeskContact.email}`}>
+            {helpDeskContact.email}
           </a>{" "}
-          or call (833) 228-2540.
+          or call {helpDeskContact.phone}.
         </div>
         <h3>Profile Information</h3>
         <Review heading="Full Name">{getFullName()}</Review>

--- a/services/ui-src/src/libs/alert-messages.js
+++ b/services/ui-src/src/libs/alert-messages.js
@@ -1,4 +1,5 @@
 import config from "../utils/config";
+import { helpDeskContact } from "./helpDeskContact"
 
 /**
  * Alert types
@@ -114,6 +115,6 @@ export const ALERTS_MSG = {
   CONTACT_HELP_DESK: {
     type: ALERT_TYPES.ERROR,
     heading: "System Submission Error",
-    text: "Please contact the Helpdesk MACPro_HelpDesk@cms.hhs.gov or (833) 228-2540 for additional support.",
+    text: `Please contact the Helpdesk ${helpDeskContact.email} or ${helpDeskContact.phone} for additional support.`,
   }
 };

--- a/services/ui-src/src/libs/helpDeskContact.js
+++ b/services/ui-src/src/libs/helpDeskContact.js
@@ -1,0 +1,4 @@
+export const helpDeskContact = {
+  email: 'MACPro_HelpDesk@cms.hhs.gov',
+  phone: '(833) 228-2540'
+}


### PR DESCRIPTION
Endpoint: https://d3w1xez0iseps6.cloudfront.net
Story: https://qmacbis.atlassian.net/browse/OY2-5196
Updated text:
> Below is the account information for your role as a State Submitter. Your name and email cannot be edited in OneMAC. It can be changed in your IDM profile. If you have questions, please contact the MACPro Help Desk at MACPro_HelpDesk@cms.hhs.gov or call (833) 228-2540.

### Changes
- Profile text on the `/profile` page has been updated
- Created a file in /libs to track the help desk email and phone number since it's referenced in multiple files

### Test
- Login and navigate to `/profile`, then confirm the updated text displays.
- Can also confirm FAQ and System Error alert message continue to show the help desk contact info.