### PR TITLE
Update user DB Schema for Pilot user load and Test user scripts oy2-6766 and oy2-6763

### DIFF
--- a/loadExistingUsers.sh
+++ b/loadExistingUsers.sh
@@ -1,75 +1,82 @@
-#
-# Load DynamoDB User Table with User Status and Roles for Existing Submissions
-#
-#set -x
-
-awsScanRaw=./testSubmissions.raw
-awsScanFormatted=./testSubmissions.txt
-
-branchName=$1
-userTable="cms-spa-form-${branchName}-user-profiles"
-submissionTable=cms-spa-form-${branchName}-change-requests
-
-aws dynamodb scan --table-name ${submissionTable} --projection-expression "#sw.#sw2,#terr" --expression-attribute-names '{"#sw":"user","#sw2":"email","#terr": "territory"}' --output text | grep -v "None" | cut -f2 > ${awsScanRaw}
-
-#
-# Format the AWS Scan output into simple uniq user list of users and statecodes
-#
-while IFS= read -r territory; do
-   read -r email
-   echo "${email}:$territory;" >> tmpFormatted.tmp
-done < ${awsScanRaw}
-
-/usr/bin/sort tmpFormatted.tmp | uniq > ${awsScanFormatted}
-
-createddate=`date '+%s'`
-
-priorEmail=""
-states=""
-
-#
-# Create Users for Submissions
-#
-while IFS= read -r line; do
-   email=`echo $line | cut -f1 -d:`
-   territory=`echo $line | cut -f2 -d:`
-   if [ "${priorEmail}" != "${email}" ]
-   then
-      if [ "${priorEmail}" != "" ]
-      then
-
-        echo '{  "id": { "S": "'${priorEmail}'" }, "type": { "S": "stateuser" }, "attributes": { "L": [ '${states}' ] } } ' > user.json
-        cat user.json
-
-        aws dynamodb put-item --table-name $userTable --item file://user.json
-
-        echo "-------"
-        echo " "
-        states=""
-      fi
-
-   fi
-       if [ "${states}" != "" ]
+ #
+ # Load DynamoDB User Table with User Status and Roles for Existing Submissions
+ #
+ #set -x
+ 
+ if [ -z "$1" ]
+ then
+     echo "usage:  loadExistingUsers <github branch name>"
+ else
+ 
+ awsScanRaw=./testSubmissions.raw
+ awsScanFormatted=./testSubmissions.txt
+ 
+ branchName=$1
+ userTable="cms-spa-form-${branchName}-user-profiles"
+ submissionTable=cms-spa-form-${branchName}-change-requests
+ 
+ aws dynamodb scan --table-name ${submissionTable} --projection-expression "#sw.#sw2,#terr" --expression-attribute-names '{"#sw":"user","#sw2":"email","#terr": "territory"}' --output text | grep -v "None" | cut -f2 > ${awsScanRaw}
+ 
+ #
+ # Format the AWS Scan output into simple uniq user list of users and statecodes
+ #
+ while IFS= read -r territory; do
+    read -r email
+    echo "${email}:$territory;" >> tmpFormatted.tmp
+ done < ${awsScanRaw}
+ 
+ /usr/bin/sort tmpFormatted.tmp | uniq > ${awsScanFormatted}
+ 
+ createddate=`date '+%s'`
+ 
+ priorEmail=""
+ states=""
+ 
+ #
+ # Create Users for Submissions
+ #
+ while IFS= read -r line; do
+    email=`echo $line | cut -f1 -d:`
+    territory=`echo $line | cut -f2 -d:`
+    if [ "${priorEmail}" != "${email}" ]
+    then
+       if [ "${priorEmail}" != "" ]
        then
-          states=${states}","
+ 
+         echo '{  "id": { "S": "'${priorEmail}'" }, "type": { "S": "stateuser" }, "attributes": { "L": [ '${states}' ] } } ' > user.json
+         cat user.json
+ 
+         aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+         echo "-------"
+         echo " "
+         states=""
        fi
-         states=${states}' { "M":  { "stateCode": { "S": "'${territory}'" }, "history": { "L": [ { "M": { "status": { "S": "approved" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } }'
-
-  priorEmail=$email
-
-done < ${awsScanFormatted}
-
-
-echo '{  "id": { "S": "'${priorEmail}'" }, "type": { "S": "stateuser" }, "attributes": { "L": ['${states}' ]  } } ' > user.json
-#Show debug info of last user.
-cat user.json
-# Add last User
-aws dynamodb put-item --table-name $userTable --item file://user.json
-
-#
-# Clean up temp files
-#
-/bin/rm tmpFormatted.tmp
-/bin/rm user.json
-/bin/rm ${awsScanRaw}
-/bin/rm ${awsScanFormatted}
+ 
+    fi
+        if [ "${states}" != "" ]
+        then
+           states=${states}","
+        fi
+          states=${states}' { "M":  { "stateCode": { "S": "'${territory}'" }, "history": { "L": [ { "M": { "status": { "S": "approved" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } }'
+ 
+   priorEmail=$email
+ 
+ done < ${awsScanFormatted}
+ 
+ 
+ echo '{  "id": { "S": "'${priorEmail}'" }, "type": { "S": "stateuser" }, "attributes": { "L": ['${states}' ]  } } ' > user.json
+ #Show debug info of last user.
+ cat user.json
+ # Add last User
+ aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+ #
+ # Clean up temp files
+ #
+ /bin/rm tmpFormatted.tmp
+ /bin/rm user.json
+ /bin/rm ${awsScanRaw}
+ /bin/rm ${awsScanFormatted}
+ 
+fi

--- a/loadTestUsers.sh
+++ b/loadTestUsers.sh
@@ -1,131 +1,140 @@
 #
 # Load DynamoDB User Table with User Status and Roles for Dev Testing
 #
-stage=$1
-#userList=$2
 
-userTable=cms-spa-form-${stage}-user-profiles
-
-testUserStatuses=(pending active pending active denied revoked)
-testUserRoles=(stateadmin stateuser stateuser cmsapprover stateadmin stateuser)
-testStates=(AL AL VA VA AL VA)
-
-#EPOCH Unix Timestamp
-createddate=`date '+%s'`
-#
-# Check if Table already Loaded, Do not load a second time
-#
-lineCount=`aws dynamodb scan --table-name $userTable | wc -l`
-if [ $lineCount -gt -6 ]
+if [ -z "$1" ]
 then
-
-
-  #
-  # Test state users
-  #
-
-
-  testuser="stateuseractive@cms.hhs.local"
-
-  stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-  testuser="stateuserpending@cms.hhs.local"
-  stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "pending" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "pending" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-  testuser="stateuserdenied@cms.hhs.local"
-  stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "denied" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "denied" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-  testuser="stateuserrevoked@cms.hhs.local"
-  stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "revoked" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "revoked" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-#
-# Test State Admins
-#
-
-  testuser="stateadminactive@cms.hhs.local"
-  stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateadmin" }, '${stateuserattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-  testuser="stateadminpending@cms.hhs.local"
-  stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "pending" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "pending" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateadmin" }, '${stateuserattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-  testuser="stateadmindenied@cms.hhs.local"
-  stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "denied" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "denied" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateadmin" }, '${stateuserattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-  testuser="stateadminrevoked@cms.hhs.local"
-  stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "revoked" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "revoked" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateadmin" }, '${stateuserattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-#
-# Test CMS Approvers
-#
-
-
-
-  testuser="cmsapproveractive@cms.hhs.local"
-  cmsapproverattributes='"attributes": { "L": [ { "M":  { "history": { "L": [ { "M": { "status": { "S": "active" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "cmsapprover" }, '${cmsapproverattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-  cmsapprover="cmsapproverpending@cms.hhs.local"
-  cmsapproverattributes='"attributes": { "L": [ { "M":  { "history": { "L": [ { "M": { "status": { "S": "pending" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "cmsapprover" }, '${cmsapproverattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-  cmsapprover="cmsapproverdenied@cms.hhs.local"
-  cmsapproverattributes='"attributes": { "L": [ { "M":  { "history": { "L": [ { "M": { "status": { "S": "denied" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "cmsapprover" }, '${cmsapproverattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-  cmsapprover="cmsapproverrevoked@cms.hhs.local"
-  cmsapproverattributes='"attributes": { "L": [ { "M":  { "history": { "L": [ { "M": { "status": { "S": "revoked" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "cmsapprover" }, '${cmsapproverattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-#
-# Legacy Test Users
-#
-  stateuser="user1@cms.hhs.local"
-  stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${stateuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-  stateuser="user2@cms.hhs.local"
-  stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${stateuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-  stateuser="user3@cms.hhs.local"
-  stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${stateuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-  stateuser="user4@cms.hhs.local"
-  stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${stateuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
-
-  stateuser="user5@cms.hhs.local"
-  stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "effectiveDate": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
-  echo '{  "id": { "S": "'${stateuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
-  aws dynamodb put-item --table-name $userTable --item file://user.json
-
+    echo "usage:  loadTestUsers <github branch name>"
+else
+ 
+ 
+ stage=$1
+ #userList=$2
+ 
+ userTable=cms-spa-form-${stage}-user-profiles
+ 
+ testUserStatuses=(pending active pending active denied revoked)
+ testUserRoles=(stateadmin stateuser stateuser cmsapprover stateadmin stateuser)
+ testStates=(AL AL VA VA AL VA)
+ 
+ #EPOCH Unix Timestamp
+ createddate=`date '+%s'`
+ #
+ # Check if Table already Loaded, Do not load a second time
+ #
+ lineCount=`aws dynamodb scan --table-name $userTable | wc -l`
+ if [ $lineCount -gt -6 ]
+ then
+ 
+ 
+   #
+   # Test state users
+   #
+ 
+ 
+   testuser="stateuseractive@cms.hhs.local"
+ 
+   stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
+   echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+   testuser="stateuserpending@cms.hhs.local"
+   stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "pending" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "pending" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
+   echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+   testuser="stateuserdenied@cms.hhs.local"
+   stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "denied" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "denied" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
+   echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+   testuser="stateuserrevoked@cms.hhs.local"
+   stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "revoked" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "revoked" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
+   echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+ #
+ # Test State Admins
+ #
+ 
+   testuser="stateadminactive@cms.hhs.local"
+   stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
+   echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateadmin" }, '${stateuserattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+   testuser="stateadminpending@cms.hhs.local"
+   stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "pending" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "pending" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
+   echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateadmin" }, '${stateuserattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+   testuser="stateadmindenied@cms.hhs.local"
+   stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "denied" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "denied" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
+   echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateadmin" }, '${stateuserattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+   testuser="stateadminrevoked@cms.hhs.local"
+   stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "revoked" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "revoked" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
+   echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "stateadmin" }, '${stateuserattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+ #
+ # Test CMS Approvers
+ #
+ 
+ 
+ 
+   testuser="cmsapproveractive@cms.hhs.local"
+   cmsapproverattributes='"attributes": { "L": [ { "M": { "status": { "S": "active" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] }'
+   echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "cmsapprover" }, '${cmsapproverattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+   testuser="cmsapproverpending@cms.hhs.local"
+   cmsapproverattributes='"attributes": { "L": [ { "M": { "status": { "S": "pending" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] }'
+   echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "cmsapprover" }, '${cmsapproverattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+   testuser="cmsapproverdenied@cms.hhs.local"
+   cmsapproverattributes='"attributes": { "L": [ { "M": { "status": { "S": "denied" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] }'
+   echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "cmsapprover" }, '${cmsapproverattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+   testuser="cmsapproverrevoked@cms.hhs.local"
+   cmsapproverattributes='"attributes": { "L": [ { "M": { "status": { "S": "revoked" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] }'
+   echo '{  "id": { "S": "'${testuser}'" }, "type": { "S": "cmsapprover" }, '${cmsapproverattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+ #
+ # Legacy Test Users
+ #
+   stateuser="user1@cms.hhs.local"
+   stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
+   echo '{  "id": { "S": "'${stateuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+   stateuser="user2@cms.hhs.local"
+   stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
+   echo '{  "id": { "S": "'${stateuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+   stateuser="user3@cms.hhs.local"
+   stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
+   echo '{  "id": { "S": "'${stateuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+   stateuser="user4@cms.hhs.local"
+   stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
+   echo '{  "id": { "S": "'${stateuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+ 
+   stateuser="user5@cms.hhs.local"
+   stateuserattributes='"attributes": { "L": [ { "M":  { "stateCode": { "S": "MI" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } },{ "M":  { "stateCode": { "S": "VA" }, "history": { "L": [ { "M": { "status": { "S": "active" }, "date": { "N": "'${createddate}'" }, "doneBy": { "S": "systemsadmin@cms.hhs.local" } } } ] } } } ] }'
+   echo '{  "id": { "S": "'${stateuser}'" }, "type": { "S": "stateuser" }, '${stateuserattributes}' } ' > user.json
+   aws dynamodb put-item --table-name $userTable --item file://user.json
+ 
+ 
+ fi
+ 
+ aws dynamodb scan --table-name $userTable
 
 fi
-
-aws dynamodb scan --table-name $userTable


### PR DESCRIPTION
Stories:  https://qmacbis.atlassian.net/browse/OY2-6766. and https://qmacbis.atlassian.net/browse/OY2-6763

=======
Changes:
=======

Updated scripts to support the new user profile format:  See Doc:  https://qmacbis.atlassian.net/wiki/spaces/MACPRO/pages/1854177318/Portal+User+Management

======
Testing:
======

This requires Manual testing/verification:

1.). Using to Cloud Tamer - Login to AWS Access to delete the user in the dynamodb table in AWS is: cms-spa-form-oy2-6766-user-profiles.

2.) Using Cloud Tamer setup command terminal with export of developer admin AWS credentials

3.) On command terminal run the command:  ./loadExistingUsers.sh oy2-6766

NOTE: This script should read change request dynamoDB and create users based on the submissions as state user approved.

4.). In AWS check the DynamoDB table:  cms-spa-form-oy2-6766-user-profiles. and verify the user schema.

5.). Using to Cloud Tamer - Login to AWS Access to delete the user in the dynamodb table in AWS is: cms-spa-form-oy2-6766-user-profiles.

6.) On command terminal run the command:  ./loadTestUsers.sh oy2-6766

7.). In AWS check the DynamoDB table:  cms-spa-form-oy2-6766-user-profiles. and verify the user schema.
