### PR TITLE
OY2-6660 inhibit sparai mapping in sourceDynamoToMsk

### DIFF
--- a/services/stream-functions/handlers/sourceDynamoToMsk.js
+++ b/services/stream-functions/handlers/sourceDynamoToMsk.js
@@ -7,7 +7,7 @@ const mappings = {
     'name': 'type_mapped.S',
     'mapping': {
       'spa': 'Medicaid SPA',
-      'sparai': 'Medicaid SPA'
+      // 'sparai': 'Medicaid SPA'
     }
   },
   'state.S': {

--- a/services/stream-functions/serverless.yml
+++ b/services/stream-functions/serverless.yml
@@ -69,7 +69,7 @@ functions:
           arn: ${self:custom.tableStreamArn}
           startingPosition: LATEST
           maximumRetryAttempts: 2
-          enabled: false
+          enabled: true
     role: LamdaSourceDynamoToMskRole
     environment:
       BOOTSTRAP_BROKER_STRING_TLS: ${self:custom.bootstrapBrokerStringTls}


### PR DESCRIPTION
### Changes
- Enabled the trigger for the sourceDynamoToMsk lambda to run
- Commented out the sparai mapping within the sourceDynamoToMsk lambda

### Test Plan
**Summary**
We want to enable writing to "SEATool" but want to inhibit SPA RAI from being included in that process.

**Charter**
Inspect the cloud watch logs for the sourceDynamoToMsk lambda with a new SPA RAI entry in our dynamodb change requests table to verify that the lambda is not processing the request (Note that we will see an ERROR that a mapping does not exist for the sparai type, just as we do with the other types, such as waiver). Can also verify in the corresponding SEATool database that this SPA RAI submission does not exist.