### PR TITLE
OY2 6872: Updated verbiage for waiver number warning message for 1915(b) Waiver Action and 1915(c) Appendix K forms

### DIFF
--- a/services/ui-src/src/changeRequest/SubmissionForm.js
+++ b/services/ui-src/src/changeRequest/SubmissionForm.js
@@ -196,7 +196,7 @@ const SubmissionForm = ({ formInfo, changeRequestType }) => {
           } else {
             newMessage.statusMessage =
             transmittalNumberDetails.idLabel +
-            " not found. You can still proceed with the submission but please ensure you have the correct " +
+            " not found. You can still proceed with the submission, but please ensure you have the correct " +
             transmittalNumberDetails.idLabel +
             ". Contact the MACPro Help Desk (code: OMP002) if you need support.";
           }


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-6872
Endpoint: https://d3n819214dwm1m.cloudfront.net

Changes:
- replaced the common warning message with the new text.

Test:
1. login as a State User
2. Submit new amendment waiver action, check warning message, and verify submission:
a. click "Submit New Waiver"
b. Select "Action type" of "Waiver amendment"
c. Select Waiver Authority (does not matter which)
d. Enter a new waiver number and verify the updated messaging
e. attach required file samples
f. Submit with warning message active 
2. Submit new renewal waiver action, check warning message, and verify submission:
a. click "Submit New Waiver"
b. Select "Action type" of "Request for waiver renewal"
c. Select Waiver Authority (does not matter which)
d. Enter a new waiver number and verify the updated messaging
e. attach required file samples
f. Submit with warning message active
2. Submit Appendix K waiver action, check warning message, and verify submission:
a. click "Submit 1915(c) Appendix K Amendment"
d. Enter a new waiver number and verify the updated messaging
e. attach required file samples
f. Submit with warning message active 
 
Thanks!