### PR TITLE
OY2-6714: add alertbar survey link

### DIFF
--- a/services/ui-src/src/components/AlertBar.js
+++ b/services/ui-src/src/components/AlertBar.js
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef } from "react";
 import { Alert } from "@cmsgov/design-system";
 import { useHistory, useLocation } from "react-router-dom";
+import { useAppContext } from "../libs/contextLib";
+
 
 export const AlertBar = () => {
   const location = useLocation();
@@ -12,7 +14,13 @@ export const AlertBar = () => {
 
   // track alert from global state (history) in a local mutable ref
   const alertRef = useRef(alert);
-
+  const { userProfile: { userData } = {} } = useAppContext();
+  const surveyLink = (
+    <a href="https://forms.gle/qcsWMaDroBkhT7rs6" target="_blank" rel="noopener noreferrer">Post-Submission Survey.</a>
+  );
+  const surveyText =(
+    <>Thanks for your submission. We truly value your feedback. Please consider taking our </>
+  );
   // every time the alert from the browser location changes...
   useEffect(() => {
     // scroll the user up to the bar
@@ -24,7 +32,6 @@ export const AlertBar = () => {
     if (alert) {
       // update our local copy if it's different
       if (alert !== alertRef.current) alertRef.current = alert;
-
       // clear it out of the browser's location so we do not see it again on refresh
       history.replace({ ...location, state: undefined }, {
         ...location.state,
@@ -33,6 +40,19 @@ export const AlertBar = () => {
     }
   }, [alert, history, location]);
 
+  /**
+   * Check if alert is successful and a stateuser then change text to have survey link else return regular text
+   * @returns the text for a given alert
+   */
+
+  const renderText=()=>{
+    if (userData.type==="stateuser" && alertRef.current.type==="success") {
+      return (<>{surveyText}{surveyLink}</>)
+    } else{
+      return (alert.current.text);
+    }
+  }
+
   return (
     <div className="alert-bar" ref={divRef}>
       {alertRef.current && alertRef.current.heading && (
@@ -40,9 +60,11 @@ export const AlertBar = () => {
           variation={alertRef.current.type}
           heading={alertRef.current.heading}
         >
-          <p className="ds-c-alert__text">{alertRef.current.text}</p>
+          <p className="ds-c-alert__text">{renderText()}</p>
         </Alert>
       )}
     </div>
   );
 };
+
+


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-6714

Endpoint: https://d24qh6lovcncv2.cloudfront.net

Test: Login as stateuseractive@cms.hhs.local a submit a SPA and make sure the correct text is shown in the alert bar and the survey link opens in a new tab/window (depending on your browser settings). 

Note: I tried doing this a bit more elegantly by adding the message with the link in the alert-messages.js file however since the link is a JSX element in cannot be put in the history like we do with all the other alert strings.