### PR TITLE
Fix bug in uploading Nightwatch results to github

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,6 +128,7 @@ jobs:
           popd
           ./run.sh
       - name: Store test reults
+        if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: test_results


### PR DESCRIPTION
Purpose
This is a merged change from the Quickstart to address a bug that's preventing Nightwatch test results from being uploaded to Github and displayed referenced in [This PR](https://github.com/CMSgov/macpro-quickstart-serverless/pull/168)
