### PR TITLE
OY2-7728 cms email

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -13,10 +13,10 @@ custom:
   spaIdTableName: cms-spa-form-${self:custom.stage}-spa-ids
   userTableName: cms-spa-form-${self:custom.stage}-user-profiles
   iamPath: ${env:IAM_PATH, "/"}
-  emailSource: ${opt:emailSource, env:CMS_SPA_FORM_FROM_EMAIL, "OneMAC@cms.hhs.gov"}
-  userAccessEmailSource:  ${opt:userAccessEmailSource, env:CMS_USER_ACCESS_FROM_EMAIL, "OneMAC@cms.hhs.gov"}
+  emailSource: ${opt:emailSource, env:CMS_SPA_FORM_FROM_EMAIL, "spa-reply@cms.hhs.gov"}
+  userAccessEmailSource:  ${opt:userAccessEmailSource, env:CMS_USER_ACCESS_FROM_EMAIL, "OneMACAccess@cms.hhs.gov"}
   reviewerEmail: ${opt:reviewTeamEmail, env:CMS_SPA_FORM_CMS_EMAIL, "OneMAC@cms.hhs.gov"}
-  systemAdminEmail: ${opt:systemAdminEmail, env:CMS_SYSTEM_ADMIN_EMAIL, "OneMAC@cms.hhs.gov"}
+  systemAdminEmail: ${opt:systemAdminEmail, env:CMS_SYSTEM_ADMIN_EMAIL, ""}
   warmupEnabled:
     production: true
     development: true


### PR DESCRIPTION
**Story:** https://qmacbis.atlassian.net/browse/OY2-7728
**Endpoint:** https://d1kui1o78tc9z3.cloudfront.net

### Changes/Work
- Changed the default email address `CMS_SPA_FORM_CMS_EMAIL` (the CMS email address for change request submissions)
- Verified that the other email addresses are set to the correct defaults per conversation with Sabrina in Slack.

Environment Variable | Address | Description
------------ | ------------- | ---
CMS_SPA_FORM_FROM_EMAIL | spa-reply@cms.hhs.gov | "FROM" address on change request emails that go to both the submitter and the CMS review inbox 
CMS_SPA_FORM_CMS_EMAIL | OneMAC@cms.hhs.gov | "TO" address for the CMS review inbox for change requests
CMS_USER_ACCESS_FROM_EMAIL | OneMACAccess@cms.hhs.gov | "FROM" address for user management emails
CMS_SYSTEM_ADMIN_EMAIL | no default set | "TO" address for the system admin user that can be manually set for testing purposes as an optional override to the system admin's email in DynamoDB

### Testing
We want to have the CMS email for a change request submission sent to OneMAC@cms.hhs.gov in all lower environments (all environments except production).
- Confirm that there is an override to the default environment variable set in GitHub for the CMS email in the production environment. Check the environment variable `PRODUCTION_CMS_SPA_FORM_CMS_EMAIL` exists in the list here: https://github.com/CMSgov/macstack-spa-submission-form/settings/secrets/actions
- Place a new change request submission in the portal and confirm that the CMS email was sent to the OneMAC@cms.hhs.gov inbox