### PR TITLE
OY2 - 7971 - SPA ID - Updated Format

### DIFF
--- a/services/ui-src/src/changeRequest/ChipSpa.js
+++ b/services/ui-src/src/changeRequest/ChipSpa.js
@@ -30,7 +30,7 @@ const ChipSpa = () => {
       idHintText: "Must follow the format SS-YY-NNNN-xxxx",
       idFAQLink: ROUTES.FAQ_SPA_ID,
       idFormat: "SS-YY-NNNN or SS-YY-NNNN-xxxx",
-      idRegex: "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
+      idRegex: "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{1,4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
       idMustExist: false,
       errorLevel: "error",
     },

--- a/services/ui-src/src/changeRequest/ChipSpaRai.js
+++ b/services/ui-src/src/changeRequest/ChipSpaRai.js
@@ -33,7 +33,7 @@ const ChipSpaRai = () => {
       idFAQLink: ROUTES.FAQ_SPA_ID,
       idFormat: "SS-YY-NNNN or SS-YY-NNNN-xxxx",
       idRegex:
-        "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
+        "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{1,4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
       idMustExist: true,
       errorLevel: "error",
     },

--- a/services/ui-src/src/changeRequest/Spa.js
+++ b/services/ui-src/src/changeRequest/Spa.js
@@ -32,7 +32,7 @@ const Spa = () => {
       idHintText: "Must follow the format SS-YY-NNNN-xxxx",
       idFAQLink: ROUTES.FAQ_SPA_ID,
       idFormat: "SS-YY-NNNN or SS-YY-NNNN-xxxx",
-      idRegex: "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
+      idRegex: "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{1,4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
       idMustExist: false,
       errorLevel: "error",
     },

--- a/services/ui-src/src/changeRequest/SpaRai.js
+++ b/services/ui-src/src/changeRequest/SpaRai.js
@@ -35,7 +35,7 @@ const SpaRai = () => {
       idHintText: "Must follow the format SS-YY-NNNN-xxxx",
       idFAQLink: ROUTES.FAQ_SPA_ID,
       idFormat: "SS-YY-NNNN or SS-YY-NNNN-xxxx",
-      idRegex: "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
+      idRegex: "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{1,4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
       idMustExist: true,
       errorLevel: "error",
     },


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-7971
Endpoint: https://d1zqpxocexedw1.cloudfront.net

Changes:
- updated the regex code for the ID in: ChipSpa, ChipSpaRai, Spa, and SpaRai

### Test Plan
Log in as stateuseractive@cms.hhs.local
For each of the SPA-ID type forms:
Click the link for the form
Enter a SPA ID and check that the error message appears appropriately
Verify that you can submit an ID with the new adjustment to the ID (1 to 4 optional characters)
SPA ID Forms are: Medicaid SPA, Medicaid SPA RAI, CHIP SPA, CHIP SPA RAI