### PR TITLE
OY2-8408: only show latest status for CMS approver

### DIFF
--- a/services/ui-src/src/containers/UserPage.js
+++ b/services/ui-src/src/containers/UserPage.js
@@ -61,7 +61,7 @@ const transformAccesses = (user = {}) => {
       }));
 
     case ROLES.CMS_APPROVER:
-      return user.attributes ?? [];
+      return [{ status: latestAccessStatus(user) }];
 
     case ROLES.SYSTEM_ADMIN:
     default:


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-8408
Endpoint: https://d2yqdx67lnfl56.cloudfront.net/

To test:
1. Login as `systemadmintest`. Pick a CMS approver user out of the table and change their status a few times.
2. Log out then log back in as that CMS approver user. Go to their user profile page and verify that despite having multiple history entries, they only have one card in the right column with the most recent status reflected.