### PR TITLE
OY2-8315: only show links to create packages to active users

### DIFF
--- a/services/ui-src/src/containers/Dashboard.js
+++ b/services/ui-src/src/containers/Dashboard.js
@@ -135,99 +135,96 @@ const Dashboard = () => {
       <PageTitleBar heading="SPA and Waiver Dashboard" text="" />
       <AlertBar />
       <div className="dashboard-container">
-        <div className="dashboard-left-col">
-          <div className="action-title">SPAs</div>
-          <Button
-            id="spaSubmitBtn"
-            variation="transparent"
-            onClick={() => history.push(ROUTES.SPA)}
-          >
-            Submit New Medicaid SPA
-          </Button>
-          <Button
-            id="spaRaiBtn"
-            variation="transparent"
-            onClick={() => history.push(ROUTES.SPA_RAI)}
-          >
-            Respond to Medicaid SPA RAI
-          </Button>
-          <Button
-            id="chipSpaBtn"
-            variation="transparent"
-            onClick={() => history.push(ROUTES.CHIP_SPA)}
-          >
-            Submit New CHIP SPA
-          </Button>
-          <Button
-            id="chipSpaRaiBtn"
-            variation="transparent"
-            onClick={() => history.push(ROUTES.CHIP_SPA_RAI)}
-          >
-            Respond to CHIP SPA RAI
-          </Button>
-          <div className="action-title">Waivers</div>
-          <Button
-            id="waiverBtn"
-            variation="transparent"
-            onClick={() => history.push(ROUTES.WAIVER)}
-          >
-            Submit 1915(b) Waiver Action
-          </Button>
-          <Button
-            id={"waiverRaiBtn"}
-            variation="transparent"
-            onClick={() => history.push(ROUTES.WAIVER_RAI)}
-          >
-            Respond to 1915(b) Waiver RAI
-          </Button>
-          <Button
-            id="waiverExtBtn"
-            variation="transparent"
-            onClick={() => history.push(ROUTES.WAIVER_EXTENSION)}
-          >
-            Request Temporary Extension form - 1915(b) and 1915(c)
-          </Button>
-          <Button
-            id="waiverAppKBtn"
-            variation="transparent"
-            onClick={() => history.push(ROUTES.WAIVER_APP_K)}
-          >
-            Submit 1915(c) Appendix K Amendment
-          </Button>
-        </div>
-        <div className="dashboard-right-col">
-          {userProfile &&
-          userProfile.userData &&
-          userProfile.userData.attributes &&
-          userProfile.userData.attributes.length !== 0 &&
-          !isActive(userProfile.userData) ? (
-            isPending(userProfile.userData) ? (
-              <EmptyList message={pendingMessage[userProfile.userData.type]} />
-            ) : (
-              <EmptyList
-                message={deniedOrRevokedMessage[userProfile.userData.type]}
-              />
-            )
-          ) : (
-            <div>
-              <div className="action-title">Submissions List</div>
-              <LoadingScreen isLoading={isLoading}>
-                <div>
-                  {changeRequestList.length > 0 ? (
-                    <PortalTable
-                      className="submissions-table"
-                      columns={columns}
-                      data={changeRequestList}
-                      initialState={initialTableState}
-                    />
-                  ) : (
-                    <EmptyList message="You have no submissions yet." />
-                  )}
-                </div>
-              </LoadingScreen>
+        {!!userProfile?.userData?.attributes &&
+        isActive(userProfile?.userData) ? (
+          <>
+            <div className="dashboard-left-col">
+              <div className="action-title">SPAs</div>
+              <Button
+                id="spaSubmitBtn"
+                variation="transparent"
+                onClick={() => history.push(ROUTES.SPA)}
+              >
+                Submit New Medicaid SPA
+              </Button>
+              <Button
+                id="spaRaiBtn"
+                variation="transparent"
+                onClick={() => history.push(ROUTES.SPA_RAI)}
+              >
+                Respond to Medicaid SPA RAI
+              </Button>
+              <Button
+                id="chipSpaBtn"
+                variation="transparent"
+                onClick={() => history.push(ROUTES.CHIP_SPA)}
+              >
+                Submit New CHIP SPA
+              </Button>
+              <Button
+                id="chipSpaRaiBtn"
+                variation="transparent"
+                onClick={() => history.push(ROUTES.CHIP_SPA_RAI)}
+              >
+                Respond to CHIP SPA RAI
+              </Button>
+              <div className="action-title">Waivers</div>
+              <Button
+                id="waiverBtn"
+                variation="transparent"
+                onClick={() => history.push(ROUTES.WAIVER)}
+              >
+                Submit 1915(b) Waiver Action
+              </Button>
+              <Button
+                id={"waiverRaiBtn"}
+                variation="transparent"
+                onClick={() => history.push(ROUTES.WAIVER_RAI)}
+              >
+                Respond to 1915(b) Waiver RAI
+              </Button>
+              <Button
+                id="waiverExtBtn"
+                variation="transparent"
+                onClick={() => history.push(ROUTES.WAIVER_EXTENSION)}
+              >
+                Request Temporary Extension form - 1915(b) and 1915(c)
+              </Button>
+              <Button
+                id="waiverAppKBtn"
+                variation="transparent"
+                onClick={() => history.push(ROUTES.WAIVER_APP_K)}
+              >
+                Submit 1915(c) Appendix K Amendment
+              </Button>
             </div>
-          )}
-        </div>
+            <div className="dashboard-right-col">
+              <div>
+                <div className="action-title">Submissions List</div>
+                <LoadingScreen isLoading={isLoading}>
+                  <div>
+                    {changeRequestList.length > 0 ? (
+                      <PortalTable
+                        className="submissions-table"
+                        columns={columns}
+                        data={changeRequestList}
+                        initialState={initialTableState}
+                      />
+                    ) : (
+                      <EmptyList message="You have no submissions yet." />
+                    )}
+                  </div>
+                </LoadingScreen>
+              </div>
+            </div>
+          </>
+        ) : isPending(userProfile.userData) ? (
+          <EmptyList message={pendingMessage[userProfile.userData.type]} />
+        ) : (
+          <EmptyList
+            message={deniedOrRevokedMessage[userProfile.userData.type]}
+          />
+        )}
       </div>
     </div>
   );

--- a/services/ui-src/src/utils/ChangeRequestDataApi.js
+++ b/services/ui-src/src/utils/ChangeRequestDataApi.js
@@ -90,7 +90,7 @@ class ChangeRequestDataApi {
   /**
    * Fetch all change requests that correspond to the user's active access to states/territories
    * @param {string} email the user's email
-   * @return {Array} a list of change requests
+   * @return {Promise<Array>} a list of change requests
    */
   async getAllByAuthorizedTerritories(userEmail) {
     if (!userEmail) return [];


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-8315
Endpoint: https://d2slmociqyuxj7.cloudfront.net/

To test:
1. Log in as `stateuseractive`. Note that the links are still visible.
2. Log in as `stateuserpending`. Note that the links are no longer present, and that the puzzle piece and message span the full page width.
3. Repeat the previous step with `stateuserdenied` and `stateuserrevoked`.