### PR TITLE
OY2-8665: only allow one state for state admin signup

### DIFF
--- a/services/ui-src/src/components/MultiSelectDropDown.js
+++ b/services/ui-src/src/components/MultiSelectDropDown.js
@@ -13,6 +13,7 @@ export const MultiSelectDropDown = ({
   errorMessage = "",
   header,
   loading = false,
+  onlyOne = false,
   options,
   required = false,
   subheader,
@@ -21,6 +22,9 @@ export const MultiSelectDropDown = ({
   type,
 }) => {
   const [value, setValue] = useState([]);
+
+  const invalid =
+    (required && value.length === 0) || (onlyOne && value.length > 1);
 
   return (
     <>
@@ -69,8 +73,8 @@ export const MultiSelectDropDown = ({
         <Select
           className="fa fa-search"
           placeholder=""
+          disabled={loading}
           dropdownHeight="185px"
-          isDisabled={loading}
           searchable="true"
           searchBy="label"
           multi="true"
@@ -79,13 +83,13 @@ export const MultiSelectDropDown = ({
           options={options}
         />
         <div className="component-submit-solid">
-          {required && value.length === 0 && (
+          {invalid && (
             <div className="field-error-message ds-u-padding-bottom--1">
               {errorMessage}
             </div>
           )}
           <button
-            disabled={loading || (required && value.length === 0)}
+            disabled={loading || invalid}
             onClick={() => submitFn(value)}
             className="ds-c-button ds-c-button--primary"
             type="button"

--- a/services/ui-src/src/containers/StateSignup.js
+++ b/services/ui-src/src/containers/StateSignup.js
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { useLocation } from "react-router-dom";
-import { territoryList } from "cmscommonlib";
+import { territoryList, USER_TYPE } from "cmscommonlib";
 
 import { useSignupCallback } from "../libs/hooksLib";
 import { userTypes } from "../libs/userLib";
@@ -27,9 +27,14 @@ export function StateSignup() {
       </div>
       <div className="signup-container state-signup">
         <MultiSelectDropDown
-          errorMessage="Please select at least one state."
+          errorMessage={
+            role === USER_TYPE.STATE_USER
+              ? "Please select at least one state."
+              : "Please select one state."
+          }
           header={userTypes[role] ?? role}
           loading={loading}
+          onlyOne={role === USER_TYPE.STATE_ADMIN}
           options={territoryList}
           required
           subheader="Select your State Access"


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-8665
Endpoint: https://d3ivu022bmkmma.cloudfront.net/

To test:
1. Log in as `stateadminunregistered`. On the signup page, select "State System Administrator". Verify that the red text at the bottom of the menu now says "Please select one state.".
2. Select one state from the menu and verify that the validation goes away and the Submit button is now enabled (blue).
3. Select additional states and verify that the validation message returns and the Submit button is now disabled (gray).
4. Deselect all but one state and verify that it returns to its appearance from step 2.
5. Submit the request and verify that it works as it did before.
6. Go into the console and remove the corresponding user entry from the user table in dynamo for the next test :smile: