### PR TITLE
OY2-6324: remove gray background and box shadows

### DIFF
--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -25,7 +25,6 @@ th {
 }
 body {
   @extend .ds-base;
-  background-color: $color-gray-lightest;
 }
 
 h1 {
@@ -262,7 +261,6 @@ input[type="file"] {
   @extend .ds-u-flex-direction--column;
   @extend .ds-u-justify-content--center;
   @extend .ds-l-col--auto;
-  background-color: $color-gray-lightest;
 
   h3 {
     @extend .ds-u-margin-top--7;
@@ -283,9 +281,7 @@ input[type="file"] {
   }
 
   .form-card {
-    background-color: $color-white;
     @extend .ds-l-col--auto;
-    box-shadow: 2px 2px 4px $color-gray-lighter;
     @extend .ds-u-padding-top--1;
     @extend .ds-u-padding-bottom--3;
     @extend .ds-u-padding-left--2;
@@ -323,11 +319,7 @@ input[type="file"] {
 }
 
 .upload-card {
-  background-color: $color-white;
   @extend .ds-l-col--auto;
-  @extend .ds-u-border-right--2;
-  @extend .ds-u-border-bottom--2;
-  @extend .ds-u-padding-left--2;
   div {
     padding-top: 1rem;
     padding-bottom: 1rem;


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-6324
Endpoint: https://d3vbpcrq9nlxt4.cloudfront.net/

To test:
1. Go to the development login page. The background between the header and footer should be white and not light gray.
2. Log in as `stateuseractive` and navigate to the user profile page. The background should be white and not light gray. Note that the box shadow should **remain** on the cards _on this page only_ per the Figma.
3. Navigate back to the dashboard, then to a submission form (any will do). Verify that the form has a fully white background and that the fields / upload section do not have outer borders or box shadows.
4. Click the link in the header to go to the FAQ. Verify that the background is fully white with no gray.
5. Log out, then back in again as `stateuserunregistered`. Verify that the signup flows also have fully white backgrounds.