### PR TITLE
OY2 8778 Form Page bug fixes

### DIFF
--- a/services/ui-src/src/changeRequest/SubmissionForm.js
+++ b/services/ui-src/src/changeRequest/SubmissionForm.js
@@ -4,7 +4,12 @@ import LoadingScreen from "../components/LoadingScreen";
 import FileUploader from "../components/FileUploader";
 import { TextField } from "@cmsgov/design-system";
 import ChangeRequestDataApi from "../utils/ChangeRequestDataApi";
-import { latestAccessStatus, RESPONSE_CODE, ROUTES, USER_STATUS } from "cmscommonlib";
+import {
+  latestAccessStatus,
+  RESPONSE_CODE,
+  ROUTES,
+  USER_STATUS,
+} from "cmscommonlib";
 import PropTypes from "prop-types";
 import PageTitleBar from "../components/PageTitleBar";
 import TransmittalNumber from "../components/TransmittalNumber";
@@ -208,6 +213,7 @@ const SubmissionForm = ({ formInfo, changeRequestType }) => {
           transmittalNumberDetails.existenceRegex
         )[0];
       }
+
       ChangeRequestDataApi.packageExists(checkingNumber)
         .then((dupID) => {
           if (!dupID && transmittalNumberDetails.idMustExist) {
@@ -223,15 +229,17 @@ const SubmissionForm = ({ formInfo, changeRequestType }) => {
               newMessage.statusMessage = `Please ensure you have the correct ${transmittalNumberDetails.idLabel} before submitting.  Contact the MACPro Help Desk (code: OMP003) if you need support.`;
             }
           }
+          setTransmittalNumberStatusMessage(newMessage);
         })
         .catch((error) => {
           console.log("There was an error submitting a request.", error);
         });
+    } else {
+      setTransmittalNumberStatusMessage(newMessage);
     }
 
     setWaiverAuthorityErrorMessage(waiverAuthorityMessage);
     setActionTypeErrorMessage(actionTypeMessage);
-    setTransmittalNumberStatusMessage(newMessage);
   }, [
     changeRequest,
     firstTimeThrough,
@@ -251,22 +259,15 @@ const SubmissionForm = ({ formInfo, changeRequestType }) => {
 
     // in case form validation takes a while (external validation)
     if (mounted) setIsLoading(true);
-    if (mounted) setAlertCode(newAlertCode); //clear the alert
     if (mounted) setFirstTimeThrough(false);
 
-    // its too soon for the firstTimeThrough to be set for validate function
-  //  if (!changeRequest.transmittalNumber) {
-   //   newMessage.statusMessage = "ID Required";
-   // }
-
     if (
-      ( transmittalNumberStatusMessage.statusLevel === "error" &&
-      transmittalNumberStatusMessage.statusMessage )  ||
+      (transmittalNumberStatusMessage.statusLevel === "error" &&
+        transmittalNumberStatusMessage.statusMessage) ||
       actionTypeErrorMessage ||
       waiverAuthorityErrorMessage
-    ) 
+    )
       newAlertCode = RESPONSE_CODE.DATA_MISSING;
-
     else if (!areUploadsReady) {
       newAlertCode = RESPONSE_CODE.ATTACHMENTS_MISSING;
     } else {
@@ -299,12 +300,12 @@ const SubmissionForm = ({ formInfo, changeRequestType }) => {
       }
     }
 
-    // now set the state variables to show the error messages
-  //  if (mounted) setTransmittalNumberStatusMessage(newMessage);
-  //  if (mounted) setActionTypeErrorMessage(actionTypeMessage);
-  //  if (mounted) setWaiverAuthorityErrorMessage(waiverAuthorityMessage);
     if (mounted) setAlertCode(newAlertCode);
     if (mounted) setIsLoading(false);
+
+    // if the same alert persists, AlertBar doesn't know to assert itself
+    var elmnt = document.getElementById("alert-bar");
+    if (elmnt) elmnt.scrollIntoView({ behavior: "smooth" });
   }
 
   // Render the component conditionally when NOT in read only mode
@@ -343,7 +344,9 @@ const SubmissionForm = ({ formInfo, changeRequestType }) => {
               <RequiredChoice
                 fieldInfo={formInfo.waiverAuthority}
                 label="Waiver Authority"
-                errorMessage={!firstTimeThrough ? waiverAuthorityErrorMessage : ""}
+                errorMessage={
+                  !firstTimeThrough ? waiverAuthorityErrorMessage : ""
+                }
                 value={changeRequest.waiverAuthority}
                 onChange={handleInputChange}
               />

--- a/services/ui-src/src/components/FileUploader.js
+++ b/services/ui-src/src/components/FileUploader.js
@@ -181,6 +181,9 @@ export default class FileUploader extends Component {
       uploader.files = filesToUpload;
     }
 
+    // remove the file list from the input so you can choose the same file again
+    event.target.value = null;
+
     this.filesUpdated();
   }
 
@@ -189,24 +192,15 @@ export default class FileUploader extends Component {
    * @param {Object} uploader the uploader that the file is associated with
    * @param {Object} file the event that triggered this action
    */
-  handleRemoveFile(uploader, file, index) {
+  handleRemoveFile(uploader, file ) {
     const fileIndex = uploader.files.indexOf(file);
-    console.log("uploader.files 1", uploader.files);
     uploader.files.splice(fileIndex, 1);
 
-    console.log("fileIndex",fileIndex);
-    console.log("uploader.files 2", uploader.files);
-
-    console.log("uploaders: ", this.state.uploaders);
     this.setState({ uploaders: this.state.uploaders });
 
     if (!uploader.files || uploader.files.length === 0) {
       uploader.hasFile = false;
     }
-
-    // remove the file list from the input so you can choose the same file again
-    var elmnt = document.getElementById("uploader-input-" + index);
-    if (elmnt) elmnt.value = null;
 
     this.filesUpdated();
   }
@@ -289,7 +283,7 @@ export default class FileUploader extends Component {
                         type="button"
                         className="uploader-clear-button"
                         title="Remove file"
-                        onClick={() => this.handleRemoveFile(uploader, file, index)}
+                        onClick={() => this.handleRemoveFile(uploader, file)}
                       >
                         <FontAwesomeIcon icon={faTimes} size="2x" />
                       </button>


### PR DESCRIPTION
Endpoint: https://d3f8takmx1nlhg.cloudfront.net/ 
Bug: https://qmacbis.atlassian.net/browse/OY2-8778 OneMAC - Attachment is required message is not displayed if uploaded doc is deleted
Bug: https://qmacbis.atlassian.net/browse/OY2-8776 OneMAC - Uploaded documents are deleted
 
Bug found during research: if you select a file to upload, then remove that file, you cannot reselect the same file again until you have added a different file (basically, the browser upload input keeps the last files chosen as a state and only uploads on changes)
 
The bugs described here stem from inconsistent state management of the FileUploader component in code not controlled by this team.  Therefore, the form itself was simplified and refactored in a way where less state variables were being managed all at once, forcing more structure around state changes and their effects.
 
### Changes
- Promoted the error message state variables so that they now flag each input’s true error state (before, they merely contained the message)
- Updated the error message show/hide to toggle on firstTimeThrough
- Removed duplicate error checking from handleSubmit - if the error states are set, there is an error.
- Consolidated the management of checking the FileUploader ready state into a new function filesUpdated, pulled all checks into this function (Waiver form, specifically)
- BUG FIX: FileUploader incorrectly only checked file upload requirements at time of “showRequiredFields” change, so would only check once.
- Added clearing the upload input’s value after file selection - we manage the file list in a separate array and want to let each input select the same file(s) again.
- Fixed the asynchronous setting of the transmittal number id checking error/warning messages - they were getting set before the return value arrived.
 
### Test Plan
Use develop branch ( https://d2dr7dgo9g0124.cloudfront.net ) to verify existence of bugs, then check endpoint ( https://d3f8takmx1nlhg.cloudfront.net/ ) to confirm the bug is fixed.

**Attachment is required messaging - BUG process**
2. Login to develop as an active state user and click link to Submit New Medicaid SPA
3. Enter a valid SPA ID
4. Click Submit
5. Scroll down, “required attachments missing” message is not there,
6. Add one file, message appears
7. Add second file, message disappears
8. Remove all files from a required type
9. Notice “required attachments missing” message is still not there,
10. Click submit - can submit this SPA without all required attachments.
11. Login to endpoint and try to recreate bug

**Uploaded Documents are deleted - BUG process**
13. Login to develop as an active state user and click link to Submit New Medicaid SPA
14. Enter a valid SPA ID
15. Add some attachments, but NOT ALL REQUIRED attachments
16. Click Submit
17. Scroll down, attachment information is no longer there.
18. Login to endpoint and try to recreate bug

**Can’t select same file BUG process**
20. Login to develop as an active state user and click link to Submit New Medicaid SPA
21. Add an attachment or multiple attachments
22. Remove attachment(s)
23. Try to add the EXACT SAME attachments - should not work
24. Login to endpoint and try to recreate bug

**ID Existence messaging not displaying BUG**
26. Login to develop as an active state user and click link to Respond to Medicaid SPA RAI
27. Type in a SPA ID that does not exist yet
28. Error message? No?  Submit
29. Should get duplicate ID message on submit…
30. Login to endpoint and try to recreate bug