### PR TITLE
oy2-8823-hsts-Committing code to implement HSTS protection

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -138,6 +138,9 @@ resources:
               Cookies:
                 Forward: none
             ViewerProtocolPolicy: redirect-to-https
+            FunctionAssociations:
+              - EventType: viewer-response
+                FunctionARN: !GetAtt HstsCloudfrontFunction.FunctionMetadata.FunctionARN
           ViewerCertificate:
             Fn::If:
               - CreateCustomCloudFrontDomain
@@ -168,6 +171,21 @@ resources:
           HostedZoneId: Z2FDTNDATAQYW2
           EvaluateTargetHealth: false
         Type: A
+    HstsCloudfrontFunction:
+      Type: AWS::CloudFront::Function
+      Properties:
+        AutoPublish: true
+        FunctionCode: |
+          function handler(event) {
+            var response = event.response;
+            var headers = response.headers;
+            headers['strict-transport-security'] = { value: 'max-age=63072000; includeSubdomains; preload'};
+            return response;
+          }
+        FunctionConfig:
+          Comment: This function adds headers to implement HSTS
+          Runtime: cloudfront-js-1.0
+        Name: hsts-${self:custom.stage}
 
     # Set the application endpoint to the custom name if CLOUDFRONT_DOMAIN_NAME is set, otherwise use the CloudFrontDistribution domain name.
     # Note this URL has no trailing slash.


### PR DESCRIPTION
Endpoint: https://d2j4t9zt9prhy4.cloudfront.net/dashboard

This implements HTTP Strict Transport Security on our applications frontend Cloudfront Distribution and meets a compliance requirement

Linked Issues to Close
Closes #240

Approach
This issue was to implement HTTP Strict Transport Security for our web application. Our frontend is a static React website hosted in S3 and fronted by Cloudfront, so this issue called for a mechanism for adding Headers to a Cloudfront response.
Modifying Cloudfront headers is possible using CloudFront Functions. This is a new component of Cloudfront, and our header manipulation case is a perfect candidate for it.

This changeset adds a javascript function that takes a Cloudfront response and adds the "strict-transport-security" header. This function is tied to the "viewer-reponse" event, one of the four possible events for Cloudfront functions (see docs. So each response from Cloudfront gets this header added before it reaches the end user, and we meet our compliance requirement.

Please refer to the docs linked in this PR for more details. But, in summary, CloudFront functions:

run in less than one millisecond.
scale to millions of requests per second instantly.
free tier of 2 million requests per month
charged $.10 per million requests after free tier
falls under Cloudfront, so no new service to approve
Learning
Guides used:

AWS guide for Cloudfront Functions
Cloudformation docs for AWS::CloudFront::Function
Cloudformation docs for AWS::CloudFront::Distribution LambdaFunctionAssociation
Pricing and general info
Assorted Notes/Considerations
It's worth noting that this functionality is also able to be implemented using Lambda@Edge, instead of Cloudfront functions, and was developed for this project but never merged. See Lambda@Edge PR (I have since deleted that PRs branch, but you can checkout branch 'skipci-lambda-at-edge-example' if you're curious). However, for this use case, Cloudfront Functions is orders of magnitude faster, much cheaper, and much less code.

I don't know the GitHub handle so I can't tag... but big shoutout to our AWS TAM Piotr. I explained this issue and asked a question about Lambda@Edge, and he pointed us to the new Cloudfront Functions offering.