### PR TITLE
adding slack notification step to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,3 +131,13 @@ jobs:
         with:
           name: test_results
           path: ./tests_output
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["develop", "master", "production"]'), env.branch_name) && failure ()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_USERNAME: Destroy Alerts
+          SLACK_ICON_EMOJI: ":bell:"
+          SLACK_COLOR: ${{job.status}}
+          SLACK_FOOTER: ""
+          MSG_MINIMAL: actions url,commit,ref


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-9559
Endpoint: n/a

### Details

Now that we have meaningful tests we want to start alerting on failures.  This PR is to address that by adding slack notifications to the "macstack-spa-submission-form-alerts" channel that was newly created. 
I requested configuration access to the "Incoming WebHooks" app within the Collabralink slack space. After that was approved you assign the app to a channel which I did and it generates a webhook for you. I copied that webhook and created a github secret "SLACK_WEBHOOK_URL". I then grabbed code from the quickstart which is using this same pattern https://github.com/CMSgov/macpro-quickstart-serverless/blob/master/.github/workflows/deploy.yml#L86-L95

### Changes

- created a new github secret
- modified the deploy.yml to use the new secret and run the slack notification step on failures 

### Implementation Notes

- Please join the channel in the collabralink slack workspace 

