### PR TITLE
OY2-9674: add "and CHIP" to text on homepage

### DIFF
--- a/services/ui-src/src/containers/Home.js
+++ b/services/ui-src/src/containers/Home.js
@@ -38,7 +38,7 @@ export default function Home() {
 
   const paperSubmissionList = [
     {
-      text: "Amendments to your Medicaid State Plans (not submitted through MACPro, MMDL or WMS)",
+      text: "Amendments to your Medicaid and CHIP State Plans (not submitted through MACPro, MMDL or WMS)",
     },
     {
       text: "Official state responses to formal requests for additional information (RAIs) for SPAs (not submitted through MACPro)",


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-9674
Endpoint: https://dkqwgdo31ryya.cloudfront.net

### Details

Specify that we support both Medicaid and CHIP SPA submissions.

### Changes

- Change "Medicaid" to "Medicaid and CHIP" on the homepage in the list of submission use cases.

### Implementation Notes

N/A

### Test Plan

1. Open the home page
2. Look at the bulleted list on the right side of the page and verify that the first bullet says "Medicaid and CHIP"
