### PR TITLE
changing slack uername from Destroy alerts to Deploy Failure alert

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,7 +134,7 @@ jobs:
           path: ./tests_output
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
-        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["develop", "master","slack-config", "production"]'), env.branch_name) && failure ()
+        if: env.SLACK_WEBHOOK_URL != '' && contains(fromJson('["develop", "master", "production"]'), env.branch_name) && failure ()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_USERNAME: ${{env.branch_name}} Deploy Failure

--- a/deploy.sh
+++ b/deploy.sh
@@ -30,7 +30,7 @@ services=(
   'ui-waf-log-assoc'
   'ui-auth'
   'ui-src'
-
+)
 
 set -e
 for i in "${services[@]}"; do


### PR DESCRIPTION
Story: n/a
Endpoint: n/a

### Details
SLACK_USERNAME variable was confusing and was default set to Destroy alerts". A change was made to modify it to "${env.branch_name} Deploy Failure" in the deploy.yml file. This will read better and be less confusing. An example output on a failed github actions run would read 
Master Deploy Failure 

### Changes

SLACK_USERNAME variable was changed form Destroy alerts to ${env.branch_name} Deploy Failure in the deploy.yml file.


