### PR TITLE
To MASTER: update the attachments URL creation

### DIFF
--- a/services/app-api/get.js
+++ b/services/app-api/get.js
@@ -22,6 +22,13 @@ export const main = handler(async (event, context) => {
   const result = await dynamoDb.get(params);
   if (!result.Item) {
     throw new Error("Item not found.");
+  } else {
+    //Clear out the s3 URLs.  The UI will generate a temp one.
+    if (result.Item.uploads) {
+      result.Item.uploads.forEach((upload) => {
+        upload.url = null;
+      });
+    }
   }
   console.log("Sending back result:", JSON.stringify(result, null, 2));
   // Return the retrieved item

--- a/services/ui-src/src/utils/ChangeRequestDataApi.js
+++ b/services/ui-src/src/utils/ChangeRequestDataApi.js
@@ -1,5 +1,6 @@
 import { API } from "aws-amplify";
 import { Auth } from "aws-amplify";
+import { Storage } from "aws-amplify";
 
 /**
  * Singleton class to perform operations with the change request backend.
@@ -50,6 +51,18 @@ class ChangeRequestDataApi {
         "changeRequestAPI",
         `/get/${id}/${userId}`
       );
+      // Get temporary URLs to the S3 bucket
+      if (changeRequest.uploads) {
+        let i;
+        // Use a for loop instead of forEach to stay in the context of this async function.
+        for (i = 0; i < changeRequest.uploads.length; i++) {
+          var fromStorage = await Storage.get(changeRequest.uploads[i].s3Key, {
+            level: "protected",
+            identityId: userId, // the identityId of that user
+          });
+          changeRequest.uploads[i].url = fromStorage.split("?", 1)[0];
+        }
+      }
       return changeRequest;
     } catch (error) {
       console.log(`There was an error fetching ID ${id}.`, error);


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-10086
Endpoint: https://d3j8mi7a7gstc1.cloudfront.net

### Details

This is a patch to MASTER which uses the s3key and the s3 bucket name from the environment to build the attachment URLs, allowing users to view each other's attachment submissions and also means that bucket migrations should not create broken links.

### Changes

- attachment URL is built at request time from the bucket and the s3key

### Test Plan

1. Verify that an old submission's attachment is visable
2. Verify that another user's attachment is visible
3. Verify that a new submissions's attachment is visible.
