### PR TITLE
Oy2 9564 t1

### DIFF
--- a/services/ui-src/src/components/FileUploader.js
+++ b/services/ui-src/src/components/FileUploader.js
@@ -7,7 +7,7 @@ import { faTimes } from "@fortawesome/free-solid-svg-icons";
 import { formatList } from "../utils";
 
 /** adjust to approximately 80 MB **/
-const MAX_FILE_SIZE_BYTES = 1024 * 1024 * (config.MAX_ATTACHMENT_SIZE_MB - 3);
+const MAX_FILE_SIZE_BYTES = 1024 * 1024 * (config.MAX_ATTACHMENT_SIZE_MB);
 
 /**
  * Provides a file uploader component with a set of required and optional uploads.


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-9764
Endpoint: https://d1kn85wn3ndmb4.cloudfront.net/spa

### Details

Fix bug with missing check for file attachments larger than 80 MB.

### Changes

- Fix check for file size and add browser alert for files larger than 80 MB.

### Implementation Notes

- N/A

### Test Plan

1.Login as statesubmitter@nightwatch.test

2. goto SPA form and add an attachment for a file larger than 80MB.
NOTE: You can use the following simple python code to create a file larger than 80MB. 
Create a bigfile.py file and run with python bigfile.py
with open('my_file.pdf', 'wb') as f:
    num_chars = 1024 * 1024 * 81
    f.write('0' * num_chars)
