### PR TITLE
reference element by id in test

### DIFF
--- a/nightwatch/tests/suites/OY2_7531_State_Submitter_View_Dashboard.js
+++ b/nightwatch/tests/suites/OY2_7531_State_Submitter_View_Dashboard.js
@@ -24,7 +24,7 @@ module.exports = {
         browser.click(manage_account_link);
         browser.pause(2000);
         //check on state access management for state submitter user 
-        let state_access_management = "(//h3)[5]";
+        let state_access_management = "//*[@id='accessHeader']";
         let maryland = "(//div[@class='state-access-card']/dt)[1]";
         let maryland_access_granted = "(//div[@class='state-access-card']/dd/em)[1]";
         //check if each element is visible


### PR DESCRIPTION
Endpoint: 

### Details

Fix previously failing Nightwatch test to reference the id of an element instead of finding it via counted header tags (header tags have been modified, which is what caused the failure initially).

### Changes

- Use element id in Nightwatch test

### Test Plan

1. Verifying Nightwatch tests pass during the GitHub Actions step
