### PR TITLE
Disableonemacintegration

### DIFF
--- a/services/stream-functions/serverless.yml
+++ b/services/stream-functions/serverless.yml
@@ -69,7 +69,7 @@ functions:
           arn: ${self:custom.tableStreamArn}
           startingPosition: LATEST
           maximumRetryAttempts: 2
-          enabled: true
+          enabled: false
     role: LamdaSourceDynamoToMskRole
     environment:
       BOOTSTRAP_BROKER_STRING_TLS: ${self:custom.bootstrapBrokerStringTls}


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-XXXX
Endpoint: https://xxxx.cloudfront.net

### Details

The purpose of this PR is to disable the current data stream to seatool until we determine the correct ingestion of that data.

### Changes

- Specific functionality changes, or
- A specific bug addressed in this PR

### Implementation Notes

- Developer focused info that may affect future work

### Test Plan

1. Test step 1
2. Test step 2
