### PR TITLE
OY2 10180 seatool ingestion

### DIFF
--- a/services/stream-functions/handlers/sourceDynamoToMsk.js
+++ b/services/stream-functions/handlers/sourceDynamoToMsk.js
@@ -7,6 +7,9 @@ const mappings = {
     'name': 'type_mapped.S',
     'mapping': {
       'spa': 'Medicaid SPA',
+      'chipspa': 'Medicaid CHIP SPA',
+      'waiver': '1915(b)',
+      'waiverappk': '1915(c)',
       // 'sparai': 'Medicaid SPA'
     }
   },


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-10180
Endpoint: TBD

### Details

This is to fix the mapping issue for different submission types to allow for seatool ingestion

### Implementation Notes

-Will probably need to revisit to address RAIs

### Test Plan

Make each of those 4 submissions(spa, chip spa, waiver, waiverappk) then check in the Cloudwatch log groups for /aws/lambda/stream-functions-develop-sourceDynamoToMsk and make sure no error is being returned on those submissions
