### PR TITLE
restore export on user mgnt page

### DIFF
--- a/services/ui-src/src/containers/UserManagement.js
+++ b/services/ui-src/src/containers/UserManagement.js
@@ -356,7 +356,7 @@ const UserManagement = () => {
         heading="User Management"
         rightSideContent={
           userProfile.userData.type === USER_TYPE.HELPDESK
-          && isUserActive
+          && isUserActive && csvExportSubmissions
         }
       />
       <AlertBar


### PR DESCRIPTION
Story: Restore Export Button  to User Page, unsure how it got removed.
Endpoint: https://d3i6x2q66v1zls.cloudfront.net/usermanagement

### Details

N/A

### Changes

N/A
### Implementation Notes

N/A

### Test Plan

1. Login as helpdeskactive@cms.hhs.local

2. On User Management Page verify export button visible.

