### PR TITLE
add labels for AppK withdrawal

### DIFF
--- a/services/app-api/changeRequest/formatWithdrawalEmails.js
+++ b/services/app-api/changeRequest/formatWithdrawalEmails.js
@@ -2,12 +2,14 @@ const TYPE_LABELS = {
   spa: "SPA",
   chipspa: "CHIP SPA",
   waiver: "Waiver",
+  waiverappk: "1915(c) Appendix K Amendment",
 };
 
 const ID_LABELS = {
   spa: "SPA Package ID",
   chipspa: "CHIP SPA Package ID",
   waiver: "Waiver Package #",
+  waiverappk: "Waiver #",
 };
 
 const compareSubmissionTimestamps = (a, b) =>


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-11798
Endpoint: TBD

### Details

Fix package withdrawal emails for Appendix K Amendments.

### Changes

- Add labels for both the subject line and the ID number for Appendix K withdrawals.

### Implementation Notes

N/A

### Test Plan

#### Locally
1. Run locally as you normally would.
2. Sign in as `statesubmitteractive` and create an AppK submission.
3. Navigate to `/packagelist` and withdraw the AppK via the Actions column.
4. Check the backend logs to see if the mocked-out email contains "undefined" anywhere in its subject line or body text.

#### On AWS
1. Set yourself up as a state submitter and log in.
2. Go to `/packagelist` and withdraw an AppK package. If there are none present, create one first.
3. Check your email and ensure that the email does not contain "undefined".
