### PR TITLE
fix alignment on redirect landing page

### DIFF
--- a/services/ui-src/src/containers/AttachmentLanding.tsx
+++ b/services/ui-src/src/containers/AttachmentLanding.tsx
@@ -7,34 +7,37 @@ export const AttachmentLanding = () => {
   return (
     <>
       <PageTitleBar heading="Welcome to OneMAC" />
-      <article className="attachment-redirect">
-        <p>
-          You have been directed here by a link to a document managed by OneMAC.
-          We now require all users to log in before accessing attachments.
-          Please follow these steps to find what you are looking for:
-        </p>
-        <ol>
-          <li>
-            <a href={getSignInUrl()}>Log in via Okta</a> <b>with your EUA ID</b>{" "}
-            to access the OneMAC dashboard.
-          </li>
-          <li>
-            On the dashboard, locate the submission you received an email about
-            in the list.
-            <aside>
-              To find it more quickly, you can use the search functionality
-              built into your browser. On Windows, this can be accessed with the
-              keyboard shortcut <kbd>Ctrl</kbd> + <kbd>F</kbd>. On macOS, it can
-              be accessed via <kbd>⌘</kbd> + <kbd>F</kbd>.
-            </aside>
-          </li>
-          <li>Click on its ID in the first column to view its details.</li>
-          <li>
-            Download one or all of the documents attached to the submission to
-            view them.
-          </li>
-        </ol>
-      </article>
+      <div className="attachment-redirect-wrapper">
+        <article className="attachment-redirect">
+          <p>
+            You have been directed here by a link to a document managed by
+            OneMAC. We now require all users to log in before accessing
+            attachments. Please follow these steps to find what you are looking
+            for:
+          </p>
+          <ol>
+            <li>
+              <a href={getSignInUrl()}>Log in via Okta</a>{" "}
+              <b>with your EUA ID</b> to access the OneMAC dashboard.
+            </li>
+            <li>
+              On the dashboard, locate the submission you received an email
+              about in the list.
+              <aside>
+                To find it more quickly, you can use the search functionality
+                built into your browser. On Windows, this can be accessed with
+                the keyboard shortcut <kbd>Ctrl</kbd> + <kbd>F</kbd>. On macOS,
+                it can be accessed via <kbd>⌘</kbd> + <kbd>F</kbd>.
+              </aside>
+            </li>
+            <li>Click on its ID in the first column to view its details.</li>
+            <li>
+              Download one or all of the documents attached to the submission to
+              view them.
+            </li>
+          </ol>
+        </article>
+      </div>
     </>
   );
 };

--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -2004,22 +2004,29 @@ aside#faq-contact-info-box {
   color: change-color($color-gray, $alpha: 0.3);
 }
 
-.attachment-redirect {
+.attachment-redirect-wrapper {
   @extend .app-bar;
   @extend .ds-u-padding-top--3;
+  @extend .ds-u-display--flex;
+  @extend .ds-u-justify-content--around;
 
-  > * {
-    @extend .ds-u-measure--wide;
-  }
+  .attachment-redirect {
+    width: 100%;
+    @include max-width-ultra-wide;
 
-  > ol {
-    padding-left: 2ch;
-  }
+    > * {
+      @extend .ds-u-measure--wide;
+    }
 
-  aside {
-    @extend .ds-u-margin--2;
-    @extend .ds-u-padding--1;
-    @extend .ds-u-border--1;
-    @extend .ds-u-radius;
+    > ol {
+      padding-left: 2ch;
+    }
+
+    aside {
+      @extend .ds-u-margin--2;
+      @extend .ds-u-padding--1;
+      @extend .ds-u-border--1;
+      @extend .ds-u-radius;
+    }
   }
 }


### PR DESCRIPTION
Story: N/A
Endpoint: https://d1voxd83wlgu30.cloudfront.net

### Details

Fix the landing page's alignment on wide screens.

### Changes

#### Before

<img width="1976" alt="Screen Shot 2021-09-15 at 2 17 37 PM" src="https://user-images.githubusercontent.com/17279173/133487715-bf9847d1-13b9-4eec-959e-27d58788f6a7.png">

#### After
<img width="1976" alt="Screen Shot 2021-09-15 at 2 17 24 PM" src="https://user-images.githubusercontent.com/17279173/133487752-3b068e76-aa67-4682-a5a5-017042d33408.png">

### Implementation Notes

N/A

### Test Plan

1. Go to `/legacy-attachments` and check the alignment.
