### PR TITLE
OY2-11473: ensure confirmation dialog on User Management screen does not display "undefined"

### DIFF
--- a/services/ui-src/src/components/PopupMenu.js
+++ b/services/ui-src/src/components/PopupMenu.js
@@ -33,7 +33,12 @@ const VARIATION_PROPS = {
   },
 };
 
-export default function PopupMenu({ variation, selectedRow, menuItems }) {
+export default function PopupMenu({
+  buttonLabel,
+  variation,
+  selectedRow,
+  menuItems,
+}) {
   const variationProps = VARIATION_PROPS[variation];
 
   const classes = useStyles();
@@ -55,6 +60,7 @@ export default function PopupMenu({ variation, selectedRow, menuItems }) {
     <>
       <Button
         aria-haspopup="true"
+        aria-label={buttonLabel}
         className="popup-menu-button"
         data-testid={POPUP_TRIGGER_TEST_ID}
         disabled={!menuItems || menuItems.length === 0}

--- a/services/ui-src/src/containers/UserManagement.js
+++ b/services/ui-src/src/containers/UserManagement.js
@@ -244,6 +244,7 @@ const UserManagement = () => {
         case APPROVING_USER_TYPE[row.original.role]:
           return (
             <PopupMenu
+              buttonLabel={`User management actions for ${row.values.name}`}
               selectedRow={row}
               menuItems={menuItems}
               variation="UserManagement"

--- a/services/ui-src/src/containers/UserManagement.test.js
+++ b/services/ui-src/src/containers/UserManagement.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  fireEvent,
   render,
   screen,
   waitForElementToBeRemoved,
@@ -39,4 +40,32 @@ it("renders table with columns", async () => {
   screen.getByText("Last Modified");
   screen.getByText("Modified By");
   screen.getByText("Actions");
+});
+
+it("confirms user actions with popup", async () => {
+  UserDataApi.getMyUserList.mockResolvedValue(userList);
+
+  render(
+    <AppContext.Provider
+      value={{
+        ...systemAdminInitialAuthState,
+      }}
+    >
+      <UserManagement />
+    </AppContext.Provider>,
+    { wrapper: MemoryRouter }
+  );
+
+  // wait for loading spinner to disappear so submissions table displays
+  await waitForElementToBeRemoved(() => screen.getByTestId(LOADER_TEST_ID));
+
+  fireEvent.click(
+    screen.getByLabelText(/actions for Peter Pending/, { selector: "button" })
+  );
+  fireEvent.click(screen.getAllByText(/grant access/i)[0]);
+
+  const modalHeader = screen.getByText(/Modify/).closest("header");
+  expect(modalHeader.nextElementSibling).toHaveTextContent(
+    "This will grant Peter Pending access to OneMAC."
+  );
 });


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-11473
Endpoint: https://d1jmg7cywpfxj0.cloudfront.net

### Details

Don't leak nulls into the user interface.

### Changes

- When modifying access for a user not associated with a territory, stop displaying "undefined" in the confirmation message.

### Implementation Notes

N/A

### Test Plan

1. Log in as `systemadmintest@cms.hhs.local` and go to User Management
2. Modify an entry pertaining to a state user. Take note of the confirmation dialog's phrasing: "...access **_to [state]_** in OneMAC".
3. Now, modify an entry pertaining to a CMS or Helpdesk user. Ensure that this time it says "...access to OneMAC".
