### PR TITLE
OY2-13705: increase pre-signed URL expiration time to 1 hour

### DIFF
--- a/services/app-api/get.js
+++ b/services/app-api/get.js
@@ -31,6 +31,7 @@ export const main = handler(async (event) => {
           s3.getSignedUrlPromise("getObject", {
             Bucket: process.env.attachmentsBucket,
             Key: `protected/${result.Item.userId}/${s3Key}`,
+            Expires: 3600,
           })
         )
       );

--- a/services/app-api/getDetail.js
+++ b/services/app-api/getDetail.js
@@ -50,6 +50,7 @@ export const getDetails = async (event) => {
           s3.getSignedUrlPromise("getObject", {
             Bucket: process.env.attachmentsBucket,
             Key: decodeURIComponent(url.split("amazonaws.com/")[1]),
+            Expires: 3600,
           })
         )
       );


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-13705
Endpoint: https://d2bbi38sl8wse3.cloudfront.net/

### Details

Increase timeout on pre-signed attachment URLs to 3600 seconds (1 hour).

### Changes

- Attachments should remain valid after the 15 minute mark.

### Implementation Notes

N/A

### Test Plan

1. Log in as `statesubmitteractive` and open a submission on the dashboard. Confirm that the attachment links are live and working. If you cannot find one with a live attachment link, make a new one.
2. Wait 16 minutes without closing the details page. Ensure that the links are still live.
3. Wait another 45 minutes without closing the details page. Ensure that now the links give you an "Access Denied" error.
4. Repeat steps 2 and 3 on a package details page (you can do both at the same time FYI)
