### PR TITLE
minor style fixes for filter pane after testing in develop

### DIFF
--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -2218,8 +2218,12 @@ aside#faq-contact-info-box {
     }
 
     .filter-accordion {
-      flex: 1;
+      flex: 0 1 calc(100vh - 325px);
       overflow-y: auto;
+
+      .ds-c-accordion__content {
+        max-height: unset;
+      }
     }
 
     > footer {


### PR DESCRIPTION
Story: N/A
Endpoint: TBD

### Details

Improve styling on filter pane when package list gets longer than a page.

### Changes

- Set a maximum height on the filter section before scrolling
- Let individual filters expand as much as needed

### Implementation Notes

- The solution here with `calc` is simplistic. If the header gets taller in the future then we may need to brush it up.

### Test Plan

1. Log in as `statesubmitteractive`. Create at least 8 submissions.
2. Go to the package dashboard and click the Filter button. Ensure that the "Reset" button is at the bottom of the viewport regardless of whether the accordions are expanded, and ensure that the accordions do not scroll internally.

<img width="826" alt="Screen Shot 2021-12-08 at 2 14 56 PM" src="https://user-images.githubusercontent.com/17279173/145269776-fd4b647b-758f-40ce-8b77-1b26d58e3b4a.png">

