### PR TITLE
OY2-13442: Ingest RAI data obtained from SEATool in OneMAC

### DIFF
--- a/services/app-api/libs/handler-lib.js
+++ b/services/app-api/libs/handler-lib.js
@@ -18,8 +18,7 @@ export default function handler(lambda) {
         response.body = { error: e.message };
         response.statusCode = 500;
       }
-      if (typeof response.body !== "string")
-        response.body = JSON.stringify(response.body);
+      response.body = JSON.stringify(response.body);
     }
     // Return HTTP response
     return response;

--- a/services/app-api/libs/handler-lib.js
+++ b/services/app-api/libs/handler-lib.js
@@ -10,20 +10,17 @@ export default function handler(lambda) {
     };
 
     // If this invokation is a prewarm, do nothing and return.
-    if (event.source == "serverless-plugin-warmup") {
-      console.log("Warmed up!");
-      return response;
+    if (event.source != "serverless-plugin-warmup") {
+      try {
+        // Run the Lambda
+        response.body = await lambda(event, context);
+      } catch (e) {
+        response.body = { error: e.message };
+        response.statusCode = 500;
+      }
+      if (typeof response.body !== "string")
+        response.body = JSON.stringify(response.body);
     }
-
-    try {
-      // Run the Lambda
-      response.body = await lambda(event, context);
-    } catch (e) {
-      response.body = { error: e.message };
-      response.statusCode = 500;
-    }
-    response.body = JSON.stringify(response.body);
-
     // Return HTTP response
     return response;
   };

--- a/services/app-api/libs/handler-lib.test.js
+++ b/services/app-api/libs/handler-lib.test.js
@@ -1,10 +1,33 @@
 import handler from "./handler-lib";
 
-it('Handler Code Stub', async () => {
+it("Handler Code Stub", async () => {
+  const response = handler("");
+  const response2 = response({ source: "serverless-plugin-warmup" }, "foo");
+  expect(response).toBeInstanceOf(Function);
+  expect(response2).toBeInstanceOf(Promise);
+});
+const testLambda = jest.fn();
 
-  const response = handler("")
-  const response2 = response({ "source": "serverless-plugin-warmup"}, "foo")
-  expect(response).toBeInstanceOf(Function)
-  expect(response2).toBeInstanceOf(Promise)
+const warmupResponse = {
+  statusCode: 200,
+  body: null,
+  headers: {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Credentials": true,
+  },
+};
 
+describe("test the handler handling", () => {
+  it("returns null with source of warmup", () => {
+    const event = { source: "serverless-plugin-warmup" };
+    const main = handler(testLambda);
+
+    main(event)
+      .then((data) => {
+        expect(data).toMatchObject(warmupResponse);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
 });

--- a/services/app-api/libs/handler-lib.test.js
+++ b/services/app-api/libs/handler-lib.test.js
@@ -1,12 +1,9 @@
 import handler from "./handler-lib";
 
-it("Handler Code Stub", async () => {
-  const response = handler("");
-  const response2 = response({ source: "serverless-plugin-warmup" }, "foo");
-  expect(response).toBeInstanceOf(Function);
-  expect(response2).toBeInstanceOf(Promise);
-});
 const testLambda = jest.fn();
+const successLambda = () => {
+  return "Success";
+};
 
 const warmupResponse = {
   statusCode: 200,
@@ -17,6 +14,11 @@ const warmupResponse = {
   },
 };
 
+const successResponse = {
+  ...warmupResponse,
+  body: '"Success"',
+};
+
 describe("test the handler handling", () => {
   it("returns null with source of warmup", () => {
     const event = { source: "serverless-plugin-warmup" };
@@ -25,6 +27,19 @@ describe("test the handler handling", () => {
     main(event)
       .then((data) => {
         expect(data).toMatchObject(warmupResponse);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  });
+
+  it("gives a 200 response for a regular return", () => {
+    const event = {};
+    const main = handler(successLambda);
+
+    main(event)
+      .then((data) => {
+        expect(data).toMatchObject(successResponse);
       })
       .catch((err) => {
         console.log(err);

--- a/services/app-api/submit.js
+++ b/services/app-api/submit.js
@@ -47,7 +47,7 @@ export const main = handler(async (event) => {
     data.userId = event.requestContext.identity.cognitoIdentityId;
 
     // returns undefined if no errors found, or the first error found.
-    if (!validateSubmission(data)) {
+    if (validateSubmission(data)) {
       throw RESPONSE_CODE.VALIDATION_ERROR;
     }
 

--- a/services/app-api/submit.js
+++ b/services/app-api/submit.js
@@ -26,9 +26,19 @@ const SUBMISSION_STATES = {
  * Submit a new record for storage.
  */
 export const main = handler(async (event) => {
-  const data = JSON.parse(event.body);
+  let data;
   let crFunctions;
   console.log("Received Event: ", JSON.stringify(event, null, 2));
+
+  // the event parse failure is an exception that should "break" the lambda
+  try {
+    data = JSON.parse(event.body);
+  } catch (error) {
+    console.log("event couldn't parse: ", error);
+    throw error;
+  }
+
+  // these errors are application errors, so are returned, instead
   try {
     // Add required data to the record before storing.
     data.id = uuid.v1();
@@ -36,11 +46,10 @@ export const main = handler(async (event) => {
     data.state = SUBMISSION_STATES.CREATED;
     data.userId = event.requestContext.identity.cognitoIdentityId;
 
-    // do a pre-check for things that should stop us immediately
+    // returns undefined if no errors found, or the first error found.
     if (!validateSubmission(data)) {
       throw RESPONSE_CODE.VALIDATION_ERROR;
     }
-    //console.log("Validate returns: ", validateSubmission(data));
 
     // get the rest of the details about the current user
     const doneBy = await getUser(data.user.email);
@@ -74,19 +83,14 @@ export const main = handler(async (event) => {
     if (!crVerifyTerritoryStateCode) {
       throw RESPONSE_CODE.TRANSMITTAL_ID_TERRITORY_NOT_VALID; // if ever NOT from ID... should change error :)
     }
-  } catch (error) {
-    // these are application errors, 200 level response
-    return error;
-  }
 
-  try {
     // check for submission-specific validation (uses database)
     const validationResponse = await crFunctions.fieldsValid(data);
     console.log("validation Response: ", validationResponse);
 
     if (validationResponse.areFieldsValid === false) {
       console.log("Message from fieldsValid: ", validationResponse);
-      return validationResponse.whyNot;
+      throw validationResponse.whyNot;
     }
 
     await dynamoDb.put({
@@ -95,7 +99,7 @@ export const main = handler(async (event) => {
     });
   } catch (error) {
     console.log("Error is: ", error);
-    throw error;
+    return error;
   }
 
   // Now send the CMS email

--- a/services/app-api/submit.js
+++ b/services/app-api/submit.js
@@ -26,10 +26,10 @@ const SUBMISSION_STATES = {
  * Submit a new record for storage.
  */
 export const main = handler(async (event) => {
+  const data = JSON.parse(event.body);
+  let crFunctions;
+  console.log("Received Event: ", JSON.stringify(event, null, 2));
   try {
-    const data = JSON.parse(event.body);
-    console.log("Received Event: ", JSON.stringify(event, null, 2));
-
     // Add required data to the record before storing.
     data.id = uuid.v1();
     data.createdAt = Date.now();
@@ -58,7 +58,7 @@ export const main = handler(async (event) => {
     }
 
     // map the changeRequest functions from the data.type
-    const crFunctions = getChangeRequestFunctions(data.type);
+    crFunctions = getChangeRequestFunctions(data.type);
     if (!crFunctions) {
       throw RESPONSE_CODE.VALIDATION_ERROR;
     }

--- a/services/app-api/submit.js
+++ b/services/app-api/submit.js
@@ -28,7 +28,7 @@ const SUBMISSION_STATES = {
 export const main = handler(async (event) => {
   let data;
   let crFunctions;
-  console.log("Received Event: ", JSON.stringify(event, null, 2));
+  //console.log("Received Event: ", JSON.stringify(event, null, 2));
 
   // the event parse failure is an exception that should "break" the lambda
   try {
@@ -54,7 +54,7 @@ export const main = handler(async (event) => {
     // get the rest of the details about the current user
     const doneBy = await getUser(data?.user?.email);
 
-    if (!doneBy) {
+    if (JSON.stringify(doneBy) === "{}") {
       throw RESPONSE_CODE.USER_NOT_FOUND;
     }
 

--- a/services/app-api/submit.js
+++ b/services/app-api/submit.js
@@ -27,6 +27,7 @@ const SUBMISSION_STATES = {
  */
 export const main = handler(async (event) => {
   const data = JSON.parse(event.body);
+  console.log("Received Event: ", JSON.stringify(event, null, 2));
 
   // Add required data to the record before storing.
   data.id = uuid.v1();

--- a/services/app-api/submit.js
+++ b/services/app-api/submit.js
@@ -52,8 +52,8 @@ export const main = handler(async (event) => {
     }
 
     // get the rest of the details about the current user
-    const doneBy = await getUser(data.user.email);
-    console.log("done by: ", doneBy);
+    const doneBy = await getUser(data?.user?.email);
+
     if (!doneBy) {
       throw RESPONSE_CODE.USER_NOT_FOUND;
     }

--- a/services/app-api/submit.test.js
+++ b/services/app-api/submit.test.js
@@ -1,8 +1,10 @@
 import { main } from "./submit";
 import { validateSubmission } from "./changeRequest/changeRequest-util";
 import { RESPONSE_CODE } from "cmscommonlib";
+import getUser from "./utils/getUser";
 
 jest.mock("./changeRequest/changeRequest-util");
+jest.mock("./utils/getUser");
 
 const expectedResponse = {
   statusCode: 200,
@@ -13,26 +15,150 @@ const expectedResponse = {
   },
 };
 
-it("Get Stub", async () => {
+const testUserEvent = {
+  resource: "/submit",
+  path: "/submit",
+  httpMethod: "POST",
+  headers: {
+    Accept: "application/json, text/plain, */*",
+    "accept-encoding": "gzip, deflate, br",
+    "Accept-Language": "en-US,en;q=0.9",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "content-type": "application/json; charset=UTF-8",
+    Host: "je8lkoa2u9.execute-api.us-east-1.amazonaws.com",
+    origin: "https://d37vvg9moxp7a1.cloudfront.net",
+    Referer: "https://d37vvg9moxp7a1.cloudfront.net/",
+    "sec-ch-ua":
+      '" Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"',
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-platform": '"macOS"',
+    "sec-fetch-dest": "empty",
+    "sec-fetch-mode": "cors",
+    "sec-fetch-site": "cross-site",
+    "User-Agent":
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
+    Via: "2.0 69e952c7b08727f752b5559b0b6d2109.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "yIp2u_H_Yk7vGXKq9YcN9AvOyyhKz4yXmMn6McC_anAGsMxaALC_Aw==",
+    "x-amz-date": "20211214T133015Z",
+    "x-amz-security-token":
+      "IQoJb3JpZ2luX2VjEHYaCXVzLWVhc3QtMSJGMEQCIFecS2+i1A0GkNHz0XYps3Kl3sUY88VzVm6atSIWKoSCAiB8g41yAkpxx3wdZIWLc/XYN7WTSLNbB9pZsvpgJYXedirEBAhfEAEaDDExNjIyOTY0MjQ0MiIMgzXQ79XuurzQGcOAKqEE/4LhIfW8GCbP52hHFYaEcLykIpPW4zhesEpNx2eeFYn2ENzPP7hlu4LVZt36dATpzD5nQ0XPvogxduJuh26TlzADKRHWndKXZY7InfeZ4ncw2mutpuAZd9X/X3tRUSW6Z4y641a0AoEN3rXQcOUxpI2BSn51P1eeuVuU7c5PdXtaifrMCNZW4WR0c8MepFyJQIyLnVBSDNWPxqRWYNgFU7+JSU8w9aAmXZKCcMTL3a9K47URvgpu1HuksudfUYnL/tEzA/7ayUVbZgGDLNAPfEwwrGysuUiO8qRkTYpUrtqOkrOk9r1jK48hk1KXbAgy6ThLFPpiVURQiAsRSXnSz9qE2nP2LJ4KZvK8MzBJBd40kilTUQR795dMjlJcNkuxw0YdH7cOXfJeByo9koZr5W9tngtBJTNxGMhi55iqrLs35xUpUMVqG5FoF6HSMnBaBjqYcRL/nEvMpDv55l6KxYzUfJoQ4y1Lq+TvpLlyLj1mjyGAnyA99vsuyQEDiizkMgbTMP8Jk3esorXjW00wK4dqlCNsZzPB4tsJbli86iG+A7L5M8eqxGH+WfY6/VaBlqMVEOQjMXJU2o7omVXHIwev58976l53jl53K9P32LjkY5fOaW+Q7Jkr5fPP1OhO/MNye7Hs6ie5S3zn5LDvsTwwZESu9kGuNDn4X2kCi9IYbXWurZVQIPiZ2MX1eMx/MvtTnQIr27PivUYNJElzwxYwjrXijQY6hgIq02dn6756pbwy8zDdb33oejWhQHuprYYJR90I7Cg5I0zRqkuPt4LqK0oJI+xugV3o1Z8oxHfJC1tIZzq5anP+oyKhwqB8mLdYghnUtxeNdPS7koKUI4/gWB/gYK9X92qiyzo7LtPAQm9U1r5UziScA3yPDfBHrqaizCx84OMnsNR4ct9dLolamLUd3hsdAedqpxr1qfBeqU0KrNUw6X3j+ORvQw/OT/YOY7aehY1DfrXqdAt+UeiagikwFH9zGlT9dEMzPrplcwFedoStBuQlNRgNb9RRhUJ3kHQzzbCxseN82kSrRC9meJz5W5fZsEK1RldAYza+coHhnGzXlFo9/sP13S/h",
+    "X-Amzn-Trace-Id": "Root=1-61b89c67-6248cd267cc233ba5317aebe",
+    "X-Forwarded-For": "52.5.212.71, 130.176.133.73",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https",
+  },
+  multiValueHeaders: {
+    Accept: ["application/json, text/plain, */*"],
+    "accept-encoding": ["gzip, deflate, br"],
+    "Accept-Language": ["en-US,en;q=0.9"],
+    "CloudFront-Forwarded-Proto": ["https"],
+    "CloudFront-Is-Desktop-Viewer": ["true"],
+    "CloudFront-Is-Mobile-Viewer": ["false"],
+    "CloudFront-Is-SmartTV-Viewer": ["false"],
+    "CloudFront-Is-Tablet-Viewer": ["false"],
+    "CloudFront-Viewer-Country": ["US"],
+    "content-type": ["application/json; charset=UTF-8"],
+    Host: ["je8lkoa2u9.execute-api.us-east-1.amazonaws.com"],
+    origin: ["https://d37vvg9moxp7a1.cloudfront.net"],
+    Referer: ["https://d37vvg9moxp7a1.cloudfront.net/"],
+    "sec-ch-ua": [
+      '" Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"',
+    ],
+    "sec-ch-ua-mobile": ["?0"],
+    "sec-ch-ua-platform": ['"macOS"'],
+    "sec-fetch-dest": ["empty"],
+    "sec-fetch-mode": ["cors"],
+    "sec-fetch-site": ["cross-site"],
+    "User-Agent": [
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
+    ],
+    Via: ["2.0 69e952c7b08727f752b5559b0b6d2109.cloudfront.net (CloudFront)"],
+    "X-Amz-Cf-Id": ["yIp2u_H_Yk7vGXKq9YcN9AvOyyhKz4yXmMn6McC_anAGsMxaALC_Aw=="],
+    "x-amz-date": ["20211214T133015Z"],
+    "x-amz-security-token": [
+      "IQoJb3JpZ2luX2VjEHYaCXVzLWVhc3QtMSJGMEQCIFecS2+i1A0GkNHz0XYps3Kl3sUY88VzVm6atSIWKoSCAiB8g41yAkpxx3wdZIWLc/XYN7WTSLNbB9pZsvpgJYXedirEBAhfEAEaDDExNjIyOTY0MjQ0MiIMgzXQ79XuurzQGcOAKqEE/4LhIfW8GCbP52hHFYaEcLykIpPW4zhesEpNx2eeFYn2ENzPP7hlu4LVZt36dATpzD5nQ0XPvogxduJuh26TlzADKRHWndKXZY7InfeZ4ncw2mutpuAZd9X/X3tRUSW6Z4y641a0AoEN3rXQcOUxpI2BSn51P1eeuVuU7c5PdXtaifrMCNZW4WR0c8MepFyJQIyLnVBSDNWPxqRWYNgFU7+JSU8w9aAmXZKCcMTL3a9K47URvgpu1HuksudfUYnL/tEzA/7ayUVbZgGDLNAPfEwwrGysuUiO8qRkTYpUrtqOkrOk9r1jK48hk1KXbAgy6ThLFPpiVURQiAsRSXnSz9qE2nP2LJ4KZvK8MzBJBd40kilTUQR795dMjlJcNkuxw0YdH7cOXfJeByo9koZr5W9tngtBJTNxGMhi55iqrLs35xUpUMVqG5FoF6HSMnBaBjqYcRL/nEvMpDv55l6KxYzUfJoQ4y1Lq+TvpLlyLj1mjyGAnyA99vsuyQEDiizkMgbTMP8Jk3esorXjW00wK4dqlCNsZzPB4tsJbli86iG+A7L5M8eqxGH+WfY6/VaBlqMVEOQjMXJU2o7omVXHIwev58976l53jl53K9P32LjkY5fOaW+Q7Jkr5fPP1OhO/MNye7Hs6ie5S3zn5LDvsTwwZESu9kGuNDn4X2kCi9IYbXWurZVQIPiZ2MX1eMx/MvtTnQIr27PivUYNJElzwxYwjrXijQY6hgIq02dn6756pbwy8zDdb33oejWhQHuprYYJR90I7Cg5I0zRqkuPt4LqK0oJI+xugV3o1Z8oxHfJC1tIZzq5anP+oyKhwqB8mLdYghnUtxeNdPS7koKUI4/gWB/gYK9X92qiyzo7LtPAQm9U1r5UziScA3yPDfBHrqaizCx84OMnsNR4ct9dLolamLUd3hsdAedqpxr1qfBeqU0KrNUw6X3j+ORvQw/OT/YOY7aehY1DfrXqdAt+UeiagikwFH9zGlT9dEMzPrplcwFedoStBuQlNRgNb9RRhUJ3kHQzzbCxseN82kSrRC9meJz5W5fZsEK1RldAYza+coHhnGzXlFo9/sP13S/h",
+    ],
+    "X-Amzn-Trace-Id": ["Root=1-61b89c67-6248cd267cc233ba5317aebe"],
+    "X-Forwarded-For": ["52.5.212.71, 130.176.133.73"],
+    "X-Forwarded-Port": ["443"],
+    "X-Forwarded-Proto": ["https"],
+  },
+  queryStringParameters: null,
+  multiValueQueryStringParameters: null,
+  pathParameters: null,
+  stageVariables: null,
+  requestContext: {
+    resourceId: "kvruyp",
+    resourcePath: "/submit",
+    httpMethod: "POST",
+    extendedRequestId: "KV1gKE7pIAMFn0w=",
+    requestTime: "14/Dec/2021:13:30:15 +0000",
+    path: "/add-rai/submit",
+    accountId: "116229642442",
+    protocol: "HTTP/1.1",
+    stage: "add-rai",
+    domainPrefix: "je8lkoa2u9",
+    requestTimeEpoch: 1639488615281,
+    requestId: "c6998b30-0037-44ea-b7b2-84fb6db6a097",
+    identity: {
+      cognitoIdentityPoolId: "us-east-1:59813137-7778-4751-be10-ca7dd7ff230f",
+      accountId: "116229642442",
+      cognitoIdentityId: "us-east-1:54fb74ef-1d89-4528-bb26-24926cbc5eef",
+      caller: "AROARWD6TTDFLDZEL2SVL:CognitoIdentityCredentials",
+      sourceIp: "52.5.212.71",
+      principalOrgId: "o-ry4nhh9eic",
+      accessKey: "ASIARWD6TTDFB5CIV4O3",
+      cognitoAuthenticationType: "authenticated",
+      cognitoAuthenticationProvider:
+        "cognito-idp.us-east-1.amazonaws.com/us-east-1_D76KEX0e0,cognito-idp.us-east-1.amazonaws.com/us-east-1_D76KEX0e0:CognitoSignIn:24d4590e-15b8-4a57-b49a-312fdc1f2ca6",
+      userArn:
+        "arn:aws:sts::116229642442:assumed-role/ui-auth-add-rai-CognitoAuthRole-19ZNUCUFEE272/CognitoIdentityCredentials",
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
+      user: "AROARWD6TTDFLDZEL2SVL:CognitoIdentityCredentials",
+    },
+    domainName: "je8lkoa2u9.execute-api.us-east-1.amazonaws.com",
+    apiId: "je8lkoa2u9",
+  },
+  body: '{"type":"spa","territory":"MI","summary":"valid submission data for testing.","transmittalNumber":"MI-22-0897","actionType":"","waiverAuthority":"","transmittalNumberWarningMessage":"","user":{"email":"statesubmitteractive@cms.hhs.local","firstName":"Angie","lastName":"Active"},"uploads":[{"s3Key":"1639488614688/CMS 179 Form Acronym Removal Signed.pdf","filename":"CMS 179 Form Acronym Removal Signed.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614688/CMS%20179%20Form%20Acronym%20Removal%20Signed.pdf","title":"CMS Form 179"},{"s3Key":"1639488614690/Attachment 3.1-A, #4b, Page 3f Track.pdf","filename":"Attachment 3.1-A, #4b, Page 3f Track.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614690/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Track.pdf","title":"SPA Pages"}]}',
+  isBase64Encoded: false,
+};
+
+it("tests the warmup", async () => {
   const response = main({ source: "serverless-plugin-warmup" }, "foo");
   expect(response).toBeInstanceOf(Promise);
 });
 
 it(`returns an error for invalid submission`, async () => {
-  const testEvent = {
-    requestContext: {
-      identity: {
-        cognitoIdentityId: "Test ID for Cognito",
-      },
-    },
-    body: '{"type":"spa"}',
-    isBase64Encoded: false,
-  };
   expectedResponse.body = RESPONSE_CODE.VALIDATION_ERROR;
 
   validateSubmission.mockReturnValue(false);
 
-  const response = main(testEvent, "foo");
+  const response = main(testUserEvent, "foo");
 
-  expect(response).resolves.toBe(expectedResponse);
+  expect(response)
+    .resolves.toStrictEqual(expectedResponse)
+    .catch((error) => {
+      console.log("caught test error: ", error);
+    });
+});
+
+it(`returns an error for unknown user`, async () => {
+  expectedResponse.body = RESPONSE_CODE.USER_NOT_FOUND;
+
+  validateSubmission.mockReturnValue(true);
+  getUser.mockResolvedValueOnce(null);
+
+  const response = main(testUserEvent, "foo");
+
+  expect(response)
+    .resolves.toStrictEqual(expectedResponse)
+    .catch((error) => {
+      console.log("caught test error: ", error);
+    });
 });

--- a/services/app-api/submit.test.js
+++ b/services/app-api/submit.test.js
@@ -25,117 +25,12 @@ const expectedResponse = {
 };
 
 const testUserEvent = {
-  resource: "/submit",
-  path: "/submit",
-  httpMethod: "POST",
-  headers: {
-    Accept: "application/json, text/plain, */*",
-    "accept-encoding": "gzip, deflate, br",
-    "Accept-Language": "en-US,en;q=0.9",
-    "CloudFront-Forwarded-Proto": "https",
-    "CloudFront-Is-Desktop-Viewer": "true",
-    "CloudFront-Is-Mobile-Viewer": "false",
-    "CloudFront-Is-SmartTV-Viewer": "false",
-    "CloudFront-Is-Tablet-Viewer": "false",
-    "CloudFront-Viewer-Country": "US",
-    "content-type": "application/json; charset=UTF-8",
-    Host: "je8lkoa2u9.execute-api.us-east-1.amazonaws.com",
-    origin: "https://d37vvg9moxp7a1.cloudfront.net",
-    Referer: "https://d37vvg9moxp7a1.cloudfront.net/",
-    "sec-ch-ua":
-      '" Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"',
-    "sec-ch-ua-mobile": "?0",
-    "sec-ch-ua-platform": '"macOS"',
-    "sec-fetch-dest": "empty",
-    "sec-fetch-mode": "cors",
-    "sec-fetch-site": "cross-site",
-    "User-Agent":
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
-    Via: "2.0 69e952c7b08727f752b5559b0b6d2109.cloudfront.net (CloudFront)",
-    "X-Amz-Cf-Id": "yIp2u_H_Yk7vGXKq9YcN9AvOyyhKz4yXmMn6McC_anAGsMxaALC_Aw==",
-    "x-amz-date": "20211214T133015Z",
-    "x-amz-security-token":
-      "IQoJb3JpZ2luX2VjEHYaCXVzLWVhc3QtMSJGMEQCIFecS2+i1A0GkNHz0XYps3Kl3sUY88VzVm6atSIWKoSCAiB8g41yAkpxx3wdZIWLc/XYN7WTSLNbB9pZsvpgJYXedirEBAhfEAEaDDExNjIyOTY0MjQ0MiIMgzXQ79XuurzQGcOAKqEE/4LhIfW8GCbP52hHFYaEcLykIpPW4zhesEpNx2eeFYn2ENzPP7hlu4LVZt36dATpzD5nQ0XPvogxduJuh26TlzADKRHWndKXZY7InfeZ4ncw2mutpuAZd9X/X3tRUSW6Z4y641a0AoEN3rXQcOUxpI2BSn51P1eeuVuU7c5PdXtaifrMCNZW4WR0c8MepFyJQIyLnVBSDNWPxqRWYNgFU7+JSU8w9aAmXZKCcMTL3a9K47URvgpu1HuksudfUYnL/tEzA/7ayUVbZgGDLNAPfEwwrGysuUiO8qRkTYpUrtqOkrOk9r1jK48hk1KXbAgy6ThLFPpiVURQiAsRSXnSz9qE2nP2LJ4KZvK8MzBJBd40kilTUQR795dMjlJcNkuxw0YdH7cOXfJeByo9koZr5W9tngtBJTNxGMhi55iqrLs35xUpUMVqG5FoF6HSMnBaBjqYcRL/nEvMpDv55l6KxYzUfJoQ4y1Lq+TvpLlyLj1mjyGAnyA99vsuyQEDiizkMgbTMP8Jk3esorXjW00wK4dqlCNsZzPB4tsJbli86iG+A7L5M8eqxGH+WfY6/VaBlqMVEOQjMXJU2o7omVXHIwev58976l53jl53K9P32LjkY5fOaW+Q7Jkr5fPP1OhO/MNye7Hs6ie5S3zn5LDvsTwwZESu9kGuNDn4X2kCi9IYbXWurZVQIPiZ2MX1eMx/MvtTnQIr27PivUYNJElzwxYwjrXijQY6hgIq02dn6756pbwy8zDdb33oejWhQHuprYYJR90I7Cg5I0zRqkuPt4LqK0oJI+xugV3o1Z8oxHfJC1tIZzq5anP+oyKhwqB8mLdYghnUtxeNdPS7koKUI4/gWB/gYK9X92qiyzo7LtPAQm9U1r5UziScA3yPDfBHrqaizCx84OMnsNR4ct9dLolamLUd3hsdAedqpxr1qfBeqU0KrNUw6X3j+ORvQw/OT/YOY7aehY1DfrXqdAt+UeiagikwFH9zGlT9dEMzPrplcwFedoStBuQlNRgNb9RRhUJ3kHQzzbCxseN82kSrRC9meJz5W5fZsEK1RldAYza+coHhnGzXlFo9/sP13S/h",
-    "X-Amzn-Trace-Id": "Root=1-61b89c67-6248cd267cc233ba5317aebe",
-    "X-Forwarded-For": "52.5.212.71, 130.176.133.73",
-    "X-Forwarded-Port": "443",
-    "X-Forwarded-Proto": "https",
-  },
-  multiValueHeaders: {
-    Accept: ["application/json, text/plain, */*"],
-    "accept-encoding": ["gzip, deflate, br"],
-    "Accept-Language": ["en-US,en;q=0.9"],
-    "CloudFront-Forwarded-Proto": ["https"],
-    "CloudFront-Is-Desktop-Viewer": ["true"],
-    "CloudFront-Is-Mobile-Viewer": ["false"],
-    "CloudFront-Is-SmartTV-Viewer": ["false"],
-    "CloudFront-Is-Tablet-Viewer": ["false"],
-    "CloudFront-Viewer-Country": ["US"],
-    "content-type": ["application/json; charset=UTF-8"],
-    Host: ["je8lkoa2u9.execute-api.us-east-1.amazonaws.com"],
-    origin: ["https://d37vvg9moxp7a1.cloudfront.net"],
-    Referer: ["https://d37vvg9moxp7a1.cloudfront.net/"],
-    "sec-ch-ua": [
-      '" Not A;Brand";v="99", "Chromium";v="96", "Google Chrome";v="96"',
-    ],
-    "sec-ch-ua-mobile": ["?0"],
-    "sec-ch-ua-platform": ['"macOS"'],
-    "sec-fetch-dest": ["empty"],
-    "sec-fetch-mode": ["cors"],
-    "sec-fetch-site": ["cross-site"],
-    "User-Agent": [
-      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
-    ],
-    Via: ["2.0 69e952c7b08727f752b5559b0b6d2109.cloudfront.net (CloudFront)"],
-    "X-Amz-Cf-Id": ["yIp2u_H_Yk7vGXKq9YcN9AvOyyhKz4yXmMn6McC_anAGsMxaALC_Aw=="],
-    "x-amz-date": ["20211214T133015Z"],
-    "x-amz-security-token": [
-      "IQoJb3JpZ2luX2VjEHYaCXVzLWVhc3QtMSJGMEQCIFecS2+i1A0GkNHz0XYps3Kl3sUY88VzVm6atSIWKoSCAiB8g41yAkpxx3wdZIWLc/XYN7WTSLNbB9pZsvpgJYXedirEBAhfEAEaDDExNjIyOTY0MjQ0MiIMgzXQ79XuurzQGcOAKqEE/4LhIfW8GCbP52hHFYaEcLykIpPW4zhesEpNx2eeFYn2ENzPP7hlu4LVZt36dATpzD5nQ0XPvogxduJuh26TlzADKRHWndKXZY7InfeZ4ncw2mutpuAZd9X/X3tRUSW6Z4y641a0AoEN3rXQcOUxpI2BSn51P1eeuVuU7c5PdXtaifrMCNZW4WR0c8MepFyJQIyLnVBSDNWPxqRWYNgFU7+JSU8w9aAmXZKCcMTL3a9K47URvgpu1HuksudfUYnL/tEzA/7ayUVbZgGDLNAPfEwwrGysuUiO8qRkTYpUrtqOkrOk9r1jK48hk1KXbAgy6ThLFPpiVURQiAsRSXnSz9qE2nP2LJ4KZvK8MzBJBd40kilTUQR795dMjlJcNkuxw0YdH7cOXfJeByo9koZr5W9tngtBJTNxGMhi55iqrLs35xUpUMVqG5FoF6HSMnBaBjqYcRL/nEvMpDv55l6KxYzUfJoQ4y1Lq+TvpLlyLj1mjyGAnyA99vsuyQEDiizkMgbTMP8Jk3esorXjW00wK4dqlCNsZzPB4tsJbli86iG+A7L5M8eqxGH+WfY6/VaBlqMVEOQjMXJU2o7omVXHIwev58976l53jl53K9P32LjkY5fOaW+Q7Jkr5fPP1OhO/MNye7Hs6ie5S3zn5LDvsTwwZESu9kGuNDn4X2kCi9IYbXWurZVQIPiZ2MX1eMx/MvtTnQIr27PivUYNJElzwxYwjrXijQY6hgIq02dn6756pbwy8zDdb33oejWhQHuprYYJR90I7Cg5I0zRqkuPt4LqK0oJI+xugV3o1Z8oxHfJC1tIZzq5anP+oyKhwqB8mLdYghnUtxeNdPS7koKUI4/gWB/gYK9X92qiyzo7LtPAQm9U1r5UziScA3yPDfBHrqaizCx84OMnsNR4ct9dLolamLUd3hsdAedqpxr1qfBeqU0KrNUw6X3j+ORvQw/OT/YOY7aehY1DfrXqdAt+UeiagikwFH9zGlT9dEMzPrplcwFedoStBuQlNRgNb9RRhUJ3kHQzzbCxseN82kSrRC9meJz5W5fZsEK1RldAYza+coHhnGzXlFo9/sP13S/h",
-    ],
-    "X-Amzn-Trace-Id": ["Root=1-61b89c67-6248cd267cc233ba5317aebe"],
-    "X-Forwarded-For": ["52.5.212.71, 130.176.133.73"],
-    "X-Forwarded-Port": ["443"],
-    "X-Forwarded-Proto": ["https"],
-  },
-  queryStringParameters: null,
-  multiValueQueryStringParameters: null,
-  pathParameters: null,
-  stageVariables: null,
+  body: '{"type":"spa"}', // rest of a valid event.body,"territory":"MI","summary":"valid submission data for testing.","transmittalNumber":"MI-22-0897","actionType":"","waiverAuthority":"","transmittalNumberWarningMessage":"","user":{"email":"statesubmitteractive@cms.hhs.local","firstName":"Angie","lastName":"Active"},"uploads":[{"s3Key":"1639488614688/CMS 179 Form Acronym Removal Signed.pdf","filename":"CMS 179 Form Acronym Removal Signed.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614688/CMS%20179%20Form%20Acronym%20Removal%20Signed.pdf","title":"CMS Form 179"},{"s3Key":"1639488614690/Attachment 3.1-A, #4b, Page 3f Track.pdf","filename":"Attachment 3.1-A, #4b, Page 3f Track.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614690/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Track.pdf","title":"SPA Pages"}]}',
   requestContext: {
-    resourceId: "kvruyp",
-    resourcePath: "/submit",
-    httpMethod: "POST",
-    extendedRequestId: "KV1gKE7pIAMFn0w=",
-    requestTime: "14/Dec/2021:13:30:15 +0000",
-    path: "/add-rai/submit",
-    accountId: "116229642442",
-    protocol: "HTTP/1.1",
-    stage: "add-rai",
-    domainPrefix: "je8lkoa2u9",
-    requestTimeEpoch: 1639488615281,
-    requestId: "c6998b30-0037-44ea-b7b2-84fb6db6a097",
     identity: {
-      cognitoIdentityPoolId: "us-east-1:59813137-7778-4751-be10-ca7dd7ff230f",
-      accountId: "116229642442",
       cognitoIdentityId: "us-east-1:54fb74ef-1d89-4528-bb26-24926cbc5eef",
-      caller: "AROARWD6TTDFLDZEL2SVL:CognitoIdentityCredentials",
-      sourceIp: "52.5.212.71",
-      principalOrgId: "o-ry4nhh9eic",
-      accessKey: "ASIARWD6TTDFB5CIV4O3",
-      cognitoAuthenticationType: "authenticated",
-      cognitoAuthenticationProvider:
-        "cognito-idp.us-east-1.amazonaws.com/us-east-1_D76KEX0e0,cognito-idp.us-east-1.amazonaws.com/us-east-1_D76KEX0e0:CognitoSignIn:24d4590e-15b8-4a57-b49a-312fdc1f2ca6",
-      userArn:
-        "arn:aws:sts::116229642442:assumed-role/ui-auth-add-rai-CognitoAuthRole-19ZNUCUFEE272/CognitoIdentityCredentials",
-      userAgent:
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.93 Safari/537.36",
-      user: "AROARWD6TTDFLDZEL2SVL:CognitoIdentityCredentials",
     },
-    domainName: "je8lkoa2u9.execute-api.us-east-1.amazonaws.com",
-    apiId: "je8lkoa2u9",
   },
-  body: '{"type":"spa","territory":"MI","summary":"valid submission data for testing.","transmittalNumber":"MI-22-0897","actionType":"","waiverAuthority":"","transmittalNumberWarningMessage":"","user":{"email":"statesubmitteractive@cms.hhs.local","firstName":"Angie","lastName":"Active"},"uploads":[{"s3Key":"1639488614688/CMS 179 Form Acronym Removal Signed.pdf","filename":"CMS 179 Form Acronym Removal Signed.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614688/CMS%20179%20Form%20Acronym%20Removal%20Signed.pdf","title":"CMS Form 179"},{"s3Key":"1639488614690/Attachment 3.1-A, #4b, Page 3f Track.pdf","filename":"Attachment 3.1-A, #4b, Page 3f Track.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614690/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Track.pdf","title":"SPA Pages"}]}',
-  isBase64Encoded: false,
 };
 
 const testDoneBy = {
@@ -166,9 +61,6 @@ const testDoneBy = {
   id: "statesubmitteractive@cms.hhs.local",
   type: USER_TYPE.STATE_SUBMITTER,
 };
-
-//body: '{"type":"spa","territory":"MI","summary":"valid submission data for testing.","transmittalNumber":"MI-22-0897","actionType":"","waiverAuthority":"","transmittalNumberWarningMessage":"","user":{"email":"statesubmitteractive@cms.hhs.local","firstName":"Angie","lastName":"Active"},"uploads":[{"s3Key":"1639488614688/CMS 179 Form Acronym Removal Signed.pdf","filename":"CMS 179 Form Acronym Removal Signed.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614688/CMS%20179%20Form%20Acronym%20Removal%20Signed.pdf","title":"CMS Form 179"},{"s3Key":"1639488614690/Attachment 3.1-A, #4b, Page 3f Track.pdf","filename":"Attachment 3.1-A, #4b, Page 3f Track.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614690/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Track.pdf","title":"SPA Pages"}]}',
-//  body: '{"type":"spa"}',
 
 beforeEach(() => {
   validateSubmission.mockImplementation(() => {
@@ -203,9 +95,7 @@ it(`returns an error for invalid submission`, async () => {
     return "VA000";
   });
 
-  const response = main(testUserEvent, "foo");
-
-  expect(response)
+  expect(main(testUserEvent))
     .resolves.toStrictEqual(expectedResponse)
     .catch((error) => {
       console.log("caught test error: ", error);
@@ -219,9 +109,7 @@ it("returns an error if submitter does not have access", async () => {
     return USER_STATUS.DENIED;
   });
 
-  const response = main(testUserEvent, "foo");
-
-  expect(response)
+  expect(main(testUserEvent))
     .resolves.toStrictEqual(expectedResponse)
     .catch((error) => {
       console.log("caught test error: ", error);
@@ -235,9 +123,7 @@ it(`returns an error for unknown user`, async () => {
     return {};
   });
 
-  const response = main(testUserEvent, "foo");
-
-  expect(response)
+  expect(main(testUserEvent))
     .resolves.toStrictEqual(expectedResponse)
     .catch((error) => {
       console.log("caught test error: ", error);
@@ -251,9 +137,7 @@ it("errors if can't find crfunctions", async () => {
     return null;
   });
 
-  const response = main(testUserEvent, "foo");
-
-  expect(response)
+  expect(main(testUserEvent))
     .resolves.toStrictEqual(expectedResponse)
     .catch((error) => {
       console.log("caught test error: ", error);
@@ -269,9 +153,7 @@ it("errors if territory is invalid", async () => {
     return false;
   });
 
-  const response = main(testUserEvent, "foo");
-
-  expect(response)
+  expect(main(testUserEvent))
     .resolves.toStrictEqual(expectedResponse)
     .catch((error) => {
       console.log("caught test error: ", error);
@@ -291,9 +173,7 @@ it("errors if second check of territory is invalid", async () => {
       return false;
     });
 
-  const response = main(testUserEvent, "foo");
-
-  expect(response)
+  expect(main(testUserEvent))
     .resolves.toStrictEqual(expectedResponse)
     .catch((error) => {
       console.log("caught test error: ", error);

--- a/services/app-api/submit.test.js
+++ b/services/app-api/submit.test.js
@@ -1,10 +1,10 @@
 import { main } from "./submit";
 import { validateSubmission } from "./changeRequest/changeRequest-util";
 import { RESPONSE_CODE } from "cmscommonlib";
-//import getUser from "./utils/getUser";
+import getUser from "./utils/getUser";
 
 jest.mock("./changeRequest/changeRequest-util");
-//jest.mock("./utils/getUser");
+jest.mock("./utils/getUser");
 
 const expectedResponse = {
   statusCode: 200,
@@ -125,11 +125,12 @@ const testUserEvent = {
     domainName: "je8lkoa2u9.execute-api.us-east-1.amazonaws.com",
     apiId: "je8lkoa2u9",
   },
-  body: '{"type":"spa"}',
+  body: '{"type":"spa","territory":"MI","summary":"valid submission data for testing.","transmittalNumber":"MI-22-0897","actionType":"","waiverAuthority":"","transmittalNumberWarningMessage":"","user":{"email":"statesubmitteractive@cms.hhs.local","firstName":"Angie","lastName":"Active"},"uploads":[{"s3Key":"1639488614688/CMS 179 Form Acronym Removal Signed.pdf","filename":"CMS 179 Form Acronym Removal Signed.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614688/CMS%20179%20Form%20Acronym%20Removal%20Signed.pdf","title":"CMS Form 179"},{"s3Key":"1639488614690/Attachment 3.1-A, #4b, Page 3f Track.pdf","filename":"Attachment 3.1-A, #4b, Page 3f Track.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614690/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Track.pdf","title":"SPA Pages"}]}',
   isBase64Encoded: false,
 };
 
 //body: '{"type":"spa","territory":"MI","summary":"valid submission data for testing.","transmittalNumber":"MI-22-0897","actionType":"","waiverAuthority":"","transmittalNumberWarningMessage":"","user":{"email":"statesubmitteractive@cms.hhs.local","firstName":"Angie","lastName":"Active"},"uploads":[{"s3Key":"1639488614688/CMS 179 Form Acronym Removal Signed.pdf","filename":"CMS 179 Form Acronym Removal Signed.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614688/CMS%20179%20Form%20Acronym%20Removal%20Signed.pdf","title":"CMS Form 179"},{"s3Key":"1639488614690/Attachment 3.1-A, #4b, Page 3f Track.pdf","filename":"Attachment 3.1-A, #4b, Page 3f Track.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614690/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Track.pdf","title":"SPA Pages"}]}',
+//  body: '{"type":"spa"}',
 
 it("tests the warmup", async () => {
   const response = main({ source: "serverless-plugin-warmup" }, "foo");
@@ -139,7 +140,7 @@ it("tests the warmup", async () => {
 it(`returns an error for invalid submission`, async () => {
   expectedResponse.body = JSON.stringify(RESPONSE_CODE.VALIDATION_ERROR);
 
-  validateSubmission.mockReturnValue(null);
+  validateSubmission.mockReturnValue("VA000");
 
   const response = main(testUserEvent, "foo");
 
@@ -149,11 +150,11 @@ it(`returns an error for invalid submission`, async () => {
       console.log("caught test error: ", error);
     });
 });
-/*
+
 it(`returns an error for unknown user`, async () => {
   expectedResponse.body = JSON.stringify(RESPONSE_CODE.USER_NOT_FOUND);
   console.log("expect: ", expectedResponse);
-  validateSubmission.mockReturnValueOnce(true);
+  validateSubmission.mockReturnValueOnce(null);
   getUser.mockResolvedValueOnce(null);
 
   const response = main(testUserEvent, "foo");
@@ -164,4 +165,3 @@ it(`returns an error for unknown user`, async () => {
       console.log("caught test error: ", error);
     });
 });
-*/

--- a/services/app-api/submit.test.js
+++ b/services/app-api/submit.test.js
@@ -1,8 +1,38 @@
-import {main} from "./submit";
+import { main } from "./submit";
+import { validateSubmission } from "./changeRequest/changeRequest-util";
+import { RESPONSE_CODE } from "cmscommonlib";
 
-it('Get Stub', async () => {
+jest.mock("./changeRequest/changeRequest-util");
 
-    const response =  main( {"source": "serverless-plugin-warmup"}, "foo")
-    expect(response).toBeInstanceOf(Promise)
+const expectedResponse = {
+  statusCode: 200,
+  body: RESPONSE_CODE.SUBMISSION_SUCCESS,
+  headers: {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Credentials": true,
+  },
+};
 
-})
+it("Get Stub", async () => {
+  const response = main({ source: "serverless-plugin-warmup" }, "foo");
+  expect(response).toBeInstanceOf(Promise);
+});
+
+it(`returns an error for invalid submission`, async () => {
+  const testEvent = {
+    requestContext: {
+      identity: {
+        cognitoIdentityId: "Test ID for Cognito",
+      },
+    },
+    body: '{"type":"spa"}',
+    isBase64Encoded: false,
+  };
+  expectedResponse.body = RESPONSE_CODE.VALIDATION_ERROR;
+
+  validateSubmission.mockReturnValue(false);
+
+  const response = main(testEvent, "foo");
+
+  expect(response).resolves.toBe(expectedResponse);
+});

--- a/services/app-api/submit.test.js
+++ b/services/app-api/submit.test.js
@@ -1,10 +1,19 @@
 import { main } from "./submit";
-import { validateSubmission } from "./changeRequest/changeRequest-util";
-import { RESPONSE_CODE } from "cmscommonlib";
+import getChangeRequestFunctions, {
+  validateSubmission,
+  hasValidStateCode,
+} from "./changeRequest/changeRequest-util";
+import {
+  RESPONSE_CODE,
+  USER_STATUS,
+  latestAccessStatus,
+  USER_TYPE,
+} from "cmscommonlib";
 import getUser from "./utils/getUser";
 
 jest.mock("./changeRequest/changeRequest-util");
 jest.mock("./utils/getUser");
+jest.mock("cmscommonlib");
 
 const expectedResponse = {
   statusCode: 200,
@@ -129,18 +138,86 @@ const testUserEvent = {
   isBase64Encoded: false,
 };
 
+const testDoneBy = {
+  firstName: "Unit",
+  lastName: "Tester",
+  attributes: [
+    {
+      stateCode: "MI",
+      history: [
+        {
+          date: 1617149287,
+          doneBy: "systemadmintest@cms.hhs.local",
+          status: "active",
+        },
+      ],
+    },
+    {
+      stateCode: "VA",
+      history: [
+        {
+          date: 1617149287,
+          doneBy: "systemadmintest@cms.hhs.local",
+          status: "active",
+        },
+      ],
+    },
+  ],
+  id: "statesubmitteractive@cms.hhs.local",
+  type: USER_TYPE.STATE_SUBMITTER,
+};
+
 //body: '{"type":"spa","territory":"MI","summary":"valid submission data for testing.","transmittalNumber":"MI-22-0897","actionType":"","waiverAuthority":"","transmittalNumberWarningMessage":"","user":{"email":"statesubmitteractive@cms.hhs.local","firstName":"Angie","lastName":"Active"},"uploads":[{"s3Key":"1639488614688/CMS 179 Form Acronym Removal Signed.pdf","filename":"CMS 179 Form Acronym Removal Signed.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614688/CMS%20179%20Form%20Acronym%20Removal%20Signed.pdf","title":"CMS Form 179"},{"s3Key":"1639488614690/Attachment 3.1-A, #4b, Page 3f Track.pdf","filename":"Attachment 3.1-A, #4b, Page 3f Track.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614690/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Track.pdf","title":"SPA Pages"}]}',
 //  body: '{"type":"spa"}',
 
-it("tests the warmup", async () => {
-  const response = main({ source: "serverless-plugin-warmup" }, "foo");
-  expect(response).toBeInstanceOf(Promise);
+beforeEach(() => {
+  validateSubmission.mockImplementation(() => {
+    return null;
+  });
+  getUser.mockImplementation(() => {
+    return testDoneBy;
+  });
+  latestAccessStatus.mockImplementation(() => {
+    return USER_STATUS.ACTIVE;
+  });
+  getChangeRequestFunctions.mockImplementation(() => {
+    return "something";
+  });
+  hasValidStateCode.mockImplementation(() => {
+    return true;
+  });
+});
+
+it("takes exception to bad JSON", async () => {
+  return expect(() =>
+    main({ data: "{ bad,,json }" }, "foo").toThrow(
+      "SyntaxError: Unexpected token b in JSON at position 2"
+    )
+  );
 });
 
 it(`returns an error for invalid submission`, async () => {
   expectedResponse.body = JSON.stringify(RESPONSE_CODE.VALIDATION_ERROR);
 
-  validateSubmission.mockReturnValue("VA000");
+  validateSubmission.mockImplementation(() => {
+    return "VA000";
+  });
+
+  const response = main(testUserEvent, "foo");
+
+  expect(response)
+    .resolves.toStrictEqual(expectedResponse)
+    .catch((error) => {
+      console.log("caught test error: ", error);
+    });
+});
+
+it("returns an error if submitter does not have access", async () => {
+  expectedResponse.body = JSON.stringify(RESPONSE_CODE.USER_NOT_AUTHORIZED);
+
+  latestAccessStatus.mockImplementation(() => {
+    return USER_STATUS.DENIED;
+  });
 
   const response = main(testUserEvent, "foo");
 
@@ -153,9 +230,66 @@ it(`returns an error for invalid submission`, async () => {
 
 it(`returns an error for unknown user`, async () => {
   expectedResponse.body = JSON.stringify(RESPONSE_CODE.USER_NOT_FOUND);
-  console.log("expect: ", expectedResponse);
-  validateSubmission.mockReturnValueOnce(null);
-  getUser.mockResolvedValueOnce(null);
+
+  getUser.mockImplementation(() => {
+    return {};
+  });
+
+  const response = main(testUserEvent, "foo");
+
+  expect(response)
+    .resolves.toStrictEqual(expectedResponse)
+    .catch((error) => {
+      console.log("caught test error: ", error);
+    });
+});
+
+it("errors if can't find crfunctions", async () => {
+  expectedResponse.body = JSON.stringify(RESPONSE_CODE.VALIDATION_ERROR);
+
+  getChangeRequestFunctions.mockImplementation(() => {
+    return null;
+  });
+
+  const response = main(testUserEvent, "foo");
+
+  expect(response)
+    .resolves.toStrictEqual(expectedResponse)
+    .catch((error) => {
+      console.log("caught test error: ", error);
+    });
+});
+
+it("errors if territory is invalid", async () => {
+  expectedResponse.body = JSON.stringify(
+    RESPONSE_CODE.TRANSMITTAL_ID_TERRITORY_NOT_VALID
+  );
+
+  hasValidStateCode.mockImplementation(() => {
+    return false;
+  });
+
+  const response = main(testUserEvent, "foo");
+
+  expect(response)
+    .resolves.toStrictEqual(expectedResponse)
+    .catch((error) => {
+      console.log("caught test error: ", error);
+    });
+});
+
+it("errors if second check of territory is invalid", async () => {
+  expectedResponse.body = JSON.stringify(
+    RESPONSE_CODE.TRANSMITTAL_ID_TERRITORY_NOT_VALID
+  );
+
+  hasValidStateCode
+    .mockImplementationOnce(() => {
+      return true;
+    })
+    .mockImplementation(() => {
+      return false;
+    });
 
   const response = main(testUserEvent, "foo");
 

--- a/services/app-api/submit.test.js
+++ b/services/app-api/submit.test.js
@@ -1,10 +1,10 @@
 import { main } from "./submit";
 import { validateSubmission } from "./changeRequest/changeRequest-util";
 import { RESPONSE_CODE } from "cmscommonlib";
-import getUser from "./utils/getUser";
+//import getUser from "./utils/getUser";
 
 jest.mock("./changeRequest/changeRequest-util");
-jest.mock("./utils/getUser");
+//jest.mock("./utils/getUser");
 
 const expectedResponse = {
   statusCode: 200,
@@ -125,9 +125,11 @@ const testUserEvent = {
     domainName: "je8lkoa2u9.execute-api.us-east-1.amazonaws.com",
     apiId: "je8lkoa2u9",
   },
-  body: '{"type":"spa","territory":"MI","summary":"valid submission data for testing.","transmittalNumber":"MI-22-0897","actionType":"","waiverAuthority":"","transmittalNumberWarningMessage":"","user":{"email":"statesubmitteractive@cms.hhs.local","firstName":"Angie","lastName":"Active"},"uploads":[{"s3Key":"1639488614688/CMS 179 Form Acronym Removal Signed.pdf","filename":"CMS 179 Form Acronym Removal Signed.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614688/CMS%20179%20Form%20Acronym%20Removal%20Signed.pdf","title":"CMS Form 179"},{"s3Key":"1639488614690/Attachment 3.1-A, #4b, Page 3f Track.pdf","filename":"Attachment 3.1-A, #4b, Page 3f Track.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614690/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Track.pdf","title":"SPA Pages"}]}',
+  body: '{"type":"spa"}',
   isBase64Encoded: false,
 };
+
+//body: '{"type":"spa","territory":"MI","summary":"valid submission data for testing.","transmittalNumber":"MI-22-0897","actionType":"","waiverAuthority":"","transmittalNumberWarningMessage":"","user":{"email":"statesubmitteractive@cms.hhs.local","firstName":"Angie","lastName":"Active"},"uploads":[{"s3Key":"1639488614688/CMS 179 Form Acronym Removal Signed.pdf","filename":"CMS 179 Form Acronym Removal Signed.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614688/CMS%20179%20Form%20Acronym%20Removal%20Signed.pdf","title":"CMS Form 179"},{"s3Key":"1639488614690/Attachment 3.1-A, #4b, Page 3f Track.pdf","filename":"Attachment 3.1-A, #4b, Page 3f Track.pdf","contentType":"application/pdf","url":"https://uploads-add-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A54fb74ef-1d89-4528-bb26-24926cbc5eef/1639488614690/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Track.pdf","title":"SPA Pages"}]}',
 
 it("tests the warmup", async () => {
   const response = main({ source: "serverless-plugin-warmup" }, "foo");
@@ -135,9 +137,9 @@ it("tests the warmup", async () => {
 });
 
 it(`returns an error for invalid submission`, async () => {
-  expectedResponse.body = RESPONSE_CODE.VALIDATION_ERROR;
+  expectedResponse.body = JSON.stringify(RESPONSE_CODE.VALIDATION_ERROR);
 
-  validateSubmission.mockReturnValue(false);
+  validateSubmission.mockReturnValue(null);
 
   const response = main(testUserEvent, "foo");
 
@@ -147,11 +149,11 @@ it(`returns an error for invalid submission`, async () => {
       console.log("caught test error: ", error);
     });
 });
-
+/*
 it(`returns an error for unknown user`, async () => {
-  expectedResponse.body = RESPONSE_CODE.USER_NOT_FOUND;
-
-  validateSubmission.mockReturnValue(true);
+  expectedResponse.body = JSON.stringify(RESPONSE_CODE.USER_NOT_FOUND);
+  console.log("expect: ", expectedResponse);
+  validateSubmission.mockReturnValueOnce(true);
   getUser.mockResolvedValueOnce(null);
 
   const response = main(testUserEvent, "foo");
@@ -162,3 +164,4 @@ it(`returns an error for unknown user`, async () => {
       console.log("caught test error: ", error);
     });
 });
+*/

--- a/services/stream-functions/README.md
+++ b/services/stream-functions/README.md
@@ -1,3 +1,11 @@
+The Lambdas within stream-functions are specific to the movement of data to and from BigMAC.
+
+### Subscribing to and handling events FROM BigMAC
+Adding a topic to listen to for the sink... 
+in serverless.yml, there is a topics: variable - add the new topic to the comma-delimited list?
+Modify sinkMskToDynamo handler to process the new topic events
+### Announcing updates of oneMAC data TO BigMAC topics
+
 a Kafka Connect cluster is built, running on fargate
 
 a kafka-connect-lambda connector kafka-connect-is POSTed to the cluster; this connector is often referenced as the 'dynamo sink'.  This dynamo sink connector continuously watches a topic on the cms-bigmac master cluster.  This topic is a stream of all existing/new/modifications-to records in the SEATool State_Plan table.  A connector is always configured to <do something> when it sees an event in the topic that is hasn't processed.  In this case, when an event is seen, the dyanmodb sink connector triggers a lambda in the onemac account.... continued on the next bullet (see stream-functions service for all of this)
@@ -12,3 +20,18 @@ a lambda is configured (see stream functions) to trigger on each new event to th
 
 All of the above is on the cqrs and cqrs-dev branch.
 
+### Connecting oneMAC branch to a BigMAC repo feature branch
+For sending only?? OR... maybe this has to be done BEFORE first deployment.... or some way to delete the connectors created by first deployment ??
+
+oneMAC feature branches default to connecting with the master-msk cluster in BigMAC.  
+To connect to a BigMAC feature branch environment instead:
+1. Login to CloudTamer and select "Web Access" for BigMac Dev as a BigMac Developer Admin
+2. Select the Amazon MSK service
+3. Choose the name of the cluster you would like to connect to
+4. under "Cluster Summary," click "View client information"
+5. copy the TLS information under "Bootstrap servers"
+6. Login to CloudTamer and select "Web Access" for Macstack Dev as a Macstack Developer Admin
+7. Go to the Systems Manager->Parameter Store
+8. Add a parameter called: /configuration/<STAGE>/bigmac/bootstrapBrokerStringTls with <STAGE> replaced by the stage name for the connecting branch.  Use "SecureString" as the type, but leave the other defaults.
+9. The parameter value should be the TLS information copied from BigMAC
+10. redeploy the github workflow to complete the connection.

--- a/services/stream-functions/handlers/sinkMskToDynamo.js
+++ b/services/stream-functions/handlers/sinkMskToDynamo.js
@@ -4,6 +4,8 @@ const { ChangeRequest } = require("cmscommonlib");
 AWS.config.update({region: 'us-east-1'});
 const ddb = new AWS.DynamoDB.DocumentClient({apiVersion: '2012-08-10'});
 
+const topicPrefix = "lmdc.seatool.submission.cdc.sea-dbo-";
+
 const SEATOOL_PLAN_TYPE = {
   CHIP_SPA: "124",
   SPA: "125",
@@ -60,75 +62,37 @@ function myHandler(event) {
     return null;
   }
   console.log('Received event:', JSON.stringify(event, null, 2));
+  const table = event.topic.replace(topicPrefix, "");
   const value = JSON.parse(event.value);
-  console.log(`Event value: ${JSON.stringify(value, null, 2)}`);
+  const eventId = event.offset;
+  console.log(`Topic: ${event.topic} Table: ${table} Event value: ${JSON.stringify(value, null, 2)}`);
 
   const SEAToolId = value.payload.ID_Number;
   if (!SEAToolId) return;
 
-  let packageStatusID = "unknown";
-  if (value.payload.SPW_Status_ID) packageStatusID = value.payload.SPW_Status_ID.toString();
+  const pk = value.payload.ID_Number;
+  if (!pk || !eventId) return;
 
-  if (!value?.payload?.Plan_Type)  return;
-  const planTypeList = ["122", "123", "124", "125"];
-  const planType = planTypeList.find( (pt) => (pt === value.payload.Plan_Type.toString()));
-  if (!planType) return;
+  // use the offset as a version number/event tracker... highest id is most recent
+  const sk = `SEATool#${table}#${eventId}`
 
-  let stateCode;
-  if (value.payload.State_Code) {
-    stateCode = value.payload.State_Code.toString();
-  } else stateCode = SEAToolId.substring(0,2);
-
-  let oneMACStatus = `SEATool Status: ${packageStatusID}`;
-  if (SEATOOL_TO_ONEMAC_STATUS[packageStatusID]) 
-    oneMACStatus = SEATOOL_TO_ONEMAC_STATUS[packageStatusID];
-
-  const idInfo = ChangeRequest.decodeId(SEAToolId, planType);
-
-  const SEAToolData = {
-    'packageStatus': packageStatusID,
-    'currentStatus': oneMACStatus,
-    'stateCode': stateCode,
-    'planType': planType,
-    'packageType': SEATOOL_TO_ONEMAC_PLAN_TYPE_IDS[planType],
-    'packageId': idInfo.packageId,
-    'componentId': idInfo.componentId,
-    'componentType': idInfo.componentType,
-    'clockEndTimestamp': value.payload.Alert_90_Days_Date,
-    'expirationTimestamp': value.payload.End_Date,
+  // put the SEATool Entry - overwrites if already exists
+  const updateSEAToolParams = {
+    TableName: process.env.oneMacTableName,
+    Item: {pk,sk,...value.payload},
   };
-  if (SEAToolId != undefined) {
 
-    // update the SEATool Entry
-    const updateSEAToolParams = {
-      TableName: process.env.oneMacTableName,
-      Key: {
-        pk: SEAToolId,
-        sk: "SEATool",
-      },
-      UpdateExpression: "SET changeHistory = list_append(:newChange, if_not_exists(changeHistory, :emptyList))",
-      ExpressionAttributeValues: {
-        ":newChange": [SEAToolData],
-        ":emptyList": [],
-      },
-      ReturnValues: "UPDATED_NEW",
-    };
-
-    ddb.update(updateSEAToolParams, function(err, data) {
-      if (err) {
-        console.log("Error", err);
-      } else {
-        console.log("Update Success, data is: ", data);
-        console.log(`Current epoch time:  ${Math.floor(new Date().getTime())}`);
-
-        // if the SEATool entry is new, do we need to add Paper IDs??
-        if (data.Attributes.changeHistory.length === 1) {
-          console.log("that was a new package from SEATool");
-        } else {
-          console.log("We have seen that package before!");
-        }
+  ddb.put(updateSEAToolParams, function(err) {
+    if (err) {
+      console.log("Error", err);
+    } else if (table === "State_Plan") {
+      const SEAToolData = {
+        currentStatus: SEATOOL_TO_ONEMAC_STATUS[value.payload.SPW_Status_ID],
+        clockEndTimestamp: value.payload.Alert_90_Days_Date,
+        componentType: SEATOOL_TO_ONEMAC_PLAN_TYPE_IDS[value.payload.Plan_Type],
+        componentId: pk,
+        expirationTimestamp: value.payload.End_Date,
       }
-    });
 
     // update OneMAC Component
     const updatePk = SEAToolData.componentId;
@@ -169,8 +133,8 @@ function myHandler(event) {
         console.log("Update Success!  Returned data is: ", data);
         console.log(`Current epoch time:  ${Math.floor(new Date().getTime())}`);
     }});
-
-  }
+    }
+  });
 }
 
 exports.handler = myHandler;

--- a/services/stream-functions/serverless.yml
+++ b/services/stream-functions/serverless.yml
@@ -108,7 +108,7 @@ functions:
         - KafkaConnectWorkerRole
         - Arn
       sessionName: ${self:custom.stage}-sink-role
-      topics: lmdc.seatool.submission.cdc.sea-dbo-State_Plan
+      topics: lmdc.seatool.submission.cdc.sea-dbo-State_Plan,lmdc.seatool.submission.cdc.sea-dbo-RAI
       sinkPrefix: spa-${self:custom.stage}-
     maximumRetryAttempts: 2
     timeout: 120


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-13442
Endpoint: https://d37vvg9moxp7a1.cloudfront.net/

### Details
RAI data coming in from SEATool via BigMAC gets added to the OneMAC data

### Changes
- added the RAI topic to the list of topics that OneMAC will receive events from
- because submit.js is part of this PR, added unit testing to many of its function calls

### Implementation Notes
Because this RAI topic data is not yet used by the Front End, the storage structure may need tweaking to support the UI needs.  At this time, it is a data dump of the fields with a logical way to access them.

Events from the RAI topic are dependent on the BigMAC environment, which is out of our control.  We have received events, so can use those for testing and verifying this PR.

### Test Plan
1. Testing this story requires access to the AWS Console.
2. Login to Macstack Dev Web Access in AWS
3. Go to CloudWatch->Log Groups and select "/aws/lambda/stream-functions-add-rai-sinkMskToDynamo" group
4. Click the top stream
5. scroll through the logs and select a line with "Received event:"  Expand the event and verify that "topic": "lmdc.seatool.submission.cdc.sea-dbo-RAI" is part of the event.
6. Make note of the payload details for that event, should include:
  a. ID_Number. (required)
  b. [RAI_Requested_Date] (required)
  c. [RAI_Received_Date] (optional - null if absent)
  d. [RAI_Withdrawn_Date] (optional - null if absent)
7. Notice the Offset value as well (this is essentially the event id according to my reasearch)
8. Open DynamoDB in console, travel to Items, and select "onemac-add-rai-one" table.
9. query the table with pk being the ID_Number from the event (it does not matter if this RAI is for a package we care about or not)
10. Open the item with sk of SEATool#RAI#<offset>
11. Verify that the fields contain the same values as the event. (I do not know why AWS capitalizes Null)
