### PR TITLE
OY2 - 14330 Prevent Duplicate State Access and Allow Re-requests after Denial/Revoke

### DIFF
--- a/services/ui-src/src/containers/UserPage.js
+++ b/services/ui-src/src/containers/UserPage.js
@@ -336,7 +336,7 @@ const UserPage = () => {
           cancelFn={() => setIsStateSelectorVisible(false)}
           errorMessage="Please select at least one state."
           loading={loading}
-          options={territoryList}
+          options={territoryRequestList}
           placeholder="Select state here"
           required
           showCancelButton
@@ -347,7 +347,7 @@ const UserPage = () => {
         />
       </div>
     );
-  }, [loading, signupUser, setIsStateSelectorVisible]);
+  }, [loading, signupUser, setIsStateSelectorVisible, territoryRequestList]);
 
   const renderAddStateButton = useMemo(() => {
     return (

--- a/services/ui-src/src/containers/UserPage.js
+++ b/services/ui-src/src/containers/UserPage.js
@@ -197,6 +197,8 @@ const UserPage = () => {
   const [isStateSelectorVisible, setIsStateSelectorVisible] = useState(false);
   const [stateAccessToRemove, setStateAccessToRemove] = useState(null);
   const [isEditingPhone, setIsEditingPhone] = useState(false);
+  const [territoryRequestList, setTerritoryRequestList] =
+    useState(territoryList);
 
   const isReadOnly =
     location.pathname !== ROUTES.PROFILE &&
@@ -207,6 +209,8 @@ const UserPage = () => {
   useEffect(() => {
     if (!isReadOnly) {
       setUserData(userProfile.userData);
+      console.log("the user profile is:", userProfile);
+      setTerritoryRequestList();
       return;
     }
 

--- a/services/ui-src/src/containers/UserPage.js
+++ b/services/ui-src/src/containers/UserPage.js
@@ -209,7 +209,7 @@ const UserPage = () => {
     if (!isReadOnly) {
       setUserData(userProfile.userData);
       console.log("the userData is:", userProfile?.userData);
-      // setTerritoryRequestList();
+      setTerritoryRequestList(territoryList);
       return;
     }
 

--- a/services/ui-src/src/containers/UserPage.js
+++ b/services/ui-src/src/containers/UserPage.js
@@ -197,8 +197,6 @@ const UserPage = () => {
   const [isStateSelectorVisible, setIsStateSelectorVisible] = useState(false);
   const [stateAccessToRemove, setStateAccessToRemove] = useState(null);
   const [isEditingPhone, setIsEditingPhone] = useState(false);
-  const [territoryRequestList, setTerritoryRequestList] =
-    useState(territoryList);
   const isReadOnly =
     location.pathname !== ROUTES.PROFILE &&
     decodeURIComponent(userId) !== userProfile.email;
@@ -208,8 +206,6 @@ const UserPage = () => {
   useEffect(() => {
     if (!isReadOnly) {
       setUserData(userProfile.userData);
-      console.log("the userData is:", userProfile?.userData);
-      setTerritoryRequestList(territoryList);
       return;
     }
 
@@ -329,6 +325,18 @@ const UserPage = () => {
   ]);
 
   const renderSelectStateAccess = useMemo(() => {
+    const territoryRequestList = [];
+    const activeStateList = [];
+
+    accesses.forEach(({ state, status }) => {
+      if (status === "active" || status === "pending")
+        activeStateList.push(state);
+    });
+    territoryList.forEach(({ label, value }) => {
+      if (activeStateList.includes(value) === false)
+        territoryRequestList.push({ label, value });
+    });
+
     return (
       <div className="profile-signup-container">
         <MultiSelectDropDown
@@ -346,7 +354,7 @@ const UserPage = () => {
         />
       </div>
     );
-  }, [loading, signupUser, setIsStateSelectorVisible, territoryRequestList]);
+  }, [loading, signupUser, setIsStateSelectorVisible, accesses]);
 
   const renderAddStateButton = useMemo(() => {
     return (

--- a/services/ui-src/src/containers/UserPage.js
+++ b/services/ui-src/src/containers/UserPage.js
@@ -199,7 +199,6 @@ const UserPage = () => {
   const [isEditingPhone, setIsEditingPhone] = useState(false);
   const [territoryRequestList, setTerritoryRequestList] =
     useState(territoryList);
-
   const isReadOnly =
     location.pathname !== ROUTES.PROFILE &&
     decodeURIComponent(userId) !== userProfile.email;
@@ -209,8 +208,8 @@ const UserPage = () => {
   useEffect(() => {
     if (!isReadOnly) {
       setUserData(userProfile.userData);
-      console.log("the user profile is:", userProfile);
-      setTerritoryRequestList();
+      console.log("the userData is:", userProfile?.userData);
+      // setTerritoryRequestList();
       return;
     }
 


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-14330
Endpoint: https://d119b8oces6768.cloudfront.net

### Details
On the User Profile Page for State Submitter Users, there is the ability to request access to a "new" state.  That component contained all territories, so a user could re-request a state they already had access to.  By removing the territory from the component list, we remove the ability of the User to accidentally change their active status to pending.  If they were denied or revoked, they should be allowed to re-request access for that territory.

### Changes
- updated the MultiSelect to use a modified territoryList, with "active" and "pending" state accesses removed from the list.

### Implementation Notes
I am not terribly good at array manipulation in Javascript, so feel free to comment if there is a "best practice" tip that I've missed.  I did use the accesses array already created for the cards for consistency!

### Test Plan
1. Log in as statesubmitteractive
2. Navigate to User Profile page and notice the state accesses
3. Click to "Add State"
4. Verify that the States with cards saying "pending" or "active" are not available in the multiselect.
5. Choose some states and select OK to put them into pending
6. Verify that "Add State" multiselect does not include the new pending states
7. revoke access for a state
8. Verify that that state is now available to request
9. Request state and verify that it is in pending status and no longer in the multiselect