### PR TITLE
OY2-14657: limit data return on Dashboard

### DIFF
--- a/services/app-api/getAllByAuthorizedTerritories.js
+++ b/services/app-api/getAllByAuthorizedTerritories.js
@@ -5,6 +5,13 @@ import { RESPONSE_CODE } from "cmscommonlib";
 import getUser from "./utils/getUser";
 import { getAuthorizedStateList } from "./user/user-util";
 
+const commonQueryConfig = {
+  TableName: process.env.tableName,
+  ExpressionAttributeNames: { "#type": "type", "#user": "user" },
+  ProjectionExpression:
+    "transmittalNumber,#type,territory,submittedAt,#user.firstName,#user.lastName,#user.email,userId,id",
+};
+
 /**
  * Returns an array of updated parameters for querying a helpdesk or reviewer role
  * Will stop once entire dynamoDB has been scanned
@@ -19,7 +26,7 @@ async function helpdeskOrReviewerDynamoDbQuery(
   allResults
 ) {
   const results = await dynamoDb.scan({
-    TableName: process.env.tableName,
+    ...commonQueryConfig,
     ExclusiveStartKey: startingKey,
   });
   allResults.push(results);
@@ -48,7 +55,7 @@ async function stateSubmitterDynamoDbQuery(
   allResults
 ) {
   const results = await dynamoDb.query({
-    TableName: process.env.tableName,
+    ...commonQueryConfig,
     ExclusiveStartKey: startingKey,
     IndexName: "territory-submittedAt-index",
     KeyConditionExpression:


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-14657
Endpoint: https://drf6yzg7zrgjt.cloudfront.net/

### Details

Reduce the size of the returned list from `getAllByAuthorizedTerritories`.

### Changes

- Limit keys returned on each change request object when querying Dynamo

### Implementation Notes

- May need to update this projection if we need more keys in this view

### Test Plan

1. Log in as `statesubmitteractive`. Smoke test the "old" dashboard view to ensure all links still work and RAI responses still process correctly.
2. Log in as `helpdeskactive` and smoke test again.
