### PR TITLE
OY2-12735: refine displayed clock statuses on Package Dash

### DIFF
--- a/services/app-api/one-seed.json
+++ b/services/app-api/one-seed.json
@@ -75,6 +75,7 @@
     "additionalInformation": "This is just a test",
     "submissionTimestamp": 1639696185888,
     "GSI1pk": "OneMAC#spa",
+    "clockEndTimestamp": 1647286706000,
     "packageId": "MD-13-1122",
     "submitterEmail": "statesubmitter@nightwatch.test",
     "componentId": "MD-13-1122",
@@ -158,6 +159,7 @@
     "additionalInformation": "This is just a test",
     "submissionTimestamp": 1639696185888,
     "GSI1pk": "OneMAC#spa",
+    "clockEndTimestamp": 1647286706000,
     "packageId": "MI-13-1122",
     "submitterEmail": "statesubmitter@nightwatch.test",
     "componentId": "MI-13-1122",
@@ -262,6 +264,7 @@
        "additionalInformation": "This is just a test",
        "submissionTimestamp": 1639695908900,
        "GSI1pk": "OneMAC#spa",
+       "clockEndTimestamp": 1646941106000,
        "packageId": "MD-77-2985",
        "submitterEmail": "statesubmitter@nightwatch.test",
        "componentId": "MD-77-2985",
@@ -366,6 +369,7 @@
         "additionalInformation": "This is just a test",
         "submissionTimestamp": 1639695908900,
         "GSI1pk": "OneMAC#spa",
+        "clockEndTimestamp": 1646941106000,
         "packageId": "MI-77-2985",
         "submitterEmail": "statesubmitter@nightwatch.test",
         "componentId": "MI-77-2985",
@@ -699,6 +703,7 @@
         "GSI1sk": "VA.1117",
         "additionalInformation": "Base waiver for testing the waiver renewals",
         "submissionTimestamp": 1638473560098,
+        "clockEndTimestamp": 1645990706000,
         "waiverAuthority": "1915(b)(4)",
         "GSI1pk": "OneMAC#waiver",
         "packageId": "VA.1117",
@@ -794,6 +799,7 @@
         "GSI1sk": "MD.1117",
         "additionalInformation": "Base waiver for testing the waiver renewals",
         "submissionTimestamp": 1638473560098,
+        "clockEndTimestamp": 1645990706000,
         "waiverAuthority": "1915(b)(4)",
         "GSI1pk": "OneMAC#waiver",
         "packageId": "MD.1117",
@@ -1029,6 +1035,7 @@
         "additionalInformation": "Need a Package In Review.....",
         "submissionTimestamp": 1640014690892,
         "GSI1pk": "OneMAC#spa",
+        "clockEndTimestamp": 1647545906000,
         "packageId": "MI-42-1122",
         "submitterEmail": "statesubmitteractive@cms.hhs.local",
         "componentId": "MI-42-1122",
@@ -1104,6 +1111,7 @@
         "additionalInformation": "Need a Package In Review.....",
         "submissionTimestamp": 1640014690892,
         "GSI1pk": "OneMAC#spa",
+        "clockEndTimestamp": 1647545906000,
         "packageId": "MD-42-1122",
         "submitterEmail": "statesubmitteractive@cms.hhs.local",
         "componentId": "MD-42-1122",
@@ -1268,7 +1276,7 @@
          }
         ],
         "componentType": "spa",
-        "currentStatus": "Approved",
+        "currentStatus": "Package Approved",
         "attachments": [
          {
           "s3Key": "1639690300084/textnotes.txt",
@@ -1474,7 +1482,7 @@
          }
         ],
         "componentType": "spa",
-        "currentStatus": "Disapproved",
+        "currentStatus": "Package Disapproved",
         "attachments": [
          {
           "s3Key": "1639609654211/textnotes.txt",
@@ -1680,7 +1688,7 @@
          }
         ],
         "componentType": "spa",
-        "currentStatus": "Withdrawn",
+        "currentStatus": "Package Withdrawn",
         "attachments": [
          {
           "s3Key": "1639595173888/textnotes.txt",

--- a/services/app-api/utils/newSubmission.js
+++ b/services/app-api/utils/newSubmission.js
@@ -23,7 +23,7 @@ export default async function newSubmission(inData) {
 
   // use the scarce index for anything marked as a package.
   if (idInfo.isNewPackage) {
-    data.GSI1pk = "OneMAC";
+    data.GSI1pk = `OneMAC#${ChangeRequest.MY_PACKAGE_GROUP[data.sk]}`;
     data.GSI1sk = data.pk;
   } else {
     data.sk += `#${inData.submissionTimestamp}`;

--- a/services/app-api/withdrawPackage.js
+++ b/services/app-api/withdrawPackage.js
@@ -1,5 +1,5 @@
 import handler from "./libs/handler-lib";
-import { RESPONSE_CODE } from "cmscommonlib";
+import { RESPONSE_CODE, ChangeRequest } from "cmscommonlib";
 
 import {
   CMSWithdrawalEmail,
@@ -28,7 +28,7 @@ export const main = handler(async (event) => {
       ...body,
       packageId: body.componentId,
       parentType: body.componentType,
-      currentStatus: "Withdrawn",
+      currentStatus: ChangeRequest.ONEMAC_STATUS.WITHDRAWN,
       submissionTimestamp: Date.now(),
     });
   } catch (e) {

--- a/services/common/index.d.ts
+++ b/services/common/index.d.ts
@@ -72,4 +72,8 @@ export namespace ChangeRequest {
   export const CONFIG: Record<string, FormInfo>;
   export const ONEMAC_STATUS: Record<string, string>;
   export const TYPE: Record<string, string>;
+  export enum PACKAGE_GROUP {
+    SPA = "spa",
+    WAIVER = "waiver",
+  }
 }

--- a/services/ui-src/src/containers/PackageList.test.js
+++ b/services/ui-src/src/containers/PackageList.test.js
@@ -100,12 +100,12 @@ it("switches to waiver columns if wavier tab selected", async () => {
 });
 
 it.each`
-  filterFieldType    | filterFieldValue  | inName                 | inValue          | textShown
-  ${"currentStatus"} | ${"Withdrawn"}    | ${"clockEndTimestamp"} | ${1570378876000} | ${"N/A"}
-  ${"currentStatus"} | ${"Terminated"}   | ${"clockEndTimestamp"} | ${1570378876000} | ${"N/A"}
-  ${"currentStatus"} | ${"Unsubmitted"}  | ${"clockEndTimestamp"} | ${1570378876000} | ${"N/A"}
-  ${"currentStatus"} | ${"AnythingElse"} | ${"clockEndTimestamp"} | ${1570378876000} | ${"Oct 6, 2019"}
-  ${"currentStatus"} | ${"AnythingElse"} | ${"clockEndTimestamp"} | ${""}            | ${"Pending"}
+  filterFieldType    | filterFieldValue       | inName                 | inValue          | textShown
+  ${"currentStatus"} | ${"Package Withdrawn"} | ${"clockEndTimestamp"} | ${null}          | ${"N/A"}
+  ${"currentStatus"} | ${"Waiver Terminated"} | ${"clockEndTimestamp"} | ${null}          | ${"N/A"}
+  ${"currentStatus"} | ${"Unsubmitted"}       | ${"clockEndTimestamp"} | ${null}          | ${"Pending"}
+  ${"currentStatus"} | ${"AnythingElse"}      | ${"clockEndTimestamp"} | ${1570378876000} | ${"Oct 6, 2019"}
+  ${"currentStatus"} | ${"AnythingElse"}      | ${"clockEndTimestamp"} | ${""}            | ${"Pending"}
 `(
   "shows $textShown in $inName when $filterFieldType is $filterFieldValue and value is $inValue",
   async ({ filterFieldType, filterFieldValue, inName, inValue, textShown }) => {

--- a/services/ui-src/src/containers/PackageList.test.js
+++ b/services/ui-src/src/containers/PackageList.test.js
@@ -105,7 +105,7 @@ it.each`
   ${"currentStatus"} | ${"Waiver Terminated"} | ${"clockEndTimestamp"} | ${null}          | ${"N/A"}
   ${"currentStatus"} | ${"Unsubmitted"}       | ${"clockEndTimestamp"} | ${null}          | ${"Pending"}
   ${"currentStatus"} | ${"AnythingElse"}      | ${"clockEndTimestamp"} | ${1570378876000} | ${"Oct 6, 2019"}
-  ${"currentStatus"} | ${"AnythingElse"}      | ${"clockEndTimestamp"} | ${""}            | ${"Pending"}
+  ${"currentStatus"} | ${"AnythingElse"}      | ${"clockEndTimestamp"} | ${null}          | ${"N/A"}
 `(
   "shows $textShown in $inName when $filterFieldType is $filterFieldValue and value is $inValue",
   async ({ filterFieldType, filterFieldValue, inName, inValue, textShown }) => {

--- a/tests/cypress/cypress/integration/OY2-11116_Package_Dashboard_Updates_90th_Day_Data_from_SEATool.feature
+++ b/tests/cypress/cypress/integration/OY2-11116_Package_Dashboard_Updates_90th_Day_Data_from_SEATool.feature
@@ -5,7 +5,7 @@ Feature: OY2-11116 Package Dashboard Updates - 90th Day Data from SEATool
         When Login with state submitter user
         And click on Packages
         And verify 90th day column is available to the immediate left to the status column
-        And verify that value of the column for the ID is Pending
+        And verify that value of the column for the ID is NA
 
     Scenario: Verify 90th day fields with CMS Reviewer
         Given I am on Login Page
@@ -13,7 +13,7 @@ Feature: OY2-11116 Package Dashboard Updates - 90th Day Data from SEATool
         When Login with CMS Reviewer User
         And click on Packages
         And verify 90th day column is available to the immediate left to the status column
-        And verify that value of the column for the ID is Pending
+        And verify that value of the column for the ID is NA
 
     Scenario: Verify 90th day fields with Help Desk User
         Given I am on Login Page
@@ -21,7 +21,7 @@ Feature: OY2-11116 Package Dashboard Updates - 90th Day Data from SEATool
         When Login with cms Help Desk User
         And click on Packages
         And verify 90th day column is available to the immediate left to the status column
-        And verify that value of the column for the ID is Pending
+        And verify that value of the column for the ID is NA
 
     # TODO: figure out how to seed data with a 90th day field
     # Scenario: Verify 90th day fields with State Submitter displays date on existing waiver

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -592,7 +592,7 @@ And(
   }
 );
 
-And("verify that value of the column for the ID is Pending", () => {
+And("verify that value of the column for the ID is NA", () => {
   OneMacPackagePage.verifyValue();
 });
 

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -147,7 +147,7 @@ export class oneMacPackagePage {
   }
 
   verifyValue() {
-    cy.get(nintiethDayColumnFirstValue).contains("Pending");
+    cy.get(nintiethDayColumnFirstValue).contains("N/A");
   }
 
   findIdNumberMD32560(waiverNumber) {


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-12735
Endpoint: https://d10clf9qw2mntz.cloudfront.net/

### Details

Update values displayed under "90th Day" column based on package status.

### Changes

- “Clock Stopped” when package status is “RAI Issued”.
- “N/A” when package status is “Package Approved”.
- “N/A” when package status is “Package Disapproved“.
- ”Pending” when package status is “Submitted” or “Unsubmitted”.

### Implementation Notes

- Added clockEndTimestamp values to seed data
- Had to update one set of Cypress tests, specifically for a previous iteration of this column. We will almost certainly need to do more work on that particular set of tests anyway.

### Test Plan

1. Log in as `helpdeskactive` and navigate to Packages.
2. Review the entries in the table to see that the intended status mappings into 90th Day are upheld.
