### PR TITLE
OY2-12735 tests

### DIFF
--- a/tests/cypress/cypress/integration/OY2-11116_Package_Dashboard_Updates_90th_Day_Data_from_SEATool.feature
+++ b/tests/cypress/cypress/integration/OY2-11116_Package_Dashboard_Updates_90th_Day_Data_from_SEATool.feature
@@ -5,7 +5,7 @@ Feature: OY2-11116 Package Dashboard Updates - 90th Day Data from SEATool
         When Login with state submitter user
         And click on Packages
         And verify 90th day column is available to the immediate left to the status column
-        And verify that value of the column for the ID is NA
+        And verify that value of the column for the ID is NA Pending or a date
 
     Scenario: Verify 90th day fields with CMS Reviewer
         Given I am on Login Page
@@ -13,7 +13,7 @@ Feature: OY2-11116 Package Dashboard Updates - 90th Day Data from SEATool
         When Login with CMS Reviewer User
         And click on Packages
         And verify 90th day column is available to the immediate left to the status column
-        And verify that value of the column for the ID is NA
+        And verify that value of the column for the ID is NA Pending or a date
 
     Scenario: Verify 90th day fields with Help Desk User
         Given I am on Login Page
@@ -21,7 +21,7 @@ Feature: OY2-11116 Package Dashboard Updates - 90th Day Data from SEATool
         When Login with cms Help Desk User
         And click on Packages
         And verify 90th day column is available to the immediate left to the status column
-        And verify that value of the column for the ID is NA
+        And verify that value of the column for the ID is NA Pending or a date
 
     # TODO: figure out how to seed data with a 90th day field
     # Scenario: Verify 90th day fields with State Submitter displays date on existing waiver

--- a/tests/cypress/cypress/integration/OY2_12735_Additional_90th_Day_statuses_for_the_Package_Dashboard.feature
+++ b/tests/cypress/cypress/integration/OY2_12735_Additional_90th_Day_statuses_for_the_Package_Dashboard.feature
@@ -1,0 +1,95 @@
+Feature: Additional 90th Day statuses for the Package Dashboard
+
+    Scenario: SPA tab - Verify clock stopped 90 day status exists
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And Click on Filter Button
+        And click on 90th day filter dropdown
+        And verify that Clock Stopped checkbox exists
+
+    
+    Scenario: SPA tab - Clock Stopped when package status is RAI Issued
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And Click on Filter Button
+        And click on Status
+        And click all of the status checkboxes
+        And click RAI Issued checkbox
+        And verify that the value of the column for the 90th day is Clock Stopped
+        
+    Scenario: SPA tab - N/A when package status is Package Approved
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And Click on Filter Button
+        And click on Status
+        And click all of the status checkboxes
+        And click Package Approved checkbox
+        And verify that the value of the column for the 90th day is NA
+
+    Scenario: SPA tab - N/A when package status is Package Disapproved
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And Click on Filter Button
+        And click on 90th day filter dropdown
+        And click on Status
+        And click all of the status checkboxes
+        And click Package Disapproved checkbox
+        And verify that the value of the column for the 90th day is NA
+
+    Scenario: SPA tab - Pending when package status is Submitted
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And Click on Filter Button
+        And click on 90th day filter dropdown
+        And click on Status
+        And click all of the status checkboxes
+        And click Submitted checkbox
+        And verify that the value of the column for the 90th day is Pending
+
+    Scenario: SPA tab - Pending when package status is Unsubmitted
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And Click on Filter Button
+        And click on 90th day filter dropdown
+        And click on Status
+        And click all of the status checkboxes
+        And click Unsubmitted checkbox
+        And verify that the value of the column for the 90th day is Pending
+
+    Scenario: Waivers tab - Pending when package status is Submitted
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And click on the Waivers tab
+        And Click on Filter Button
+        And click on 90th day filter dropdown
+        And click on Status
+        And click all of the status checkboxes
+        And click Submitted checkbox
+        And verify that the value of the column for the 90th day is Pending
+
+    Scenario: Waivers tab - Pending when package status is Unsubmitted
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And click on the Waivers tab
+        And Click on Filter Button
+        And click on 90th day filter dropdown
+        And click on Status
+        And click all of the status checkboxes
+        And click Unsubmitted checkbox
+        And verify that the value of the column for the 90th day is Pending

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -1445,3 +1445,36 @@ And("verify the Waivers tab is clickable", () => {
 And("refresh the page", () => {
   cy.reload();
 });
+And("verify that Clock Stopped checkbox exists", () => {
+  OneMacPackagePage.verifyNinetiethDayClockStoppedCheckboxExists();
+});
+And("click all of the status checkboxes", () => {
+  OneMacPackagePage.clickAllStatusFilterCheckboxes();
+});
+And("click RAI Issued checkbox", () => {
+  OneMacPackagePage.clickRaiIssuedCheckbox();
+});
+And(
+  "verify that the value of the column for the 90th day is Clock Stopped",
+  () => {
+    OneMacPackagePage.verify90thDayRowOneIsClockStopped();
+  }
+);
+And("click Package Approved checkbox", () => {
+  OneMacPackagePage.clickPackageApprovedCheckbox();
+});
+And("verify that the value of the column for the 90th day is NA", () => {
+  OneMacPackagePage.verify90thDayRowOneIsNA();
+});
+And("click Package Disapproved checkbox", () => {
+  OneMacPackagePage.clickPackageDisapprovedCheckbox();
+});
+And("click Submitted checkbox", () => {
+  OneMacPackagePage.clickSubmittedCheckbox();
+});
+And("verify that the value of the column for the 90th day is Pending", () => {
+  OneMacPackagePage.verify90thDayRowOneIsPending();
+});
+And("click Unsubmitted checkbox", () => {
+  OneMacPackagePage.clickUnsubmittedCheckbox();
+});

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -592,9 +592,12 @@ And(
   }
 );
 
-And("verify that value of the column for the ID is NA", () => {
-  OneMacPackagePage.verifyValue();
-});
+And(
+  "verify that value of the column for the ID is NA Pending or a date",
+  () => {
+    OneMacPackagePage.verifyValue();
+  }
+);
 
 And(
   "verify that 90th day value is Jan 5, 2022 for the Id Number MD.32560",

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -168,7 +168,9 @@ export class oneMacPackagePage {
   }
 
   verifyValue() {
-    cy.get(nintiethDayColumnFirstValue).contains("N/A");
+    cy.get(nintiethDayColumnFirstValue).contains(
+      /N\/A|Pending|((Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+(\d{1,2})\s+(\d{4}))/
+    );
   }
 
   findIdNumberMD32560(waiverNumber) {

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -37,6 +37,7 @@ const closeButton = "//header/button[1]";
 const typeDropDownFilter = "//button[text()='Type']";
 const typeDropDown = "#componentType-button";
 const statusDropDown = "#packageStatus-button";
+const statusFilterCheckboxes = "#packageStatus label";
 //Element is Xpath use cy.xpath instead of cy.get
 const ninetiethDayFilterDropdown = "//button[text()='90th Day']";
 //Element is Xpath use cy.xpath instead of cy.get
@@ -45,7 +46,8 @@ const ninetiethDayNACheckbox =
 //Element is Xpath use cy.xpath instead of cy.get
 const ninetiethDayPendingCheckbox =
   "//label[contains(@for,'checkbox_ninetiethDay-Pending_')]";
-
+const ninetiethDayClockStoppedCheckbox =
+  "//label[contains(@for,'checkbox_ninetiethDay-Clock Stopped')]";
 const ninetiethDayDatePickerFilter =
   '*[role=combobox][aria-owns^="ninetiethDay-date-filter"]';
 //Element is Xpath use cy.xpath instead of cy.get
@@ -145,6 +147,20 @@ const statesSelected = "#territory";
 const removeBtn = (state) => `//*[@aria-label='Remove ${state}']`;
 const waiversTab = "#show-waivers-button";
 const spasTab = "#show-spas-button";
+//Element is Xpath use cy.xpath instead of cy.get
+const raiIssuedCheckbox = "//span[contains(text(),'RAI Issued')]";
+//Element is Xpath use cy.xpath instead of cy.get
+const packageApprovedCheckbox =
+  "//label[contains(@for,'checkbox_packageStatus-Package Approved')]";
+//Element is Xpath use cy.xpath instead of cy.get
+const packageDisapprovedCheckbox =
+  "//label[contains(@for,'checkbox_packageStatus-Package Disapproved')]";
+//Element is Xpath use cy.xpath instead of cy.get
+const submittedCheckbox =
+  "//label[contains(@for,'checkbox_packageStatus-Submitted')]";
+//Element is Xpath use cy.xpath instead of cy.get
+const unsubmittedCheckbox =
+  "//label[contains(@for,'checkbox_packageStatus-Unsubmitted')]";
 
 export class oneMacPackagePage {
   verify90thDayColumn() {
@@ -271,6 +287,12 @@ export class oneMacPackagePage {
   }
   clickOnNinetiethDayPendingCheckbox() {
     cy.xpath(ninetiethDayPendingCheckbox).click();
+  }
+  verifyNinetiethDayClockStoppedCheckboxExists() {
+    cy.xpath(ninetiethDayClockStoppedCheckbox).should("exist");
+  }
+  clickOnNinetiethDayClockStoppedCheckbox() {
+    cy.xpath(ninetiethDayClockStoppedCheckbox).click();
   }
   verifyNinetiethDayDatePickerFilterExists() {
     cy.get(ninetiethDayDatePickerFilter).should("exist");
@@ -580,6 +602,50 @@ export class oneMacPackagePage {
   }
   verifyWaiversTabIsClickable() {
     cy.get(waiversTab).should("not.be.disabled");
+  }
+  verifyRaiIssuedCheckboxExists() {
+    cy.xpath(raiIssuedCheckbox).should("be.visible");
+  }
+  clickRaiIssuedCheckbox() {
+    cy.xpath(raiIssuedCheckbox).click();
+  }
+  verifyPackageApprovedCheckboxExists() {
+    cy.xpath(packageApprovedCheckbox).should("be.visible");
+  }
+  clickPackageApprovedCheckbox() {
+    cy.xpath(packageApprovedCheckbox).click();
+  }
+  verifyPackageDisapprovedCheckboxExists() {
+    cy.xpath(packageDisapprovedCheckbox).should("be.visible");
+  }
+  clickPackageDisapprovedCheckbox() {
+    cy.xpath(packageDisapprovedCheckbox).click();
+  }
+  verifySubmittedCheckboxExists() {
+    cy.xpath(submittedCheckbox).should("be.visible");
+  }
+  clickSubmittedCheckbox() {
+    cy.xpath(submittedCheckbox).click();
+  }
+  verifyUnsubmittedCheckboxExists() {
+    cy.xpath(unsubmittedCheckbox).should("be.visible");
+  }
+  clickUnsubmittedCheckbox() {
+    cy.xpath(unsubmittedCheckbox).click();
+  }
+  clickAllStatusFilterCheckboxes() {
+    cy.get(statusFilterCheckboxes).each(($el) => {
+      cy.wrap($el).click();
+    });
+  }
+  verify90thDayRowOneIsPending() {
+    cy.get(packageRowOne90thDay).should("have.text", "Pending");
+  }
+  verify90thDayRowOneIsNA() {
+    cy.get(packageRowOne90thDay).should("have.text", "N/A");
+  }
+  verify90thDayRowOneIsClockStopped() {
+    cy.get(packageRowOne90thDay).should("have.text", "Clock Stopped");
   }
 }
 export default oneMacPackagePage;


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-12735

### Test Plan

```
Feature: Additional 90th Day statuses for the Package Dashboard

    Scenario: SPA tab - Verify clock stopped 90 day status exists
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And Click on Filter Button
        And click on 90th day filter dropdown
        And verify that Clock Stopped checkbox exists

    
    Scenario: SPA tab - Clock Stopped when package status is RAI Issued
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And Click on Filter Button
        And click on Status
        And click all of the status checkboxes
        And click RAI Issued checkbox
        And verify that the value of the column for the 90th day is Clock Stopped
        
    Scenario: SPA tab - N/A when package status is Package Approved
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And Click on Filter Button
        And click on Status
        And click all of the status checkboxes
        And click Package Approved checkbox
        And verify that the value of the column for the 90th day is NA

    Scenario: SPA tab - N/A when package status is Package Disapproved
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And Click on Filter Button
        And click on 90th day filter dropdown
        And click on Status
        And click all of the status checkboxes
        And click Package Disapproved checkbox
        And verify that the value of the column for the 90th day is NA

    Scenario: SPA tab - Pending when package status is Submitted
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And Click on Filter Button
        And click on 90th day filter dropdown
        And click on Status
        And click all of the status checkboxes
        And click Submitted checkbox
        And verify that the value of the column for the 90th day is Pending

    Scenario: SPA tab - Pending when package status is Unsubmitted
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And Click on Filter Button
        And click on 90th day filter dropdown
        And click on Status
        And click all of the status checkboxes
        And click Unsubmitted checkbox
        And verify that the value of the column for the 90th day is Pending

    Scenario: Waivers tab - Pending when package status is Submitted
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And click on the Waivers tab
        And Click on Filter Button
        And click on 90th day filter dropdown
        And click on Status
        And click all of the status checkboxes
        And click Submitted checkbox
        And verify that the value of the column for the 90th day is Pending

    Scenario: Waivers tab - Pending when package status is Unsubmitted
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And click on the Waivers tab
        And Click on Filter Button
        And click on 90th day filter dropdown
        And click on Status
        And click all of the status checkboxes
        And click Unsubmitted checkbox
        And verify that the value of the column for the 90th day is Pending

```