### PR TITLE
Regression Automation Maintenance: Increased viewport

### DIFF
--- a/tests/cypress/cypress.json
+++ b/tests/cypress/cypress.json
@@ -12,6 +12,6 @@
   "downloadsFolder": "downloads",
   "supportFile": "support/index.js",
   "defaultCommandTimeout": 60000,
-  "viewportWidth": 1200,
+  "viewportWidth": 1280,
   "viewportHeight": 720
 }


### PR DESCRIPTION
Changes: Increased viewport.
Reasoning: This is the fix for the actions button sometimes not being visible in viewport. That is happening because the computer doesn't know to scroll right to see the object. The simplest solution that makes sense is increasing the viewport. It is now set to that of a Macbook-13 inch.
