### PR TITLE
OY2-11676 tests - waiver tab layout pt 1

### DIFF
--- a/tests/cypress/cypress/integration/OY2_11676_Package_Dashboard_New_Waiver_tab_layout.feature
+++ b/tests/cypress/cypress/integration/OY2_11676_Package_Dashboard_New_Waiver_tab_layout.feature
@@ -16,20 +16,20 @@ Feature: OY2-11676 Package Dashboard: New Waiver tab layout
         And click on the Waivers tab
         And Click on Filter Button
         And click on Type
-        And click 1915b Waiver Renewal check box
+        #And click 1915b Waiver Renewal check box
         And Click on Filter Button
         And verify the type in row one is Base Waiver
         And verify the waiver number format in row one is SS.#### or SS.#####
 
-    Scenario: verify waiver renewal waiver number pattern
-        Given I am on Login Page
-        When Clicking on Development Login
-        When Login with state submitter user
-        And click on Packages
-        And click on the Waivers tab
-        And Click on Filter Button
-        And click on Type
-        And click 1915b Base Waiver check box
-        And Click on Filter Button
-        And verify the type in row one is Waiver Renewal
-        And verify the waiver number format in row one is SS.#####.S##
+    #Scenario: verify waiver renewal waiver number pattern
+        #Given I am on Login Page
+        #When Clicking on Development Login
+        #When Login with state submitter user
+        #And click on Packages
+        #And click on the Waivers tab
+        #And Click on Filter Button
+        #And click on Type
+        #And click 1915b Base Waiver check box
+        #And Click on Filter Button
+        #And verify the type in row one is Waiver Renewal
+        #And verify the waiver number format in row one is SS.#####.S##

--- a/tests/cypress/cypress/integration/OY2_11676_Package_Dashboard_New_Waiver_tab_layout.feature
+++ b/tests/cypress/cypress/integration/OY2_11676_Package_Dashboard_New_Waiver_tab_layout.feature
@@ -1,0 +1,35 @@
+Feature: OY2-11676 Package Dashboard: New Waiver tab layout 
+
+    Scenario: screen enhancement
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And click on the Waivers tab
+        And verify the type in row one is some kind of 1915b Waiver
+
+    Scenario: verify base waiver waiver number pattern
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And click on the Waivers tab
+        And Click on Filter Button
+        And click on Type
+        And click 1915b Waiver Renewal check box
+        And Click on Filter Button
+        And verify the type in row one is Base Waiver
+        And verify the waiver number format in row one is SS.#### or SS.#####
+
+    Scenario: verify waiver renewal waiver number pattern
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And click on the Waivers tab
+        And Click on Filter Button
+        And click on Type
+        And click 1915b Base Waiver check box
+        And Click on Filter Button
+        And verify the type in row one is Waiver Renewal
+        And verify the waiver number format in row one is SS.#####.S##

--- a/tests/cypress/cypress/integration/OY2_13092_Package_Dashboard_Filter.feature
+++ b/tests/cypress/cypress/integration/OY2_13092_Package_Dashboard_Filter.feature
@@ -55,7 +55,7 @@ Feature: OY2-13092 Package Dashboard - Filter
         And Click on Filter Button
         And click on Type
         And verify 1915b Base Waiver exists
-        And verify 1915b Waiver Renewal exists
+        #And verify 1915b Waiver Renewal exists
 
     Scenario: SPAs tab - deselect all and verify error message, then select one and verify it exists
         Given I am on Login Page
@@ -80,11 +80,11 @@ Feature: OY2-13092 Package Dashboard - Filter
         And Click on Filter Button
         And click on Type
         And click 1915b Base Waiver check box
-        And click 1915b Waiver Renewal check box
+        #And click 1915b Waiver Renewal check box
         And verify Error message displayed should be No Results Found
         And verify Error message details is displayed
         And click 1915b Base Waiver check box
-        And click 1915b Waiver Renewal check box
+        #And click 1915b Waiver Renewal check box
 
 
     Scenario: SPAs tab - verify one exists, deselct selection then verify error message

--- a/tests/cypress/cypress/integration/OY2_13092_Package_Dashboard_Filter.feature
+++ b/tests/cypress/cypress/integration/OY2_13092_Package_Dashboard_Filter.feature
@@ -54,7 +54,8 @@ Feature: OY2-13092 Package Dashboard - Filter
         And click on the Waivers tab
         And Click on Filter Button
         And click on Type
-        And verify 1915b waiver exists
+        And verify 1915b Base Waiver exists
+        And verify 1915b Waiver Renewal exists
 
     Scenario: SPAs tab - deselect all and verify error message, then select one and verify it exists
         Given I am on Login Page
@@ -78,10 +79,12 @@ Feature: OY2-13092 Package Dashboard - Filter
         And click on the Waivers tab
         And Click on Filter Button
         And click on Type
-        And click 1915b waiver check box
+        And click 1915b Base Waiver check box
+        And click 1915b Waiver Renewal check box
         And verify Error message displayed should be No Results Found
         And verify Error message details is displayed
-        And click 1915b waiver check box
+        And click 1915b Base Waiver check box
+        And click 1915b Waiver Renewal check box
 
 
     Scenario: SPAs tab - verify one exists, deselct selection then verify error message

--- a/tests/cypress/cypress/integration/OY2_15426_Package_Dashboard_Waiver_Family_Column_for_the_Waivers_tab.feature
+++ b/tests/cypress/cypress/integration/OY2_15426_Package_Dashboard_Waiver_Family_Column_for_the_Waivers_tab.feature
@@ -10,7 +10,7 @@ Feature: OY2-15426 Package Dashboard: Waiver Family Column for the Waivers tab
         And click on the Waivers tab
         And verify the Waivers Family # column exists
         And verify Waiver Family # column is sortable
-        And verify the Waiver format in column one is SS.#### or SS.##### 
+        And verify the Waiver family format in row one is SS.#### or SS.#####
         And click show hide columns button
         And verify the Waivers Family checkbox exists
     

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -1123,8 +1123,11 @@ And("verify reset Exists", () => {
 And("click on Type", () => {
   OneMacPackagePage.clickTypeDropDown();
 });
-And("verify 1915b waiver exists", () => {
-  OneMacPackagePage.verifywaiver1915bCheckBoxExists();
+And("verify 1915b Base Waiver exists", () => {
+  OneMacPackagePage.verifyBaseWaiver1915bCheckBoxExists();
+});
+And("verify 1915b Waiver Renewal exists", () => {
+  OneMacPackagePage.verifyWaiverRenewal1915bCheckBoxExists();
 });
 And("verify CHIP SPA Exists", () => {
   OneMacPackagePage.verifyCHIPSPACheckBoxExists();
@@ -1147,8 +1150,11 @@ And("verify seatool status 1 exists", () => {
 And("verify sparai submitted exists", () => {
   OneMacPackagePage.verifysparaiSubmittedExists();
 });
-And("click 1915b waiver check box", () => {
-  OneMacPackagePage.clickwaiver1915bCheckBox();
+And("click 1915b Base Waiver check box", () => {
+  OneMacPackagePage.clickBaseWaiver1915bCheckBox();
+});
+And("click 1915b Waiver Renewal check box", () => {
+  OneMacPackagePage.clickWaiverRenewal1915bCheckBox();
 });
 And("click CHIP SPA check box", () => {
   OneMacPackagePage.clickCHIPSPACheckBox();
@@ -1460,7 +1466,7 @@ And("verify the Waivers Family # column exists", () => {
 And("verify Waiver Family # column is sortable", () => {
   OneMacPackagePage.verifyWaiverFamilyNumColumnIsSortable();
 });
-And("verify the Waiver format in column one is SS.#### or SS.#####", () => {
+And("verify the Waiver family format in row one is SS.#### or SS.#####", () => {
   OneMacPackagePage.verifyWaiverFamilyRowOneFormat();
 });
 And("verify the Waivers Family checkbox exists", () => {
@@ -1501,4 +1507,19 @@ And("verify that the value of the column for the 90th day is Pending", () => {
 });
 And("click Unsubmitted checkbox", () => {
   OneMacPackagePage.clickUnsubmittedCheckbox();
+});
+And("verify the type in row one is some kind of 1915b Waiver", () => {
+  OneMacPackagePage.verifypackageRowOneTypeContains1915bWaiver();
+});
+And("verify the type in row one is Base Waiver", () => {
+  OneMacPackagePage.verifypackageRowOneTypeHasTextBaseWaiver();
+});
+And("verify the type in row one is Waiver Renewal", () => {
+  OneMacPackagePage.verifypackageRowOneTypeHasTextWaiverRenewal();
+});
+And("verify the waiver number format in row one is SS.#### or SS.#####", () => {
+  OneMacPackagePage.verifypackageRowOneIDBaseWaiverFormat();
+});
+And("verify the waiver number format in row one is SS.#####.S##", () => {
+  OneMacPackagePage.verifypackageRowOneIDWaiverRenewalFormat();
 });

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -74,8 +74,10 @@ const packageRowOne90thDay = "#ninetiethDay-0";
 //Element is Xpath use cy.xpath instead of cy.get
 const resetButton = "//button[contains(text(),'Reset')]";
 //Element is Xpath use cy.xpath instead of cy.get
-const waiver1915bCheckBox =
-  "//label[contains(@for,'checkbox_componentType-1915(b) Waiver')]";
+const baseWaiver1915bCheckBox =
+  "//label[contains(@for,'checkbox_componentType-1915(b) Base Waiver')]";
+const waiverRenewal1915bCheckBox =
+  "//label[contains(@for,'checkbox_componentType-1915(b) Waiver Renewal')]";
 //Element is Xpath use cy.xpath instead of cy.get
 const CHIPSPACheckBox =
   "//label[contains(@for,'checkbox_componentType-CHIP SPA')]";
@@ -166,6 +168,7 @@ const submittedCheckbox =
 //Element is Xpath use cy.xpath instead of cy.get
 const unsubmittedCheckbox =
   "//label[contains(@for,'checkbox_packageStatus-Unsubmitted')]";
+const packageRowOneID = "#componentId-0";
 
 export class oneMacPackagePage {
   verify90thDayColumn() {
@@ -366,8 +369,11 @@ export class oneMacPackagePage {
   clickTypeDropDown() {
     cy.get(typeDropDown).click();
   }
-  verifywaiver1915bCheckBoxExists() {
-    cy.xpath(waiver1915bCheckBox).should("be.visible");
+  verifyWaiverRenewal1915bCheckBoxExists() {
+    cy.xpath(waiverRenewal1915bCheckBox).should("be.visible");
+  }
+  verifyBaseWaiver1915bCheckBoxExists() {
+    cy.xpath(baseWaiver1915bCheckBox).should("be.visible");
   }
   verifyCHIPSPACheckBoxExists() {
     cy.xpath(CHIPSPACheckBox).should("be.visible");
@@ -390,8 +396,11 @@ export class oneMacPackagePage {
   verifysparaiSubmittedExists() {
     cy.xpath(sparaiSubmitted).should("be.visible");
   }
-  clickwaiver1915bCheckBox() {
-    cy.xpath(waiver1915bCheckBox).click();
+  clickBaseWaiver1915bCheckBox() {
+    cy.xpath(baseWaiver1915bCheckBox).click();
+  }
+  clickWaiverRenewal1915bCheckBox() {
+    cy.xpath(waiverRenewal1915bCheckBox).click();
   }
   clickCHIPSPACheckBox() {
     cy.xpath(CHIPSPACheckBox).click();
@@ -674,6 +683,23 @@ export class oneMacPackagePage {
   }
   verify90thDayRowOneIsClockStopped() {
     cy.get(packageRowOne90thDay).should("have.text", "Clock Stopped");
+  }
+  verifypackageRowOneIDBaseWaiverFormat() {
+    cy.get(packageRowOneID).contains(/[A-Z]{2}\.\d{4}||[A-Z]{2}\.\d{5}/);
+  }
+  verifypackageRowOneIDWaiverRenewalFormat() {
+    cy.get(packageRowOneID).contains(/[A-Z]{2}\.\d{5}\.[A-Z]{1}\d{2}/);
+  }
+  verifypackageRowOneTypeContains1915bWaiver() {
+    cy.get(packageRowOneType)
+      .should("contain.text", "1915(b)")
+      .and("contain.text", "Waiver");
+  }
+  verifypackageRowOneTypeHasTextBaseWaiver() {
+    cy.get(packageRowOneType).should("contain.text", "Base Waiver");
+  }
+  verifypackageRowOneTypeHasTextWaiverRenewal() {
+    cy.get(packageRowOneType).should("contain.text", "Waiver Renewal");
   }
 }
 export default oneMacPackagePage;


### PR DESCRIPTION
#### Test Summary:
update to filter tests for waivers
add tests for base waiver and waiver renewal.

Story: https://qmacbis.atlassian.net/browse/OY2-11676

### Test Plan
````
Feature: OY2-11676 Package Dashboard: New Waiver tab layout 

    Scenario: screen enhancement
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And click on the Waivers tab
        And verify the type in row one is some kind of 1915b Waiver

    Scenario: verify base waiver waiver number pattern
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And click on the Waivers tab
        And Click on Filter Button
        And click on Type
        And click 1915b Waiver Renewal check box
        And Click on Filter Button
        And verify the type in row one is Base Waiver
        And verify the waiver number format in row one is SS.#### or SS.#####

    Scenario: verify waiver renewal waiver number pattern
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And click on the Waivers tab
        And Click on Filter Button
        And click on Type
        And click 1915b Base Waiver check box
        And Click on Filter Button
        And verify the type in row one is Waiver Renewal
        And verify the waiver number format in row one is SS.#####.S##
````

