### PR TITLE
OY2 15647: State User can "Respond to RAI"

### DIFF
--- a/services/app-api/one-seed.json
+++ b/services/app-api/one-seed.json
@@ -6,7 +6,7 @@
     "changeHistory": [
      {
       "componentType": "sparai",
-      "componentTimestamp": 1639696189171,
+      "componentTimestamp": 1643218567141,
       "submitterName": "StateSubmitter Nightwatch",
       "componentId": "MD-13-1122"
      },
@@ -67,7 +67,7 @@
     "sparai": [
      {
       "componentType": "sparai",
-      "componentTimestamp": 1639696189171,
+      "componentTimestamp": 1643218567141,
       "submitterName": "StateSubmitter Nightwatch",
       "componentId": "MD-13-1122"
      }
@@ -83,6 +83,51 @@
     "submissionId": "4240e440-5ec5-11ec-b2ea-eb35c89f340d"
    },
    {
+    "pk": "MD-13-1122",
+    "sk": "sparai#1643218567141",
+    "submitterId": "us-east-1:17735f75-6535-4e48-bc51-c224a6d2a2d9",
+    "changeHistory": [
+     {
+      "componentType": "sparai",
+      "additionalInformation": "Seed Data response to the RAI for MD-13-1122",
+      "componentId": "MD-13-1122",
+      "attachments": [
+       {
+        "s3Key": "1643218566081/Attachment 3.1-A, #4b, Page 3f Clean.pdf",
+        "filename": "Attachment 3.1-A, #4b, Page 3f Clean.pdf",
+        "title": "RAI Response",
+        "contentType": "application/pdf",
+        "url": "https://uploads-return-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A17735f75-6535-4e48-bc51-c224a6d2a2d9/1643218566081/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Clean.pdf"
+       }
+      ],
+      "submissionId": "710db810-7ece-11ec-b6d3-3bd98b0823f6",
+      "currentStatus": "Submitted",
+      "submitterId": "us-east-1:17735f75-6535-4e48-bc51-c224a6d2a2d9",
+      "submitterName": "Kristin Grue",
+      "submissionTimestamp": 1643218567141,
+      "submitterEmail": "k.grue@theta-llc.com"
+     }
+    ],
+    "componentType": "sparai",
+    "currentStatus": "Submitted",
+    "attachments": [
+     {
+      "s3Key": "1643218566081/Attachment 3.1-A, #4b, Page 3f Clean.pdf",
+      "filename": "Attachment 3.1-A, #4b, Page 3f Clean.pdf",
+      "title": "RAI Response",
+      "contentType": "application/pdf",
+      "url": "https://uploads-return-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A17735f75-6535-4e48-bc51-c224a6d2a2d9/1643218566081/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Clean.pdf"
+     }
+    ],
+    "additionalInformation": "Seed Data response to the RAI for MD-13-1122",
+    "submissionTimestamp": 1643218567141,
+    "packageId": "MD-13-1122",
+    "submitterEmail": "k.grue@theta-llc.com",
+    "componentId": "MD-13-1122",
+    "submitterName": "Kristin Grue",
+    "submissionId": "710db810-7ece-11ec-b6d3-3bd98b0823f6"
+   },
+   {
     "pk": "MI-13-1122",
     "sk": "spa",
     "devComment": "Package added via seed data for application testing",
@@ -90,8 +135,8 @@
     "changeHistory": [
      {
       "componentType": "sparai",
-      "componentTimestamp": 1639696189171,
-      "submitterName": "StateSubmitter Nightwatch",
+      "componentTimestamp": 1643218567141,
+      "submitterName": "Kristin Grue",
       "componentId": "MD-13-1122"
      },
      {
@@ -151,8 +196,8 @@
     "sparai": [
      {
       "componentType": "sparai",
-      "componentTimestamp": 1639696189171,
-      "submitterName": "StateSubmitter Nightwatch",
+      "componentTimestamp": 1643218567141,
+      "submitterName": "Kristin Grue",
       "componentId": "MI-13-1122"
      }
     ],
@@ -165,6 +210,51 @@
     "componentId": "MI-13-1122",
     "submitterName": "StateSubmitter Nightwatch",
     "submissionId": "4240e440-5ec5-11ec-b2ea-eb35c89f340d"
+   },
+   {
+    "pk": "MI-13-1122",
+    "sk": "sparai#1643218567141",
+    "submitterId": "us-east-1:17735f75-6535-4e48-bc51-c224a6d2a2d9",
+    "changeHistory": [
+     {
+      "componentType": "sparai",
+      "additionalInformation": "Seed Data response to the RAI for MI-13-1122",
+      "componentId": "MI-13-1122",
+      "attachments": [
+       {
+        "s3Key": "1643218566081/Attachment 3.1-A, #4b, Page 3f Clean.pdf",
+        "filename": "Attachment 3.1-A, #4b, Page 3f Clean.pdf",
+        "title": "RAI Response",
+        "contentType": "application/pdf",
+        "url": "https://uploads-return-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A17735f75-6535-4e48-bc51-c224a6d2a2d9/1643218566081/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Clean.pdf"
+       }
+      ],
+      "submissionId": "710db810-7ece-11ec-b6d3-3bd98b0823f6",
+      "currentStatus": "Submitted",
+      "submitterId": "us-east-1:17735f75-6535-4e48-bc51-c224a6d2a2d9",
+      "submitterName": "Kristin Grue",
+      "submissionTimestamp": 1643218567141,
+      "submitterEmail": "k.grue@theta-llc.com"
+     }
+    ],
+    "componentType": "sparai",
+    "currentStatus": "Submitted",
+    "attachments": [
+     {
+      "s3Key": "1643218566081/Attachment 3.1-A, #4b, Page 3f Clean.pdf",
+      "filename": "Attachment 3.1-A, #4b, Page 3f Clean.pdf",
+      "title": "RAI Response",
+      "contentType": "application/pdf",
+      "url": "https://uploads-return-rai-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A17735f75-6535-4e48-bc51-c224a6d2a2d9/1643218566081/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Clean.pdf"
+     }
+    ],
+    "additionalInformation": "Seed Data response to the RAI for MI-13-1122",
+    "submissionTimestamp": 1643218567141,
+    "packageId": "MI-13-1122",
+    "submitterEmail": "k.grue@theta-llc.com",
+    "componentId": "MI-13-1122",
+    "submitterName": "Kristin Grue",
+    "submissionId": "710db810-7ece-11ec-b6d3-3bd98b0823f6"
    },
    {
        "pk": "MD-77-2985",

--- a/services/common/changeRequest.js
+++ b/services/common/changeRequest.js
@@ -450,7 +450,7 @@ export const CONFIG = {
       idFAQLink: ROUTES.FAQ_WAIVER_ID,
       idHintText: "Must follow the format SS.#### or SS.#####",
       idFormat: "SS.#### or SS.#####",
-      idRegex: "(^[A-Z]{2}[.][0-9]{4,5}$)",
+      idRegex: "(^[A-Z]{2}[.-][0-9]{4,5}$)",
       idExistValidations: [
         {
           idMustExist: true,
@@ -477,7 +477,7 @@ export const CONFIG = {
       idHintText: "Please use the exact Waiver Number sent with the RAI",
       idFormat: "the Number format sent with the RAI",
       idRegex:
-        "(^[A-Z]{2}[.][0-9]{4,5}$)|(^[A-Z]{2}[.][0-9]{4,5}[.]R[0-9]{2}$)|(^[A-Z]{2}[.][0-9]{4,5}[.]R[0-9]{2}[.]M[0-9]{2}$)",
+        "(^[A-Z]{2}[.-][0-9]{4,5}$)|(^[A-Z]{2}[.][0-9]{4,5}[.]R[0-9]{2}$)|(^[A-Z]{2}[.][0-9]{4,5}[.]R[0-9]{2}[.]M[0-9]{2}$)",
       idExistValidations: [
         {
           idMustExist: true,

--- a/services/common/changeRequest.js
+++ b/services/common/changeRequest.js
@@ -477,7 +477,7 @@ export const CONFIG = {
       idHintText: "Please use the exact Waiver Number sent with the RAI",
       idFormat: "the Number format sent with the RAI",
       idRegex:
-        "(^[A-Z]{2}[.-][0-9]{4,5}$)|(^[A-Z]{2}[.][0-9]{4,5}[.]R[0-9]{2}$)|(^[A-Z]{2}[.][0-9]{4,5}[.]R[0-9]{2}[.]M[0-9]{2}$)",
+        "(^[A-Z]{2}[.-][0-9]{4,5}$)|(^[A-Z]{2}[.-][0-9]{4,5}[.]R[0-9]{2}$)|(^[A-Z]{2}[.-][0-9]{4,5}[.]R[0-9]{2}[.]M?[0-9]{2}$)",
       idExistValidations: [
         {
           idMustExist: true,

--- a/services/stream-functions/handlers/sinkMskToDynamo.js
+++ b/services/stream-functions/handlers/sinkMskToDynamo.js
@@ -64,7 +64,7 @@ function createTestEvent(event, value) {
     "topic": event.topic,
     "partition": event.partition,
     "offset": event.offset,
-    "value": { 
+    "value": JSON.stringify({ 
       "payload": {
         "ID_Number": value.payload.ID_Number,
         "Submission_Date": value.payload.Submission_Date,
@@ -75,7 +75,7 @@ function createTestEvent(event, value) {
         "SPW_Status_ID": value.payload.SPW_Status_ID,
         "replica_id": value.payload.replica_id
       }
-    }
+    }),
   };
 
   return testEvent;
@@ -153,7 +153,10 @@ function myHandler(event) {
   
     ddb.update(updatePackageParams, function(err, data) {
       if (err) {
-        console.log("Error", err);
+        if (err.code === "ConditionalCheckFailedException")
+          console.log("Not a OneMAC package: ", updatePk);
+        else 
+          console.log("Error", err);
       } else {
         console.log("Update Success!  Returned data is: ", data);
         console.log(`Current epoch time:  ${Math.floor(new Date().getTime())}`);

--- a/services/stream-functions/handlers/sinkMskToDynamo.js
+++ b/services/stream-functions/handlers/sinkMskToDynamo.js
@@ -58,7 +58,7 @@ const topLevelUpdates = [
   "currentStatus",
 ];
 
-function createTestEvent(event) {
+function createTestEvent(event, value) {
 
   const testEvent = {
     "topic": event.topic,
@@ -66,14 +66,14 @@ function createTestEvent(event) {
     "offset": event.offset,
     "value": { 
       "payload": {
-        "ID_Number": event.payload.ID_Number,
-        "Submission_Date": event.payload.Submission_Date,
-        "Plan_Type": event.payload.Plan_Type,
-        "Action_Type": event.payload.Action_Type,
-        "Alert_90_Days_Date": event.payload.Alert_90_Days_Date,
-        "Summary_Memo": event.payload.Summary_Memo,
-        "SPW_Status_ID": event.payload.SPW_Status_ID,
-        "replica_id": event.payload.replica_id
+        "ID_Number": value.payload.ID_Number,
+        "Submission_Date": value.payload.Submission_Date,
+        "Plan_Type": value.payload.Plan_Type,
+        "Action_Type": value.payload.Action_Type,
+        "Alert_90_Days_Date": value.payload.Alert_90_Days_Date,
+        "Summary_Memo": value.payload.Summary_Memo,
+        "SPW_Status_ID": value.payload.SPW_Status_ID,
+        "replica_id": value.payload.replica_id
       }
     }
   };
@@ -87,9 +87,9 @@ function myHandler(event) {
   }
   console.log('Received event:', JSON.stringify(event, null, 2));
   const table = event.topic.replace(topicPrefix, "");
-  if (table === "State_Plan") console.log('Test State_Plan Event: ',JSON.stringify(createTestEvent(event), null, 2));
   const value = JSON.parse(event.value);
   const eventId = event.offset;
+  if (table === "State_Plan") console.log('Test State_Plan Event: ',JSON.stringify(createTestEvent(event, value), null, 2));
   console.log(`Topic: ${event.topic} Table: ${table} Event value: ${JSON.stringify(value, null, 2)}`);
 
   const SEAToolId = value.payload.ID_Number;

--- a/services/ui-src/src/changeRequest/NewSPA.js
+++ b/services/ui-src/src/changeRequest/NewSPA.js
@@ -10,9 +10,19 @@ const SPA_CHOICES = [
     linkTo: "/spa",
   },
   {
+    title: "Respond to Medicaid SPA RAI",
+    description: "Submit additional information",
+    linkTo: "/sparai",
+  },
+  {
     title: "CHIP SPA",
     description: "Submit new CHIP State Plan Amendment",
     linkTo: "/chipspa",
+  },
+  {
+    title: "Respond to CHIP SPA RAI",
+    description: "Submit additional information",
+    linkTo: "/chipsparai",
   },
 ];
 

--- a/services/ui-src/src/changeRequest/NewWaiver.js
+++ b/services/ui-src/src/changeRequest/NewWaiver.js
@@ -15,6 +15,11 @@ const WAIVER_CHOICES = [
     linkTo: "/waiverextension",
   },
   {
+    title: "Respond to Waiver RAI",
+    description: "Submit additional information",
+    linkTo: "/waiverrai",
+  },
+  {
     title: "Appendix K Amendment",
     description: "Submit Appendix K Amendment",
     linkTo: "/waiverappk",

--- a/tests/cypress/support/pages/oneMacSubmissionTypePage.js
+++ b/tests/cypress/support/pages/oneMacSubmissionTypePage.js
@@ -4,9 +4,9 @@ const statePlanAmendmentSPA =
 //Element is Xpath use cy.xpath instead of cy.get
 const waiverAction = '//h4[contains(text(),"Waiver Action")]';
 //Element is Xpath use cy.xpath instead of cy.get
-const MedicalSPA = '//h4[contains(text(),"Medicaid SPA")]';
+const MedicalSPA = '//h4[text()="Medicaid SPA"]';
 //Element is Xpath use cy.xpath instead of cy.get
-const ChipSPA = '//h4[contains(text(),"CHIP SPA")]';
+const ChipSPA = '//h4[text()="CHIP SPA"]';
 //Element is Xpath use cy.xpath instead of cy.get
 const waiverActionWaiverAction = '//h4[contains(text(),"Waiver Action")]';
 //Element is Xpath use cy.xpath instead of cy.get


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-15647
Endpoint: https://d3atnsmoo1ec4c.cloudfront.net

### Details
Users need to be able to submit RAI Responses to Requests made on packages not originally submitted through OneMAC.

### Changes
- Revert "New Submission" triage to include the RAI form links (with blank IDs)
- Updated the Waiver Number format validation regex (on forms that require IDs to be present in the system) to allow '-' as the third character, as it looks like many waiver numbers in SEATool have that format.
- the "M" in the Waiver Amendment numbers appears to be optional as well.

### Test Plan
You need IDs that are valid but were not submitted via OneMAC... can go through the AWS console, but here are a few:
MI-14-0015. SPA and CHIP SPA RAI Responses (we don't verify against PlanType)
MI.0438. (Base Waiver RAI)
MI.0438.R02 (Waiver Renewal RAI)
MI.0438.R02.M01 (Waiver Amendment RAI) (again, we don't check against PlanType)

1. Login as a submitter user (might be helpful to have access to MI)
2. Select "New Submission"
3. Use the triage to submit the following:
  a. Medicaid SPA Response to RAI
  b. CHIP SPA Response to RAI
  c. Waiver Action Response to RAI with a Base Waiver for ID
  c. Waiver Action Response to RAI with a Waiver Renewal for ID
  c. Waiver Action Response to RAI with a Waiver Amendment for ID (this will include App K IDs)
4. Verify the emails are sent to submitter and CMS
