### PR TITLE
OY2-11676 increment 2: expanding rows in waiver table

### DIFF
--- a/services/app-api/one-seed.json
+++ b/services/app-api/one-seed.json
@@ -763,6 +763,17 @@
             "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A3211a6ff-043f-436b-8313-1b314582b2a5/1638473559097/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Track.pdf"
            }
           ],
+          "children": [
+            {
+              "componentType": "waiverrai",
+              "componentId": "VA.1117",
+              "currentStatus": "Submitted",
+              "submitterName": "Angie Active",
+              "displayId": "VA.1117",
+              "submitterEmail": "statesubmitteractive@cms.hhs.local",
+              "submissionTimestamp": 1643296612626
+            }
+          ],
           "submissionId": "9c5c8b70-53a6-11ec-b5bc-c9173b9fa278",
           "waiverAuthority": "1915(b)(4)",
           "currentStatus": "Submitted",
@@ -2075,6 +2086,26 @@
             "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1636137484260/15MB.pdf"
            }
           ],
+          "children": [
+            {
+              "componentType": "waiverextension",
+              "componentId": "MI.10330",
+              "currentStatus": "Submitted",
+              "submitterName": "Statesubmitter Nightwatch",
+              "displayId": "MI.10330",
+              "submitterEmail": "statesubmitter@nightwatch.test",
+              "submissionTimestamp": 1643138320362
+            },
+            {
+              "componentType": "waiveramendment",
+              "componentId": "MI.10330.R00.M01",
+              "currentStatus": "Submitted",
+              "submitterName": "StateSubmitter Nightwatch",
+              "displayId": "R00.01",
+              "submitterEmail": "statesubmitter@nightwatch.test",
+              "submissionTimestamp": 1643212119072
+            }
+          ],
           "submissionId": "86573ae0-3e67-11ec-b244-9b7cbfa0a2c8",
           "waiverAuthority": "1915(b)(4)",
           "currentStatus": "Submitted",
@@ -2142,6 +2173,17 @@
           "contentType": "application/pdf",
           "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1639507770586/15MB.pdf"
          }
+        ],
+        "children": [
+          {
+            "componentType": "waiverrai",
+            "componentId": "MD.83420",
+            "currentStatus": "Submitted",
+            "submitterName": "Statesubmitter Nightwatch",
+            "displayId": "MD.83420",
+            "submitterEmail": "statesubmitter@nightwatch.test",
+            "submissionTimestamp": 1643296612626
+          }
         ],
         "GSI1sk": "MD.83420",
         "additionalInformation": "This is just a test",

--- a/services/app-api/one-seed.json
+++ b/services/app-api/one-seed.json
@@ -1888,6 +1888,17 @@
           "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1636137484260/15MB.pdf"
          }
         ],
+        "children": [
+          {
+            "componentType": "waiverextension",
+            "componentId": "MD.10330",
+            "currentStatus": "Submitted",
+            "submitterName": "Statesubmitter Nightwatch",
+            "displayId": "MD.10330",
+            "submitterEmail": "statesubmitter@nightwatch.test",
+            "submissionTimestamp": 1643138320362
+          }
+        ],
         "GSI1sk": "MD.10330",
         "additionalInformation": "This is just a test",
         "submissionTimestamp": 1636137490470,

--- a/services/app-api/one-seed.json
+++ b/services/app-api/one-seed.json
@@ -1831,6 +1831,15 @@
         "sk": "waivernew",
         "submitterId": "us-east-1:86a190fe-b195-42bf-9685-9761bf0ff14b",
         "changeHistory": [
+          {
+            "componentType": "waiveramendment",
+            "componentId": "MD.10330.R00.M01",
+            "currentStatus": "Submitted",
+            "submitterName": "StateSubmitter Nightwatch",
+            "displayId": "R00.01",
+            "submitterEmail": "statesubmitter@nightwatch.test",
+            "submissionTimestamp": 1643212119072
+          },
          {
           "componentType": "122",
           "clockEndTimestamp": null,
@@ -1886,6 +1895,13 @@
           "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
           "contentType": "application/pdf",
           "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1636137484260/15MB.pdf"
+          },
+          {
+            "s3Key": "1643212113804/IMG_0954.jpg",
+            "filename": "IMG_0954.jpg",
+            "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+            "contentType": "image/jpeg",
+            "url": "https://uploads-oy2-15674-inc2-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3Afca18499-f892-4266-ad18-8b53c6fb7f39/1643212113804/IMG_0954.jpg"
          }
         ],
         "children": [
@@ -1897,6 +1913,15 @@
             "displayId": "MD.10330",
             "submitterEmail": "statesubmitter@nightwatch.test",
             "submissionTimestamp": 1643138320362
+          },
+          {
+            "componentType": "waiveramendment",
+            "componentId": "MD.10330.R00.M01",
+            "currentStatus": "Submitted",
+            "submitterName": "StateSubmitter Nightwatch",
+            "displayId": "R00.01",
+            "submitterEmail": "statesubmitter@nightwatch.test",
+            "submissionTimestamp": 1643212119072
           }
         ],
         "GSI1sk": "MD.10330",
@@ -1907,9 +1932,107 @@
         "packageId": "MD.10330",
         "submitterEmail": "statesubmitter@nightwatch.test",
         "componentId": "MD.10330",
+        "waiveramendment": [
+          {
+            "componentType": "waiveramendment",
+            "componentId": "MD.10330.R00.M01",
+            "currentStatus": "Submitted",
+            "submitterName": "StateSubmitter Nightwatch",
+            "displayId": "R00.01",
+            "submitterEmail": "statesubmitter@nightwatch.test",
+            "submissionTimestamp": 1643212119072
+          }
+        ],
         "submitterName": "Statesubmitter Nightwatch",
         "submissionId": "86573ae0-3e67-11ec-b244-9b7cbfa0a2c8"
        },
+      {
+        "pk": "MD.10330.R01",
+        "sk": "waiverrenewal",
+        "submitterId": "us-east-1:fca18499-f892-4266-ad18-8b53c6fb7f39",
+        "changeHistory": [
+          {
+            "componentType": "waiveramendment",
+            "componentId": "MD.10330.R01.M01",
+            "currentStatus": "Submitted",
+            "submitterName": "StateSubmitter Nightwatch",
+            "displayId": "R01.01",
+            "submitterEmail": "statesubmitter@nightwatch.test",
+            "submissionTimestamp": 1643212212642
+          },
+          {
+            "componentType": "waiverrenewal",
+            "additionalInformation": "renew",
+            "componentId": "MD.10330.R01",
+            "attachments": [
+              {
+                "s3Key": "1643212168056/IMG_3202.jpg",
+                "filename": "IMG_3202.jpg",
+                "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+                "contentType": "image/jpeg",
+                "url": "https://uploads-oy2-15674-inc2-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3Afca18499-f892-4266-ad18-8b53c6fb7f39/1643212168056/IMG_3202.jpg"
+              }
+            ],
+            "submissionId": "8c52e960-7ebf-11ec-bd30-a11f4457ce6b",
+            "waiverAuthority": "1915(b)(4)",
+            "currentStatus": "Submitted",
+            "submitterId": "us-east-1:fca18499-f892-4266-ad18-8b53c6fb7f39",
+            "submitterName": "StateSubmitter Nightwatch",
+            "submissionTimestamp": 1643212170520,
+            "submitterEmail": "statesubmitter@nightwatch.test"
+          }
+        ],
+        "componentType": "waiverrenewal",
+        "currentStatus": "Submitted",
+        "attachments": [
+          {
+            "s3Key": "1643212168056/IMG_3202.jpg",
+            "filename": "IMG_3202.jpg",
+            "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+            "contentType": "image/jpeg",
+            "url": "https://uploads-oy2-15674-inc2-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3Afca18499-f892-4266-ad18-8b53c6fb7f39/1643212168056/IMG_3202.jpg"
+          },
+          {
+            "s3Key": "1643212211505/plain.pdf",
+            "filename": "plain.pdf",
+            "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+            "contentType": "application/pdf",
+            "url": "https://uploads-oy2-15674-inc2-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3Afca18499-f892-4266-ad18-8b53c6fb7f39/1643212211505/plain.pdf"
+          }
+        ],
+        "GSI1sk": "MD.10330.R01",
+        "additionalInformation": "renew",
+        "children": [
+          {
+            "componentType": "waiveramendment",
+            "componentId": "MD.10330.R01.M01",
+            "currentStatus": "Submitted",
+            "submitterName": "StateSubmitter Nightwatch",
+            "displayId": "R01.01",
+            "submitterEmail": "statesubmitter@nightwatch.test",
+            "submissionTimestamp": 1643212212642
+          }
+        ],
+        "submissionTimestamp": 1643212170520,
+        "waiverAuthority": "1915(b)(4)",
+        "GSI1pk": "OneMAC#waiver",
+        "packageId": "MD.10330.R01",
+        "submitterEmail": "statesubmitter@nightwatch.test",
+        "componentId": "MD.10330.R01",
+        "waiveramendment": [
+          {
+            "componentType": "waiveramendment",
+            "componentId": "MD.10330.R01.M01",
+            "currentStatus": "Submitted",
+            "submitterName": "StateSubmitter Nightwatch",
+            "displayId": "R01.01",
+            "submitterEmail": "statesubmitter@nightwatch.test",
+            "submissionTimestamp": 1643212212642
+          }
+        ],
+        "submitterName": "StateSubmitter Nightwatch",
+        "submissionId": "8c52e960-7ebf-11ec-bd30-a11f4457ce6b"
+      },
        {
         "pk": "MI.10330",
         "sk": "waivernew",

--- a/services/app-api/withdrawPackage.js
+++ b/services/app-api/withdrawPackage.js
@@ -24,12 +24,15 @@ export const main = handler(async (event) => {
 
   let updatedPackageData;
   try {
+    const { componentId, submitterEmail, submitterName } = body;
     updatedPackageData = await updateComponent({
-      ...body,
-      packageId: body.componentId,
+      componentId,
+      packageId: componentId,
       parentType: body.componentType,
       currentStatus: ChangeRequest.ONEMAC_STATUS.WITHDRAWN,
       submissionTimestamp: Date.now(),
+      submitterEmail,
+      submitterName,
     });
   } catch (e) {
     console.error("Failed to update package", e);

--- a/services/common/changeRequest.js
+++ b/services/common/changeRequest.js
@@ -149,7 +149,7 @@ const waiverBaseTransmittalNumber = {
   idFAQLink: ROUTES.FAQ_WAIVER_ID,
 };
 
-const defaultActionsByStatus = {
+export const defaultActionsByStatus = {
   [ONEMAC_STATUS.UNSUBMITTED]: [],
   [ONEMAC_STATUS.SUBMITTED]: [PACKAGE_ACTION.WITHDRAW],
   [ONEMAC_STATUS.IN_REVIEW]: [PACKAGE_ACTION.WITHDRAW],

--- a/services/ui-src/src/components/PortalTable.tsx
+++ b/services/ui-src/src/components/PortalTable.tsx
@@ -8,11 +8,7 @@ import {
   useTable,
 } from "react-table";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faSearch,
-  faLevelUpAlt,
-  faChevronDown,
-} from "@fortawesome/free-solid-svg-icons";
+import { faSearch, faChevronDown } from "@fortawesome/free-solid-svg-icons";
 import { constant, noop } from "lodash";
 import cx from "classnames";
 
@@ -143,7 +139,7 @@ export default function PortalTable<V extends {} = {}>({
               return (
                 <tr
                   {...row.getRowProps()}
-                  className={cx(row.getRowProps().className, {
+                  className={cx({
                     // @ts-ignore FIXME remove when react-table types are improved
                     "parent-row-expanded": row.isExpanded,
                     // @ts-ignore FIXME remove when react-table types are improved
@@ -153,7 +149,7 @@ export default function PortalTable<V extends {} = {}>({
                   {expandable && (
                     <td className="row-expander-cell">
                       {/* @ts-ignore */}
-                      {row.depth === 0 ? (
+                      {row.depth === 0 && (
                         <button
                           aria-label="Expand row"
                           // @ts-ignore FIXME remove when react-table types are improved
@@ -163,8 +159,6 @@ export default function PortalTable<V extends {} = {}>({
                         >
                           <FontAwesomeIcon icon={faChevronDown} />
                         </button>
-                      ) : (
-                        <FontAwesomeIcon icon={faLevelUpAlt} />
                       )}
                     </td>
                   )}

--- a/services/ui-src/src/components/PortalTable.tsx
+++ b/services/ui-src/src/components/PortalTable.tsx
@@ -1,14 +1,20 @@
 import React, { ReactNode } from "react";
 import {
   TableOptions,
+  useExpanded,
   useFilters,
   useGlobalFilter,
   useSortBy,
   useTable,
 } from "react-table";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faSearch } from "@fortawesome/free-solid-svg-icons";
-import { constant } from "lodash";
+import {
+  faSearch,
+  faLevelUpAlt,
+  faChevronDown,
+} from "@fortawesome/free-solid-svg-icons";
+import { constant, noop } from "lodash";
+import cx from "classnames";
 
 import Expand from "../images/Expand.svg";
 import {
@@ -20,8 +26,10 @@ export { CustomFilterTypes, CustomFilterUi } from "./SearchAndFilter";
 
 export type TableProps<V extends {}> = {
   className?: string;
+  expandable?: boolean;
   searchBarTitle: ReactNode;
   withSearchBar?: boolean;
+  TEMP_onReset?: () => void;
 } & Pick<SearchFilterProps<V>, "pageContentRef"> &
   TableOptions<V>;
 
@@ -32,9 +40,11 @@ const defaultColumn = {
 };
 
 export default function PortalTable<V extends {} = {}>({
+  expandable,
   pageContentRef,
   searchBarTitle,
   withSearchBar,
+  TEMP_onReset = noop,
   ...props
 }: TableProps<V>) {
   const {
@@ -67,7 +77,8 @@ export default function PortalTable<V extends {} = {}>({
     },
     useGlobalFilter,
     useFilters,
-    useSortBy
+    useSortBy,
+    useExpanded
   );
 
   return (
@@ -81,12 +92,14 @@ export default function PortalTable<V extends {} = {}>({
           pageContentRef={pageContentRef}
           searchBarTitle={searchBarTitle}
           setAllFilters={setAllFilters}
+          TEMP_onReset={TEMP_onReset}
         />
       )}
       <table className={props.className} {...getTableProps()}>
         <thead>
           {headerGroups.map((headerGroup) => (
             <tr {...headerGroup.getHeaderGroupProps()}>
+              {expandable && <th />}
               {headerGroup.headers.map((column) => (
                 <th
                   // @ts-ignore FIXME remove when react-table types are improved
@@ -128,7 +141,33 @@ export default function PortalTable<V extends {} = {}>({
               // @ts-ignore FIXME remove when react-table types are improved
               prepareRow(row, rowIndex);
               return (
-                <tr {...row.getRowProps()}>
+                <tr
+                  {...row.getRowProps()}
+                  className={cx(row.getRowProps().className, {
+                    // @ts-ignore FIXME remove when react-table types are improved
+                    "parent-row-expanded": row.isExpanded,
+                    // @ts-ignore FIXME remove when react-table types are improved
+                    "child-row-expanded": row.depth > 0,
+                  })}
+                >
+                  {expandable && (
+                    <td className="row-expander-cell">
+                      {/* @ts-ignore */}
+                      {row.depth === 0 ? (
+                        <button
+                          aria-label="Expand row"
+                          // @ts-ignore FIXME remove when react-table types are improved
+                          disabled={!row.canExpand}
+                          // @ts-ignore FIXME remove when react-table types are improved
+                          onClick={() => row.toggleRowExpanded()}
+                        >
+                          <FontAwesomeIcon icon={faChevronDown} />
+                        </button>
+                      ) : (
+                        <FontAwesomeIcon icon={faLevelUpAlt} />
+                      )}
+                    </td>
+                  )}
                   {row.cells.map((cell, index) => {
                     return (
                       <td

--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -120,6 +120,7 @@ const PackageList = () => {
         [ChangeRequest.TYPE.WAIVER_APP_K]: "1915(c) Appendix K Amendment",
         [ChangeRequest.TYPE.WAIVER_EXTENSION]: "1915(b) Temporary Extension",
         [ChangeRequest.TYPE.WAIVER_AMENDMENT]: "1915(b) Amendment",
+        [ChangeRequest.TYPE.WAIVER_RAI]: "1915(b) RAI Response",
       }[componentType] ?? []),
     []
   );

--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -46,6 +46,8 @@ const getFamily = ({ componentId }) =>
 export const getState = ({ componentId }) =>
   componentId ? componentId.toString().substring(0, 2) : "--";
 
+const getChildren = ({ children }) => children;
+
 /**
  * Component containing dashboard
  */
@@ -387,6 +389,8 @@ const PackageList = () => {
     return rightSideContent;
   }
 
+  const TEMP_onReset = useCallback(() => setPackageList((d) => [...d]), []);
+
   function renderSubmissionList() {
     if (userData.type !== USER_TYPE.CMS_ROLE_APPROVER) {
       if (userStatus === USER_STATUS.PENDING) {
@@ -420,12 +424,12 @@ const PackageList = () => {
             columns={columns}
             data={packageList}
             expandable={tab === ChangeRequest.PACKAGE_GROUP.WAIVER}
-            getSubRows={({ children }) => children}
+            getSubRows={getChildren}
             initialState={initialTableState}
             pageContentRef={dashboardRef}
             searchBarTitle="Search by Package ID or Submitter Name"
             withSearchBar
-            TEMP_onReset={() => setPackageList((d) => [...d])}
+            TEMP_onReset={TEMP_onReset}
           />
         ) : (
           <EmptyList message="You have no submissions yet." />

--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -117,6 +117,7 @@ const PackageList = () => {
         [ChangeRequest.TYPE.WAIVER_RENEWAL]: "1915(b) Waiver Renewal",
         [ChangeRequest.TYPE.WAIVER_APP_K]: "1915(c) Appendix K Amendment",
         [ChangeRequest.TYPE.WAIVER_EXTENSION]: "1915(b) Temporary Extension",
+        [ChangeRequest.TYPE.WAIVER_AMENDMENT]: "1915(b) Amendment",
       }[componentType] ?? []),
     []
   );
@@ -386,8 +387,6 @@ const PackageList = () => {
     return rightSideContent;
   }
 
-  const [tableKey, updateTableKey] = useState(0);
-
   function renderSubmissionList() {
     if (userData.type !== USER_TYPE.CMS_ROLE_APPROVER) {
       if (userStatus === USER_STATUS.PENDING) {
@@ -426,8 +425,7 @@ const PackageList = () => {
             pageContentRef={dashboardRef}
             searchBarTitle="Search by Package ID or Submitter Name"
             withSearchBar
-            key={tableKey}
-            TEMP_onReset={() => updateTableKey((k) => k + 1)}
+            TEMP_onReset={() => setPackageList((d) => [...d])}
           />
         ) : (
           <EmptyList message="You have no submissions yet." />

--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -2328,3 +2328,35 @@ aside#faq-contact-info-box {
 .custom-multi-select {
   color: $color-black;
 }
+
+.parent-row-expanded {
+  background-color: $color-primary-alt-lightest;
+
+  button {
+    @extend .ds-u-fill--transparent;
+  }
+
+  .row-expander-cell button svg {
+    transform: rotateZ(180deg);
+  }
+}
+
+.child-row-expanded .row-expander-cell {
+  text-align: center;
+
+  svg {
+    transform: rotateZ(90deg);
+  }
+}
+
+.row-expander-cell {
+  @extend .ds-u-color--gray;
+
+  button {
+    @extend .ds-u-fill--transparent;
+
+    &:disabled {
+      color: $color-gray-lightest;
+    }
+  }
+}

--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -2329,23 +2329,15 @@ aside#faq-contact-info-box {
   color: $color-black;
 }
 
-.parent-row-expanded {
+.parent-row-expanded .row-expander-cell button svg {
+  transform: rotateZ(180deg);
+}
+
+.child-row-expanded {
   background-color: $color-primary-alt-lightest;
 
   button {
     @extend .ds-u-fill--transparent;
-  }
-
-  .row-expander-cell button svg {
-    transform: rotateZ(180deg);
-  }
-}
-
-.child-row-expanded .row-expander-cell {
-  text-align: center;
-
-  svg {
-    transform: rotateZ(90deg);
   }
 }
 

--- a/tests/cypress/cypress/integration/OY2_13092_Package_Dashboard_Filter.feature
+++ b/tests/cypress/cypress/integration/OY2_13092_Package_Dashboard_Filter.feature
@@ -80,7 +80,7 @@ Feature: OY2-13092 Package Dashboard - Filter
         And Click on Filter Button
         And click on Type
         And click 1915b Base Waiver check box
-        #And click 1915b Waiver Renewal check box
+        And click 1915b Waiver Renewal check box
         And verify Error message displayed should be No Results Found
         And verify Error message details is displayed
         And click 1915b Base Waiver check box

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -487,6 +487,7 @@ export class oneMacPackagePage {
     cy.get(submittedByColumn).should("be.visible");
   }
   verifyactionsColumnExists() {
+    cy.get(actionsColumn).scrollIntoView();
     cy.get(actionsColumn).should("be.visible");
   }
   verifyIDNumberColumnDoesNotExist() {


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-11676
Endpoint: https://d2z6l48d6nb1n6.cloudfront.net/

### Details

Add row expansion with child components in the Waivers tab on the Submission Dashboard.

### Changes

- Add optional expansion feature to `PortalTable` component
- Turn it on for `PackageList` when on Waivers tab, collecting subrows from `children` key

### Implementation Notes

- Had to modify filter functionality to minimize the impact of a bug in React Table affecting subrows. The bug is still possible to trigger if you filter (or search) in a way that hides a subrow without hiding its parent, then remove those filter conditions. Apparently this will be fixed (or addressed in some way) in React Table version 8, but that just recently went into its first alpha release after almost a year of work.

### Test Plan

1. Log in as `statesubmitter@nightwatch.test`
2. Navigate to Packages -> Waivers
3. Verify that waiver package entries have a downward facing chevron at the very left side, and that it is faded out and unactionable unless that package has "child" components
4. Verify that when you click on the chevron icon, it reveals the "child" components with a distinct look from the "parent" components, and that when you click it a second time they are hidden once again.