### PR TITLE
OY2 15647 Tests

### DIFF
--- a/tests/cypress/cypress/integration/OY2_15647_State_User_can_Respond_to_RAI.feature
+++ b/tests/cypress/cypress/integration/OY2_15647_State_User_can_Respond_to_RAI.feature
@@ -1,0 +1,27 @@
+Feature: OY2-15647 State User can Respond to RAI
+    Scenario: Verify state user can access Respond to Medicaid SPA RAI for seatool
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        Then click on New Submission
+        And Click on State Plan Amendment SPA
+        And click on Respond to Medicaid SPA RAI
+        And verify ID field is empty and not disabled
+
+    Scenario: Verify state user can access Respond to CHIP SPA RAI for seatool
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        Then click on New Submission
+        And Click on State Plan Amendment SPA
+        And click on Respond to CHIP SPA RAI
+        And verify ID field is empty and not disabled
+
+    Scenario: Verify state user can access Respond to Waiver RAI for seatool
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        Then click on New Submission
+        And Click on Waiver Action
+        And click on Respond to Waiver RAI
+        And verify ID field is empty and not disabled

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -1571,3 +1571,15 @@ And("verify OneMAC CMS User Guide is valid", () => {
 And("verify OneMAC CMS Role Approver Guide is valid", () => {
   OneMacFAQPage.verifyCmsRoleApproverGuideLinkIsValid();
 });
+And("click on Respond to Medicaid SPA RAI", () => {
+  OneMacSubmissionTypePage.clickRespondToMedicaidSPARAI();
+});
+And("click on Respond to CHIP SPA RAI", () => {
+  OneMacSubmissionTypePage.clickRespondToCHIPSPARAI();
+});
+And("click on Respond to Waiver RAI", () => {
+  OneMacSubmissionTypePage.clickRespondToWaiverRAI();
+});
+And("verify ID field is empty and not disabled", () => {
+  medicaidSPARAIResponsePage.verifySPAIDFieldIsEmptyAndNotDisabled();
+});

--- a/tests/cypress/support/pages/MedicaidSPARAIResponsePage.js
+++ b/tests/cypress/support/pages/MedicaidSPARAIResponsePage.js
@@ -11,6 +11,8 @@ const RevisedAmendedStatePlanLanguageBTNUploadFile = "#uploader-input-0";
 const officialRAIResponseBTN = "//tbody/tr[2]/td[2]/label[1]";
 const officialRAIResponseBTNUploadFile = "#uploader-input-1";
 
+const spaIDField = "#transmittalNumber";
+
 export class MedicaidSPARAIResponsePage {
   uploadRAIResponseAddFile() {
     cy.get(RAIResponseAddFileBTN).click();
@@ -36,6 +38,9 @@ export class MedicaidSPARAIResponsePage {
     cy.xpath(officialRAIResponseBTN).click();
     const filePath = "/files/adobe.pdf";
     cy.get(officialRAIResponseBTNUploadFile).attachFile(filePath);
+  }
+  verifySPAIDFieldIsEmptyAndNotDisabled() {
+    cy.get(spaIDField).should("be.empty").and("not.be.disabled");
   }
 }
 export default MedicaidSPARAIResponsePage;

--- a/tests/cypress/support/pages/oneMacSubmissionTypePage.js
+++ b/tests/cypress/support/pages/oneMacSubmissionTypePage.js
@@ -1,19 +1,23 @@
 //Element is Xpath use cy.xpath instead of cy.get
-const statePlanAmendmentSPA =
-  '//h4[contains(text(),"State Plan Amendment (SPA)")]';
+const statePlanAmendmentSPA = '//h4[text()="State Plan Amendment (SPA)"]';
 //Element is Xpath use cy.xpath instead of cy.get
-const waiverAction = '//h4[contains(text(),"Waiver Action")]';
+const waiverAction = '//h4[text()="Waiver Action"]';
 //Element is Xpath use cy.xpath instead of cy.get
 const MedicalSPA = '//h4[text()="Medicaid SPA"]';
 //Element is Xpath use cy.xpath instead of cy.get
 const ChipSPA = '//h4[text()="CHIP SPA"]';
 //Element is Xpath use cy.xpath instead of cy.get
-const waiverActionWaiverAction = '//h4[contains(text(),"Waiver Action")]';
+const waiverActionWaiverAction = '//h4[text()="Waiver Action"]';
 //Element is Xpath use cy.xpath instead of cy.get
-const RequestTemporaryExtension =
-  '//h4[contains(text(),"Request Temporary Extension")]';
+const RequestTemporaryExtension = '//h4[text()="Request Temporary Extension"]';
 //Element is Xpath use cy.xpath instead of cy.get
-const AppendixKAmendment = '//h4[contains(text(),"Appendix K Amendment")]';
+const AppendixKAmendment = '//h4[text()="Appendix K Amendment"]';
+//Element is Xpath use cy.xpath instead of cy.get
+const respondToMedicaidSPARAI = '//h4[text()="Respond to Medicaid SPA RAI"]';
+//Element is Xpath use cy.xpath instead of cy.get
+const respondToCHIPSPARAI = '//h4[text()="Respond to CHIP SPA RAI"]';
+//Element is Xpath use cy.xpath instead of cy.get
+const respondToWaiverRAI = '//h4[text()="Respond to Waiver RAI"]';
 
 export class oneMacSubmissionTypePage {
   clickStatePlanAmendmentSPA() {
@@ -42,6 +46,15 @@ export class oneMacSubmissionTypePage {
 
   clickAppendixKAmendment() {
     cy.xpath(AppendixKAmendment).click();
+  }
+  clickRespondToMedicaidSPARAI() {
+    cy.xpath(respondToMedicaidSPARAI).click();
+  }
+  clickRespondToCHIPSPARAI() {
+    cy.xpath(respondToCHIPSPARAI).click();
+  }
+  clickRespondToWaiverRAI() {
+    cy.xpath(respondToWaiverRAI).click();
   }
 }
 export default oneMacSubmissionTypePage;


### PR DESCRIPTION
Checked for each form button and then verify the ID field is empty and editable.

Story: https://qmacbis.atlassian.net/browse/OY2-15647

### Test Plan
```
Feature: OY2-15647 State User can Respond to RAI
    Scenario: Verify state user can access Respond to Medicaid SPA RAI for seatool
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        Then click on New Submission
        And Click on State Plan Amendment SPA
        And click on Respond to Medicaid SPA RAI
        And verify ID field is empty and not disabled

    Scenario: Verify state user can access Respond to CHIP SPA RAI for seatool
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        Then click on New Submission
        And Click on State Plan Amendment SPA
        And click on Respond to CHIP SPA RAI
        And verify ID field is empty and not disabled

    Scenario: Verify state user can access Respond to Waiver RAI for seatool
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        Then click on New Submission
        And Click on Waiver Action
        And click on Respond to Waiver RAI
        And verify ID field is empty and not disabled
```
