### PR TITLE
OY2-15620: Updated SPA Package Details View - Card View with Actions

### DIFF
--- a/services/ui-src/src/DynamicRoutes.tsx
+++ b/services/ui-src/src/DynamicRoutes.tsx
@@ -163,13 +163,13 @@ export default function DynamicRoutes() {
         ))}
       {userRoleObj.canAccessDashboard && (
         <>
-          <Route exact path={ROUTES.DETAIL + "/:componentType/:packageId"}>
+          <Route exact path={ROUTES.DETAIL + "/:componentType/:componentId"}>
             <DetailView />
           </Route>
           <Route
             exact
             path={
-              ROUTES.DETAIL + "/:componentType/:componentTimestamp/:packageId"
+              ROUTES.DETAIL + "/:componentType/:componentTimestamp/:componentId"
             }
           >
             <DetailView />

--- a/services/ui-src/src/changeRequest/DetailView.js
+++ b/services/ui-src/src/changeRequest/DetailView.js
@@ -17,42 +17,34 @@ const AUTHORITY_LABELS = {
 
 const PAGE_DETAILS = {
   [ChangeRequest.TYPE.WAIVER_BASE]: {
-    pageTitle: "Base Waiver Details",
     detailsHeader: "Base Waiver",
     idLabel: "Waiver Number",
   },
   [ChangeRequest.TYPE.SPA]: {
-    pageTitle: "Medicaid SPA Details",
     detailsHeader: "Medicaid SPA",
     idLabel: "Medicaid SPA ID",
   },
   [ChangeRequest.TYPE.CHIP_SPA]: {
-    pageTitle: "CHIP SPA Details",
     detailsHeader: "CHIP SPA",
     idLabel: "CHIP SPA ID",
   },
   [ChangeRequest.TYPE.SPA_RAI]: {
-    pageTitle: "Response to RAI",
     detailsHeader: "RAI Response",
     idLabel: "Medicaid SPA ID",
   },
   [ChangeRequest.TYPE.CHIP_SPA_RAI]: {
-    pageTitle: "Response to RAI",
     detailsHeader: "RAI Response",
     idLabel: "CHIP SPA ID",
   },
   waiverrai: {
-    pageTitle: "Response to RAI",
     detailsHeader: "RAI Response",
     idLabel: "Waiver Number",
   },
   waiverrenewal: {
-    pageTitle: "Waiver Renewal",
     detailsHeader: "Waiver Renewal",
     idLabel: "Waiver Number",
   },
   waiveramendment: {
-    pageTitle: "Waiver Amendment",
     detailsHeader: "Waiver Amendment",
     idLabel: "Waiver Number",
   },
@@ -60,28 +52,24 @@ const PAGE_DETAILS = {
 
 /**
  * Given an id and the relevant submission type forminfo, show the details
- * @param {Object} formInfo - all the change request details specific to this submission
  */
 const DetailView = () => {
   // The browser history, so we can redirect to the home page
   const history = useHistory();
-  const { componentType, componentTimestamp, packageId } = useParams();
+  const { componentType, componentTimestamp, componentId } = useParams();
 
-  console.log("component type is: ", componentType);
-  console.log("component timestamp is: ", componentTimestamp);
   // so we show the spinner during the data load
   const [isLoading, setIsLoading] = useState(true);
 
   // The record we are using for the form.
   const [details, setDetails] = useState();
 
-  console.log("here in DetailView with Package ID: ", packageId);
   useEffect(() => {
     let mounted = true;
 
-    if (!packageId) return;
+    if (!componentId) return;
 
-    PackageApi.getDetail(packageId, componentType, componentTimestamp)
+    PackageApi.getDetail(componentId, componentType, componentTimestamp)
       .then((fetchedDetail) => {
         console.log("got the package: ", fetchedDetail);
         if (mounted) setDetails(fetchedDetail);
@@ -101,7 +89,7 @@ const DetailView = () => {
     return function cleanup() {
       mounted = false;
     };
-  }, [packageId, history, componentType, componentTimestamp]);
+  }, [componentId, history, componentType, componentTimestamp]);
 
   const renderChangeHistory = (changeHistory) => {
     return (
@@ -136,10 +124,7 @@ const DetailView = () => {
 
   return (
     <LoadingScreen isLoading={isLoading}>
-      <PageTitleBar
-        heading={PAGE_DETAILS[componentType].pageTitle}
-        enableBackNav
-      />
+      <PageTitleBar heading={componentId} enableBackNav />
       {details && (
         <article className="form-container">
           <div className="read-only-submission">
@@ -164,16 +149,16 @@ const DetailView = () => {
                     details.waiverAuthority}
                 </Review>
               )}
-              {details.packageId && (
+              {details.componentId && (
                 <Review heading={PAGE_DETAILS[componentType].idLabel}>
-                  {details.packageId}
+                  {details.componentId}
                 </Review>
               )}
             </section>
             <FileList
               heading="Attachments"
               uploadList={details.attachments}
-              zipId={details.packageId}
+              zipId={details.componentId}
             />
             {details.additionalInformation && (
               <section>

--- a/services/ui-src/src/changeRequest/DetailView.test.js
+++ b/services/ui-src/src/changeRequest/DetailView.test.js
@@ -12,7 +12,7 @@ jest.mock("react-router-dom", () => ({
     return {
       componentType: "spa",
       componentTimestamp: 16746532223,
-      packageId: "MI-11-1111",
+      componentId: "MI-11-1111",
     };
   },
   useHistory: jest.fn(),
@@ -59,7 +59,7 @@ describe("Detail View Tests", () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByText("Medicaid SPA Details", { selector: "h1" }))
+      expect(screen.getByText("MI-11-1111", { selector: "h1" }))
     );
   });
 });

--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -98,11 +98,7 @@ const PackageList = () => {
 
   const renderId = useCallback(
     ({ row, value }) => (
-      <Link
-        to={`/detail/${row.original.componentType}/${row.original.submissionTimestamp}/${value}`}
-      >
-        {value}
-      </Link>
+      <Link to={`/detail/${row.original.componentType}/${value}`}>{value}</Link>
     ),
     []
   );


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-15620
Endpoint: https://d2ejxjm0qtmoph.cloudfront.net

### Details
The first story to clean up our package details pages!  The story is specific to SPA details, but the page itself is component-neutral-yet-aware (right now)

### Changes
- Add a two-column card to top of details
- include allowed package actions in card
- no longer display extra details

### Test Plan
1. Log in as a user that can see SPA package details
2. View a SPA and verify the card matches what is asked for in the story
