### PR TITLE
OY2-16347 Tests

### DIFF
--- a/tests/cypress/cypress/integration/OY2_16347.feature
+++ b/tests/cypress/cypress/integration/OY2_16347.feature
@@ -1,0 +1,34 @@
+Feature: Temporary Extension form - Add warning messaging and relaxing the ID validation rules
+    Background: Reoccuring Steps
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        Then click on New Submission
+        And Click on Waiver Action
+        And Click on Request Temporary Extension
+
+
+    Scenario: Screen enhancement - verify warning messages have been relaxed
+        And Type waiver number with 4 characters on Request Waiver Temporary Extenstion Page
+        And verify error message is not present on Request Waiver Temporary Extenstion Page
+        And clear Waiver Number Input box on Request Waiver Temporary Extenstion Page
+        And Type Valid Waiver Number With 5 Characters
+        And verify error message is not present on Request Waiver Temporary Extenstion Page
+        And clear Waiver Number Input box on Request Waiver Temporary Extenstion Page
+        And type in invalid Waiver Number
+        And verify error message is not present on Request Waiver Temporary Extenstion Page
+        And clear Waiver Number Input box on Request Waiver Temporary Extenstion Page
+        And type waiver number with state abbreviation different from user on Request Waiver Temporary Extenstion Page
+        And verify that error message for incorrect Waiver Number is Displayed
+
+    Scenario: Create Temporary Extension with valid waiver number
+        And Type existing Unique Valid Waiver Number With 5 Characters
+        And Upload 1915 b 4 file
+        And Type "This test has a valid waiver number" in Summary Box
+        And Click on Submit Button
+
+    Scenario: Create Temporary Extension with invalid waiver number
+        And type in invalid Waiver Number
+        And Upload 1915 b 4 file
+        And Type "This test has an invalid waiver number" in Summary Box
+        And Click on Submit Button

--- a/tests/cypress/cypress/integration/OY2_3900_SPA_Waivers_FormatTest.feature
+++ b/tests/cypress/cypress/integration/OY2_3900_SPA_Waivers_FormatTest.feature
@@ -49,19 +49,6 @@ Feature: OY2_3900_SPA_Waivers_FormatTest
         And verify error message is present on New Waiver Page
         And Return to dashboard Page
 
-# Scenario: Verify the Waiver Number format on Temporary Extension Form
-#     And Click on Waiver Action
-#     And Click on Request Temporary Extension
-#     And Type waiver number with 4 characters on Request Waiver Temporary Extenstion Page
-#     And verify error message is not present on Request Waiver Temporary Extenstion Page
-#     And clear Waiver Number Input box on Request Waiver Temporary Extenstion Page
-#     And Type Valid Waiver Number With 5 Characters
-#     And verify error message is not present on Request Waiver Temporary Extenstion Page
-#     And clear Waiver Number Input box on Request Waiver Temporary Extenstion Page
-#     And type in invalid Waiver Number on Request Waiver Temporary Extenstion Page
-#     And verify that error message for incorrect Waiver Number is Displayed
-#     And Return to dashboard Page
-
 # Scenario: Verify the Waiver Number format on Appendix K Form
 #     And Click on Waiver Action
 #     And Click on Appendix K Amendment

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -454,6 +454,13 @@ And(
 );
 
 And(
+  "type waiver number with state abbreviation different from user on Request Waiver Temporary Extenstion Page",
+  () => {
+    OneMacRequestWaiverTemporaryExtension.inputWaiverNumber("JK");
+  }
+);
+
+And(
   "verify error message is not present on Request Waiver Temporary Extenstion Page",
   () => {
     OneMacRequestWaiverTemporaryExtension.verifyErrorMessageIsNotDisplayed();


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-16347

### Test Plan

```
Feature: Temporary Extension form - Add warning messaging and relaxing the ID validation rules
    Background: Reoccuring Steps
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        Then click on New Submission
        And Click on Waiver Action
        And Click on Request Temporary Extension


    Scenario: Screen enhancement - verify warning messages have been relaxed
        And Type waiver number with 4 characters on Request Waiver Temporary Extenstion Page
        And verify error message is not present on Request Waiver Temporary Extenstion Page
        And clear Waiver Number Input box on Request Waiver Temporary Extenstion Page
        And Type Valid Waiver Number With 5 Characters
        And verify error message is not present on Request Waiver Temporary Extenstion Page
        And clear Waiver Number Input box on Request Waiver Temporary Extenstion Page
        And type in invalid Waiver Number
        And verify error message is not present on Request Waiver Temporary Extenstion Page
        And clear Waiver Number Input box on Request Waiver Temporary Extenstion Page
        And type waiver number with state abbreviation different from user on Request Waiver Temporary Extenstion Page
        And verify that error message for incorrect Waiver Number is Displayed

    Scenario: Create Temporary Extension with valid waiver number
        And Type existing Unique Valid Waiver Number With 5 Characters
        And Upload 1915 b 4 file
        And Type "This test has a valid waiver number" in Summary Box
        And Click on Submit Button

    Scenario: Create Temporary Extension with invalid waiver number
        And type in invalid Waiver Number
        And Upload 1915 b 4 file
        And Type "This test has an invalid waiver number" in Summary Box
        And Click on Submit Button
```