### PR TITLE
allow dev login in VAL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,8 +121,8 @@ jobs:
       - name: set path
         run: |
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
-      - name: Set dev login flag
-        if: ${{ env.branch_name != 'production' && env.branch_name != 'master' }}
+      - name: Set dev login flag for all but production branch
+        if: ${{ env.branch_name != 'production' }}
         run: echo "ALLOW_DEV_LOGIN=true" >> $GITHUB_ENV
       - name: Set testing email address unless in prod
         if: ${{ env.branch_name != 'production' }}


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-16219
Endpoint: TBD

### Details

Allowing test users to access OneMAC in the VAL environment.

### Changes

- Set the flag in `master` branch builds in addition to `develop` and feature branches
- Users will now see the Packages link and CMS Reviewer role if they log in as a test user in VAL.

### Implementation Notes

- All other features we choose to flag with the `ALLOW_DEV_LOGIN` variable will be visible in VAL going forward.

### Test Plan

N/A