### PR TITLE
OY2-16617 Test fixes

### DIFF
--- a/tests/cypress/cypress/integration/OY2-13093_Submission_Dashboard_Filter_options_that_include_Dates.spec.feature
+++ b/tests/cypress/cypress/integration/OY2-13093_Submission_Dashboard_Filter_options_that_include_Dates.spec.feature
@@ -97,7 +97,7 @@ Feature: OY2-13093 Submission Dashboard - Filter options that include Dates
         And Click on Filter Button
         And verify 90th day column one is not na
         And verify 90th day column one is not Pending
-        
+
     Scenario: Filter by date submitted - Date picker
         Given I am on Login Page
         When Clicking on Development Login

--- a/tests/cypress/cypress/integration/OY2_11581_Add_an_Expiration_Date_Column_to_the_Package_Dashboard.spec.feature
+++ b/tests/cypress/cypress/integration/OY2_11581_Add_an_Expiration_Date_Column_to_the_Package_Dashboard.spec.feature
@@ -6,6 +6,9 @@ Feature: OY2-11581 Add an Expiration Date Column to the Package Dashboard
         When Login with state submitter user
         And click on Packages
         And click on the Waivers tab
+        And click show hide columns button
+        And click expiration date checkbox
+        And click show hide columns button
         And verify Expiration Date column is available to the immediate left to the status column
 
     # TODO: figure out how to seed a Waiver with an expiration date

--- a/tests/cypress/cypress/integration/OY2_11581_Add_an_Expiration_Date_Column_to_the_Package_Dashboard_part3.spec.feature
+++ b/tests/cypress/cypress/integration/OY2_11581_Add_an_Expiration_Date_Column_to_the_Package_Dashboard_part3.spec.feature
@@ -40,4 +40,7 @@ Feature: OY2-11581 Add an Expiration Date Column to the Package Dashboard part 3
         And verify submission Successful message
         And click on Packages
         And click on the Waivers tab
+        And click show hide columns button
+        And click expiration date checkbox
+        And click show hide columns button
         And verify expiration date column exists

--- a/tests/cypress/cypress/integration/OY2_11676_Package_Dashboard_New_Waiver_tab_layout.spec.feature
+++ b/tests/cypress/cypress/integration/OY2_11676_Package_Dashboard_New_Waiver_tab_layout.spec.feature
@@ -65,6 +65,9 @@ Feature: OY2-11676 Package Dashboard: New Waiver tab layout
         And verify date submitted column exists for the child
         And verify submitted by column exists for the child
         And verify actions column exists for the child
+        And click show hide columns button
+        And click expiration date checkbox
+        And click show hide columns button
         And verify expiration date column exists for the child
 
     Scenario: verify the caret is disabled for a row without children

--- a/tests/cypress/cypress/integration/OY2_13095_Package_Dashboard_Column_Picker.spec.feature
+++ b/tests/cypress/cypress/integration/OY2_13095_Package_Dashboard_Column_Picker.spec.feature
@@ -37,11 +37,12 @@ Feature: OY2-13095 Package Dashboard - Column Picker
         And verify status column exists
         And verify date submitted column exists
         And verify submitted by column exists
+        And verify expiration date column does not exist
         And verify actions column exists
         And click show hide columns button
         And verify 90th day exists
         And verify date submitted exists
-        And verify expiration date exists
+        And verify expiration date exists 
         And verify state exists
         And verify status exists
         And verify submitted by exists
@@ -80,7 +81,6 @@ Feature: OY2-13095 Package Dashboard - Column Picker
         And click show hide columns button
         And click 90th day checkbox
         And click date submitted checkbox
-        And click expiration date checkbox
         And click state checkbox
         And click status checkbox
         And click submitted by checkbox

--- a/tests/cypress/cypress/integration/OY2_15426_Package_Dashboard_Waiver_Family_Column_for_the_Waivers_tab.spec.feature
+++ b/tests/cypress/cypress/integration/OY2_15426_Package_Dashboard_Waiver_Family_Column_for_the_Waivers_tab.spec.feature
@@ -8,13 +8,11 @@ Feature: OY2-15426 Package Dashboard: Waiver Family Column for the Waivers tab
         And click show hide columns button
         And verify the Waiver Family checkbox does not exist
         And click on the Waivers tab
-        And verify the Waivers Family # column exists
-        And verify Waiver Family # column is sortable
-        And verify the Waiver family format in row one is SS.#### or SS.#####
+        And verify the Waiver Family # column does not exist
         And click show hide columns button
         And verify the Waivers Family checkbox exists
     
-    Scenario: Verify unchecking Waiver Family checkbox removes the column
+    Scenario: Verify unchecking Waiver Family checkbox adds the column
         Given I am on Login Page
         When Clicking on Development Login
         When Login with state submitter user
@@ -22,4 +20,7 @@ Feature: OY2-15426 Package Dashboard: Waiver Family Column for the Waivers tab
         And click on the Waivers tab
         And click show hide columns button
         And click the Waivers Family checkbox
-        And verify the Waiver Family # column does not exist
+        And click show hide columns button
+        And verify the Waivers Family # column exists
+        And verify Waiver Family # column is sortable
+        And verify the Waiver family format in row one is SS.#### or SS.#####

--- a/tests/cypress/cypress/integration/OY2_16294_Withdraw_action_on_waiver_component.spec.feature
+++ b/tests/cypress/cypress/integration/OY2_16294_Withdraw_action_on_waiver_component.spec.feature
@@ -48,7 +48,7 @@ Feature: Clicking withdraw package on a waiver component doesn't withdraw the co
         And search for Unique Valid Waiver Number with 5 Characters
         And wait for parent row expander to be enabled
         And click parent row expander
-        And click actions button on the child row
+        And click actions button for Temporary Extension in Child Row
         And click withdraw package button
         And click yes, withdraw package button
         And verify success message for Package Withdrawal

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -634,6 +634,9 @@ And("search for Unique Valid Waiver Number with 5 Characters", () => {
 And("click actions button on the child row", () => {
   OneMacPackagePage.clickActionsColumnForChild();
 });
+And("click actions button for Temporary Extension in Child Row", () => {
+  OneMacPackagePage.clickActionsBtnForTempExtensionChild();
+});
 And("verify child row has status {string}", (status) => {
   OneMacPackagePage.verifyChildRowStatusIs(status);
 });

--- a/tests/cypress/fixtures/sharedWaiverNumber.json
+++ b/tests/cypress/fixtures/sharedWaiverNumber.json
@@ -1,3 +1,3 @@
 {
-  "newWaiverNumber": "MD.89700"
+  "newWaiverNumber": "MD.24370"
 }

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -198,7 +198,7 @@ export class oneMacPackagePage {
 
   verifyValue() {
     cy.get(nintiethDayColumnFirstValue).contains(
-      /N\/A|Pending|((Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+(\d{1,2})\s+(\d{4}))/
+      /N\/A|Pending|Clock Stopped|((Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+(\d{1,2})\s+(\d{4}))/
     );
   }
 
@@ -590,6 +590,7 @@ export class oneMacPackagePage {
     cy.get(stateDropdownFilter).should("be.visible");
   }
   clickStateDropdownFilter() {
+    cy.get(stateDropdownFilter).wait(1000);
     cy.get(stateDropdownFilter).click();
   }
   verifyStateFilterSelectExists() {
@@ -608,7 +609,7 @@ export class oneMacPackagePage {
     cy.get(stateFilterSelect).should(
       "have.attr",
       "aria-describedby",
-      "react-select-2-placeholder"
+      "react-select-3-placeholder"
     );
   }
   typeStateToSelect(state) {

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -181,6 +181,8 @@ const parentRowExpander = "//tr[1]//button[@aria-label='Expand row']";
 const rowTwo = "tbody > tr:nth-child(2)";
 const packageRowTwoSubmittedBy = "#submitter-1";
 const packageRowTwoActions = "#packageActions-1";
+//Element is Xpath use cy.xpath instead of cy.get
+const allPackageRowActions = "//td[contains(@id,'packageActions')]";
 const packageRowTwoExpirationDate = "#expirationTimestamp-1";
 //Element is Xpath use cy.xpath instead of cy.get
 const childRows = "//tr[@class = 'child-row-expanded']";
@@ -786,6 +788,13 @@ export class oneMacPackagePage {
   }
   clickActionsColumnForChild() {
     cy.get(packageRowTwoActions).scrollIntoView().click();
+  }
+  clickActionsBtnForTempExtensionChild() {
+    cy.xpath(childRows)
+      .filter(":contains('Temporary Extension')")
+      .then(($el) => {
+        cy.wrap($el).find("button").first().scrollIntoView().click();
+      });
   }
   verifyexpirationDateColumnExistsForChild() {
     cy.get(packageRowTwoExpirationDate).should("be.visible");

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -26,7 +26,8 @@ const errorMessageForNoResultsFound =
   "//p[contains(text(),'Adjust your search and filter to find what you are')]";
 const stateColumnHeader = "#territoryColHeader";
 //Element is Xpath use cy.xpath instead of cy.get
-const arrowOnStateColumnHeader = "//thead/tr[1]/th[3]/span[1]/img[1]";
+const arrowOnStateColumnHeader =
+  "//th[@id='territoryColHeader']//span[@class='sort-icons-table']";
 //Element is Xpath use cy.xpath instead of cy.get
 const filterButton = "//button[contains(text(),'Filter')]";
 //Element is Xpath use cy.xpath instead of cy.get
@@ -97,7 +98,7 @@ const raiResponseSubmitted = "//span[contains(text(),'RAIResponse Submitted')]";
 //Element is Xpath use cy.xpath instead of cy.get
 const seaToolStatus1 = "//span[contains(text(),'SEATool Status: 1')]";
 //Element is Xpath use cy.xpath instead of cy.get
-const medicaidSPAInList = "//tbody/tr[1]/td[2]/span[1]";
+const medicaidSPAInList = "//tbody/tr[1]/td[3]/span[1]";
 //Element is Xpath use cy.xpath instead of cy.get
 const ShowHideColumnsBTN = "//button[contains(text(),'Show/Hide Columns')]";
 //Element is Xpath use cy.xpath instead of cy.get
@@ -138,10 +139,10 @@ const PackageWithdrawn =
   "//a[contains(text(),'MD-13-8218')]/../following-sibling::td[7]/button";
 //Element is Xpath use cy.xpath instead of cy.get
 const waiverTerminated =
-  "//a[contains(text(),'MD.10330')]/../following-sibling::td[9]/button";
+  "//a[text()='MD.10330']/../following-sibling::td[contains(@id,'packageActions')]/button";
 //Element is Xpath use cy.xpath instead of cy.get
 const Unsubmitted =
-  "//a[contains(text(),'MD.83420')]/../following-sibling::td[9]/button";
+  "//a[contains(text(),'MD.83420')]/../following-sibling::td[contains(@id,'packageActions')]/button";
 const stateDropdownFilter = "#territory-button";
 const stateFilterSelect = "#territory-filter-select";
 const statesSelected = "#territory";
@@ -267,7 +268,6 @@ export class oneMacPackagePage {
     cy.get(stateColumnHeader).should("be.visible");
   }
   verifyStateColumnIsSortable() {
-    cy.get(stateColumnHeader).click();
     cy.xpath(arrowOnStateColumnHeader).should("be.visible");
   }
   verifyfilterButtonExists() {
@@ -292,18 +292,21 @@ export class oneMacPackagePage {
     cy.xpath(ninetiethDayFilterDropdown).should("be.visible");
   }
   clickOn90thDayFilterDropDown() {
+    cy.xpath(ninetiethDayFilterDropdown).wait(1000);
     cy.xpath(ninetiethDayFilterDropdown).click();
   }
   verifyExpirationDateFilterDropDownExists() {
     cy.xpath(expirationDateFilterDropdown).should("be.visible");
   }
   clickOnExpirationDateFilterDropDown() {
+    cy.xpath(expirationDateFilterDropdown).wait(1000);
     cy.xpath(expirationDateFilterDropdown).click();
   }
   verifyDateSubmittedFilterDropDownExists() {
     cy.xpath(dateSubmittedFilterDropdown).should("be.visible");
   }
   clickOnDateSubmittedFilterDropDown() {
+    cy.xpath(dateSubmittedFilterDropdown).wait(1000);
     cy.xpath(dateSubmittedFilterDropdown).click();
   }
   verifyNinetiethDayNACheckboxExists() {
@@ -328,18 +331,21 @@ export class oneMacPackagePage {
     cy.get(ninetiethDayDatePickerFilter).should("exist");
   }
   clickOnNinetiethDayDatePickerFilter() {
+    cy.get(ninetiethDayDatePickerFilter).wait(1000);
     cy.get(ninetiethDayDatePickerFilter).click();
   }
   verifyExpirationDateDatePickerFilterExists() {
     cy.get(expirationDateDatePickerFilter).should("exist");
   }
   clickOnExpirationDateDatePickerFilter() {
+    cy.get(expirationDateDatePickerFilter).wait(1000);
     cy.get(expirationDateDatePickerFilter).click();
   }
   verifyDateSubmittedDatePickerFilterExists() {
     cy.xpath(dateSubmittedDatePickerFilter).last().should("exist");
   }
   clickOnDateSubmittedDatePickerFilter() {
+    cy.xpath(dateSubmittedDatePickerFilter).wait(1000);
     cy.xpath(dateSubmittedDatePickerFilter).last().click();
   }
   clickOnThisQuarterDatePickerBtn() {
@@ -384,9 +390,11 @@ export class oneMacPackagePage {
     cy.xpath(resetButton).should("be.visible");
   }
   clickOnResetButton() {
+    cy.xpath(resetButton).wait(1000);
     cy.xpath(resetButton).click();
   }
   clickTypeDropDown() {
+    cy.get(typeDropDown).wait(1000);
     cy.get(typeDropDown).click();
   }
   verifyWaiverRenewal1915bCheckBoxExists() {
@@ -402,6 +410,7 @@ export class oneMacPackagePage {
     cy.xpath(MedicaidSPACheckBox).should("be.visible");
   }
   clickstatusDropDown() {
+    cy.get(statusDropDown).wait(1000);
     cy.get(statusDropDown).click();
   }
   verifypackageApproveCheckBoxExists() {


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-16617
Endpoint: https://xxxx.cloudfront.net

### Test Plan
There are no new spec files created because by updating the tests, scenarios that could be covered by automation were complete. The rest of the files changed were to fix issues the automation ran into with these changes.

```
    Scenario: Verify that package dashboard waiver tab includes an Expiration Date column, which would be sortable and to the immediate left of the status column dashboard.
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And click on the Waivers tab
        And click show hide columns button
        And click expiration date checkbox
        And click show hide columns button
        And verify Expiration Date column is available to the immediate left to the status column

    Scenario: Respond to SPARAI and verify expiration date column does not exist
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        Then click on New Submission
        And Click on State Plan Amendment SPA
        And click on CHIP SPA
        And type in SPA ID in CHIP SPA page
        And Add file for Current State Plan
        And Add file for Amended State Plan Language
        And Add file for Cover Letter
        And Type Additonal Information Comments
        And Click on Submit Button
        And click on spa Respond to RAI
        And Add file for Revised Amended State Plan Language
        And Add file for Official RAI Response
        And Add Additional Comments
        And Click on Submit Button
        And verify submission Successful message after RAI
        And click on Packages
        And verify expiration date column does not exist

  Scenario: verify all waiver columns are displayed for a child row
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And click on the Waivers tab
        And search for "MD.10330"
        And wait for parent row expander to be enabled
        And click parent row expander
        And verify Waiver Number column exists for the child
        And verify type column exists for the child
        And verify state column exists for the child
        And verify 90th day column exists for the child
        And verify status column exists for the child
        And verify date submitted column exists for the child
        And verify submitted by column exists for the child
        And verify actions column exists for the child
        And click show hide columns button
        And click expiration date checkbox
        And click show hide columns button
        And verify expiration date column exists for the child

        Scenario: Waivers Tab - Screen enhancement
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And click on the Waivers tab
        And verify show hide columns button exists
        And verify IDNumber column exists
        And verify type column exists
        And verify state column exists
        And verify 90th day column exists
        And verify Waiver Number column exists
        And verify status column exists
        And verify date submitted column exists
        And verify submitted by column exists
        And verify expiration date column does not exist
        And verify actions column exists
        And click show hide columns button
        And verify 90th day exists
        And verify date submitted exists
        And verify expiration date exists 
        And verify state exists
        And verify status exists
        And verify submitted by exists
        And verify type exists
        And click show hide columns button

 Scenario: Verify unchecking Waiver Family checkbox adds the column
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And click on the Waivers tab
        And click show hide columns button
        And click the Waivers Family checkbox
        And click show hide columns button
        And verify the Waivers Family # column exists
        And verify Waiver Family # column is sortable
        And verify the Waiver family format in row one is SS.#### or SS.#####

```
