### PR TITLE
remove attachments from the top level updates

### DIFF
--- a/services/app-api/getDetail.test.js
+++ b/services/app-api/getDetail.test.js
@@ -1,22 +1,9 @@
 import dynamoDb from "./libs/dynamodb-lib";
-import { validateUserReadOnly } from "./utils/validateUser";
 import { getDetails } from "./getDetail";
 import { getUser } from "./getUser";
 import { RESPONSE_CODE } from "cmscommonlib";
 
-const testDoneBy = {
-  roleList: [
-    { role: "statesubmitter", status: "active", territory: "VA" },
-    { role: "statesubmitter", status: "active", territory: "MD" },
-  ],
-  email: "myemail@email.com",
-  firstName: "firsty",
-  lastName: "lasty",
-  fullName: "firsty lastly",
-};
-
 jest.mock("./getUser");
-jest.mock("./utils/validateUser");
 jest.mock("./libs/dynamodb-lib");
 
 beforeAll(() => {
@@ -26,16 +13,18 @@ beforeAll(() => {
 const validDoneBy = {
   roleList: [{ role: "statesubmitter", status: "active", territory: "MI" }],
   email: "myemail@email.com",
-  firstName: "firsty",
-  lastName: "lasty",
+  fullName: "firsty lastly",
+};
+
+const unauthorizedDoneBy = {
+  roleList: [{ role: "cmsroleapprover", status: "active", territory: "N/A" }],
+  email: "myemail@email.com",
   fullName: "firsty lastly",
 };
 
 const invalidDoneBy = {
   roleList: [{ role: "statesubmitter", status: "denied", territory: "MI" }],
   email: "myemail@email.com",
-  firstName: "firsty",
-  lastName: "lasty",
   fullName: "firsty lastly",
 };
 
@@ -46,7 +35,7 @@ const validEvent = {
     cNum: 18274923435,
   },
   pathParameters: {
-    id: "id",
+    id: "MInumber",
   },
 };
 const noPathEvent = {
@@ -61,40 +50,9 @@ beforeEach(() => {
   getUser.mockResolvedValue(validDoneBy);
 
   dynamoDb.get.mockResolvedValue({
-    Items: [
-      {
-        componentType: "waivernew",
-        componentId: "VA.1117",
-        submissionId: "9c5c8b70-53a6-11ec-b5bc-c9173b9fa278",
-        currentStatus: "Package In Review",
-        submitterId: "us-east-1:3211a6ff-043f-436b-8313-1b314582b2a5",
-        submitterName: "Angie Active",
-        submissionTimestamp: 1638473560098,
-        submitterEmail: "statesubmitteractive@cms.hhs.local",
-      },
-      {
-        componentType: "spa",
-        componentId: "VA-45-5913",
-        submissionId: "cb9978d0-5dfb-11ec-a7a2-c5995198046c",
-        currentStatus: "Disapproved",
-        submitterId: "us-east-1:86a190fe-b195-42bf-9685-9761bf0ff14b",
-        submitterName: "Statesubmitter Nightwatch",
-        submissionTimestamp: 1639609658284,
-        submitterEmail: "statesubmitter@nightwatch.test",
-      },
-      {
-        componentType: "chipspa",
-        componentId: "VA-33-2244-CHIP",
-        submissionId: "41103ac0-61aa-11ec-af2f-49cb8bfb8860",
-        currentStatus: "Submitted",
-        submitterId: "us-east-1:3211a6ff-043f-436b-8313-1b314582b2a5",
-        submitterName: "Angie Active",
-        submissionTimestamp: 1640014441278,
-        submitterEmail: "statesubmitteractive@cms.hhs.local",
-      },
-    ],
-    Count: 3,
-    ScannedCount: 3,
+    Item: {
+      field1: "one",
+    },
   });
 });
 
@@ -108,19 +66,42 @@ describe("handles errors and exceptions", () => {
         console.log("caught test error: ", error);
       });
   });
+
+  it("checks for valid user", async () => {
+    const expectedReturn = RESPONSE_CODE.USER_NOT_AUTHORIZED;
+    getUser.mockResolvedValueOnce(invalidDoneBy);
+
+    expect(getDetails(validEvent))
+      .resolves.toStrictEqual(expectedReturn)
+      .catch((error) => {
+        console.log("caught test error: ", error);
+      });
+  });
+
+  it("checks for authorized user", async () => {
+    const expectedReturn = RESPONSE_CODE.USER_NOT_AUTHORIZED;
+    getUser.mockResolvedValueOnce(unauthorizedDoneBy);
+
+    expect(getDetails(validEvent))
+      .resolves.toStrictEqual(expectedReturn)
+      .catch((error) => {
+        console.log("caught test error: ", error);
+      });
+  });
 });
 
 describe("component details are returned", () => {
+  it("returns empty object if no results", async () => {
+    dynamoDb.get.mockResolvedValueOnce({ notAnItem: "something" });
+
+    expect(getDetails(validEvent))
+      .resolves.toStrictEqual({})
+      .catch((error) => {
+        console.log("caught test error: ", error);
+      });
+  });
+
   it("returns details", async () => {
-    getUser.mockResolvedValue(testDoneBy);
-    validateUserReadOnly.mockReturnValue(true);
-
-    dynamoDb.get.mockResolvedValue({
-      Item: {
-        field1: "one",
-      },
-    });
-
     expect(getDetails(validEvent))
       .resolves.toStrictEqual({
         field1: "one",

--- a/services/app-api/utils/updateComponent.js
+++ b/services/app-api/utils/updateComponent.js
@@ -5,7 +5,6 @@ const topLevelUpdates = [
   "clockEndTimestamp",
   "expirationTimestamp",
   "currentStatus",
-  "attachments",
 ];
 
 export default async function updateComponent({


### PR DESCRIPTION
Story: More of a Figma observation
Endpoint: https://d2w5ecfqlh1f36.cloudfront.net/

### Details
When we created the data model, the Figmas depicted all package attachments rolled up into one attachments section, so that's how they were stored in the database.
New Figmas and stories are clearly different in that regard, with a "Base Supporting Documentation" section and Attachment sections under other component detail areas.

This PR removes the rollup of the attachments.

### Changes
- removed attachments as a top level attribute to be updated when a new submission is received

### Test Plan
1. Log in as submitter user
2. Submit a child component to a parent component viewable in OneMac
3. verify that the attachments are not in the "Base Supporting Documentation" section
