### PR TITLE
OY216322 Tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -196,6 +196,7 @@ jobs:
             OY2_16029_Submission_Form_Submit_button_updates_and_Warning_Text.spec.feature,
             OY2_16471_State_should_not_be_able_to_withdraw_RAI_Responses_in_OneMAC.spec.feature,
             OY2_14656_Left_Hand_Navigation_for_Package_Details_View.spec.feature,
+            OY2_16322_RAI_Response_for_SPA_package_view.spec.feature,
           ]
     steps:
       - name: set branch_name

--- a/tests/cypress/cypress/integration/OY2_16322_RAI_Response_for_SPA_package_view.spec.feature
+++ b/tests/cypress/cypress/integration/OY2_16322_RAI_Response_for_SPA_package_view.spec.feature
@@ -1,0 +1,36 @@
+Feature: RAI Response for SPA package view
+    Background: Reoccuring Steps
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And search for "MD-93-2234"
+
+    Scenario: Respond to RAI from the Package details page and then verify RAI info in package details page
+        And click the SPA ID link in the first row
+        And click on Respond to RAI package action
+        And Add file for RAI Response
+        And Click on Submit Button
+        And click on Packages
+        And search for "MD-93-2234"
+        And click the SPA ID link in the first row
+        And verify RAI Responses header exists
+        And verify the RAI Responses caret at the top of the list exists and is enabled
+        And verify the RAI response card at the top of the list exists
+        And verify the download button for the RAI response at the top of the list exists
+        And verify the first RAI response does not have Additional Info
+
+    Scenario: Respond to RAI from the Package page and then verify RAI info in package details page
+        And click the actions button in row one
+        And click the Respond to RAI button
+        And Add file for RAI Response
+        And Type Additonal Information Comments
+        And Click on Submit Button
+        And click on Packages
+        And search for "MD-93-2234"
+        And click the SPA ID link in the first row
+        And verify RAI Responses header exists
+        And verify the RAI Responses caret at the top of the list exists and is enabled
+        And verify the RAI response card at the top of the list exists
+        And verify the download button for the RAI response at the top of the list exists
+        And verify the first RAI response has Additional Info

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -636,7 +636,7 @@ And("click actions button on the child row", () => {
 });
 And("verify actions button on the child row is disabled", () => {
   OneMacPackagePage.verifyChildActionsBtnIsDisabled();
-  });
+});
 And("click actions button for Temporary Extension in Child Row", () => {
   OneMacPackagePage.clickActionsBtnForTempExtensionChild();
 });
@@ -1897,4 +1897,35 @@ And("verify user is on new spa page", () => {
 });
 And("verify user is on new waiver page", () => {
   OneMacSubmissionTypePage.verifyNewWaiverPage();
+});
+And("verify RAI Responses header exists", () => {
+  OneMacPackageDetailsPage.verifyRaiResponseHeaderExists();
+});
+And(
+  "verify the RAI Responses caret at the top of the list exists and is enabled",
+  () => {
+    OneMacPackageDetailsPage.verifyTopRaiRespCaretExistsAndEnabled();
+  }
+);
+And("verify the RAI response card at the top of the list exists", () => {
+  OneMacPackageDetailsPage.verifyTopRaiRespCardExists();
+});
+And(
+  "verify the download button for the RAI response at the top of the list exists",
+  () => {
+    OneMacPackageDetailsPage.verifyTopRaiRespDownloadBtnExistsAndEnabled();
+  }
+);
+And("verify the first RAI response does not have Additional Info", () => {
+  OneMacPackageDetailsPage.verifyTopRaiRespAddInfoDoesNotExist();
+});
+And("verify the first RAI response has Additional Info", () => {
+  OneMacPackageDetailsPage.verifyTopRaiRespAddInfoExists();
+});
+And;
+And("click the actions button in row one", () => {
+  OneMacPackagePage.clickPackageRowOneActionsBtn();
+});
+And("click the Respond to RAI button", () => {
+  OneMacPackagePage.clickRespondToRAIBtn();
 });

--- a/tests/cypress/support/pages/oneMacPackageDetailsPage.js
+++ b/tests/cypress/support/pages/oneMacPackageDetailsPage.js
@@ -1,3 +1,8 @@
+const topRaiRespCaret = "#sparai0_caret-button";
+const topRaiRespDownloadBtn = "#dl_sparai0";
+const topRaiRespCard = "#sparai0_caret";
+const topRaiRespAddInfo = "#addl-info-rai-0";
+
 //Elements are Xpath use cy.xpath instead of cy.xpath
 const detailsPage = "//div[@class='form-container']";
 const actionCard = "//div[@class='detail-card']";
@@ -13,6 +18,7 @@ const CHIPSPAIDHeader = "//h3[contains(text(),'SPA ID')]";
 const typeHeader = "//h3[contains(text(),'Type')]";
 const stateHeader = "//h3[text()='State']";
 const dateSubmittedHeader = "//h3[text()='Date Submitted']";
+const raiResponsesHeader = "//section//h2[text()='RAI Responses']";
 
 export class oneMacPackageDetailsPage {
   verifyPackageDetailsPageIsVisible() {
@@ -68,6 +74,26 @@ export class oneMacPackageDetailsPage {
   }
   verifyDateExists() {
     cy.xpath(dateSubmittedHeader).next().should("be.visible");
+  }
+  verifyRaiResponseHeaderExists() {
+    cy.xpath(raiResponsesHeader).scrollIntoView().should("be.visible");
+  }
+  verifyTopRaiRespCaretExistsAndEnabled() {
+    cy.get(topRaiRespCaret).scrollIntoView().should("be.visible");
+    cy.get(topRaiRespCaret).should("be.enabled");
+  }
+  verifyTopRaiRespCardExists() {
+    cy.get(topRaiRespCard).scrollIntoView().should("be.visible");
+  }
+  verifyTopRaiRespDownloadBtnExistsAndEnabled() {
+    cy.get(topRaiRespDownloadBtn).scrollIntoView().should("be.visible");
+    cy.get(topRaiRespDownloadBtn).should("be.enabled");
+  }
+  verifyTopRaiRespAddInfoDoesNotExist() {
+    cy.get(topRaiRespAddInfo).should("not.exist");
+  }
+  verifyTopRaiRespAddInfoExists() {
+    cy.get(topRaiRespAddInfo).scrollIntoView().should("be.visible");
   }
 }
 export default oneMacPackageDetailsPage;

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -192,6 +192,8 @@ const withdrawPackageConfirmBtn = "//button[contains(text(),'Yes, withdraw')]";
 const successMessage = "#alert-bar";
 //Element is Xpath use cy.xpath instead of cy.get
 const packageRowOneSPAIDLink = "//td[@id='componentId-0']//a";
+const packageRowOneActionsBtn = "//td[@id='packageActions-0']//button";
+const respondToRAIBtn = "//li[text()='Respond to RAI'][@aria-disabled='false']";
 
 export class oneMacPackagePage {
   verify90thDayColumn() {
@@ -835,6 +837,12 @@ export class oneMacPackagePage {
   }
   clickSPAIDLinkInFirstRow() {
     cy.xpath(packageRowOneSPAIDLink).click();
+  }
+  clickPackageRowOneActionsBtn() {
+    cy.xpath(packageRowOneActionsBtn).click();
+  }
+  clickRespondToRAIBtn() {
+    cy.xpath(respondToRAIBtn).click();
   }
 }
 export default oneMacPackagePage;


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-16322

### Test Plan

```
Feature: RAI Response for SPA package view
    Background: Reoccuring Steps
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And search for "MD-93-2234"

    Scenario: Respond to RAI from the Package details page and then verify RAI info in package details page
        And click the SPA ID link in the first row
        And click on Respond to RAI package action
        And Add file for RAI Response
        And Click on Submit Button
        And click on Packages
        And search for "MD-93-2234"
        And click the SPA ID link in the first row
        And verify RAI Responses header exists
        And verify the RAI Responses caret at the top of the list exists and is enabled
        And verify the RAI response card at the top of the list exists
        And verify the download button for the RAI response at the top of the list exists
        And verify the first RAI response does not have Additional Info

    Scenario: Respond to RAI from the Package page and then verify RAI info in package details page
        And click the actions button in row one
        And click the Respond to RAI button
        And Add file for RAI Response
        And Type Additonal Information Comments
        And Click on Submit Button
        And click on Packages
        And search for "MD-93-2234"
        And click the SPA ID link in the first row
        And verify RAI Responses header exists
        And verify the RAI Responses caret at the top of the list exists and is enabled
        And verify the RAI response card at the top of the list exists
        And verify the download button for the RAI response at the top of the list exists
        And verify the first RAI response has Additional Info
```
