### PR TITLE
create Additional Info page on detail view

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -198,6 +198,7 @@ jobs:
             OY2_14656_Left_Hand_Navigation_for_Package_Details_View.spec.feature,
             OY2_16322_RAI_Response_for_SPA_package_view.spec.feature,
             OY2_16707_CMS_Users_Denied_a_CRA_Role_loses_Read_Only_Access_to_OneMAC.spec.feature,
+            OY2_15984_Updated_SPA_Package_Details_View_Additional_Information_Page.spec.js,
           ]
     steps:
       - name: set branch_name

--- a/services/ui-src/src/components/PageTitleBar.js
+++ b/services/ui-src/src/components/PageTitleBar.js
@@ -22,6 +22,7 @@ const PageTitleBar = ({
   heading,
   rightSideContent,
   enableBackNav,
+  backTo,
   backNavConfirmationMessage,
 }) => {
   const history = useHistory();
@@ -35,9 +36,10 @@ const PageTitleBar = ({
     async (event) => {
       event.preventDefault();
       if (backNavConfirmationMessage) openCancelConfirmation();
+      else if (backTo) history.push(backTo);
       else history.goBack();
     },
-    [backNavConfirmationMessage, history, openCancelConfirmation]
+    [backNavConfirmationMessage, backTo, history, openCancelConfirmation]
   );
 
   return (
@@ -73,7 +75,7 @@ const PageTitleBar = ({
           acceptText="Leave Anyway"
           cancelText="Stay on Page"
           heading="Leave this page?"
-          onAccept={() => history.goBack()}
+          onAccept={() => (backTo ? history.push(backTo) : history.goBack())}
           onCancel={closeCancelConfirmation}
         >
           {backNavConfirmationMessage}

--- a/tests/cypress/cypress.json
+++ b/tests/cypress/cypress.json
@@ -1,9 +1,9 @@
 {
-  "baseUrl": "https://d2dr7dgo9g0124.cloudfront.net/",
+  "baseUrl": "https://d29q22ry23m267.cloudfront.net/",
   "redirectionLimit": 20,
   "retries": 2,
   "watchForFileChanges": true,
-  "testFiles": "**/*.feature",
+  "testFiles": ["**/*.feature", "**/*.spec.js"],
   "fixturesFolder": "fixtures",
   "pluginsFile": "plugins/index.js",
   "screenshotsFolder": "screenshots",
@@ -13,5 +13,7 @@
   "supportFile": "support/index.js",
   "defaultCommandTimeout": 70000,
   "viewportWidth": 1440,
-  "viewportHeight": 900
+  "viewportHeight": 900,
+  "experimentalStudio": true,
+  "types": ["cypress", "cypress-axe"]
 }

--- a/tests/cypress/cypress/integration/OY2_15984_Updated_SPA_Package_Details_View_Additional_Information_Page.spec.js
+++ b/tests/cypress/cypress/integration/OY2_15984_Updated_SPA_Package_Details_View_Additional_Information_Page.spec.js
@@ -1,0 +1,21 @@
+describe("Updated SPA Package Details View - Additional Information Page", () => {
+  beforeEach(() => {
+    cy.visit("/");
+    cy.get("#devloginBtn").click();
+    cy.get("#email").type("statesubmitter@nightwatch.test");
+    cy.get("#password").type("Passw0rd!");
+    cy.get("#loginDevUserBtn").click();
+  });
+
+  it("Check if addition info exists for Waivers and SPA's", () => {
+    cy.get("#packageListLink").click();
+    cy.get("#componentId-0 > a").click();
+    cy.get(":nth-child(2) > .ds-c-vertical-nav__label").click();
+    cy.get(".ds-c-review__body").should("be.visible");
+    cy.get("#packageListLink").click();
+    cy.get("#show-waivers-button").click();
+    cy.get("#componentId-0 > a").click();
+    cy.get(":nth-child(2) > .ds-c-vertical-nav__label").click();
+    cy.get(".ds-c-review__body").should("be.visible");
+  });
+});

--- a/tests/cypress/support/pages/oneMacPackageDetailsPage.js
+++ b/tests/cypress/support/pages/oneMacPackageDetailsPage.js
@@ -21,7 +21,7 @@ const dateSubmittedHeader = "//h3[text()='Date Submitted']";
 const raiResponsesHeader = "//section//h2[text()='RAI Responses']";
 const packageOverviewNavBtn = "//button[text()='Package Overview']";
 const packageDetailsNavBtn =
-  "//li[contains(@class, 'nav')]//div[text()='Package Details']";
+  "//li[contains(@class, 'nav')]//a[text()='Package Details']";
 
 export class oneMacPackageDetailsPage {
   verifyPackageDetailsPageIsVisible() {


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-15984
Endpoint: https://d29q22ry23m267.cloudfront.net/

### Details

Add a new page to the details view (from package dashboard) to house the Additional Information.

### Changes

- Remove Add'l Info from main Package Details page
- Create new tab for Add'l Info and put it there

### Implementation Notes

- Had to modify `PageTitleBar` to support hash routing on the details page

### Test Plan

1. Log in as `statesubmitteractive` and to to the Packages page.
2. Click on any Medicaid SPA. Verify that there is now a second link in the left-side nav that reads "Additional Information", and that the "Additional Information" section in the existing "Package Details" page is no longer present.
3. Click on the "Additional Information" menu item. Verify that the "Package Details" are all removed from view, and that in their place you see a section with the heading "Additional Information" and the package summary as paragraph text below it. If there is no summary attached to the SPA package, there should be a message that reads "No Additional Information has been submitted."
4. Repeat steps 2 and 3 with a CHIP SPA and a Base Waiver.