### PR TITLE
OY2 16707: CMS Users Denied a CRA Role loses Read Only Access to OneMAC

### DIFF
--- a/loadTestUsers.py
+++ b/loadTestUsers.py
@@ -125,7 +125,7 @@ def seed_cognito(test_users, user_pool_id, password):
         elif user["role"].startswith("state"):
             role = "onemac-state-user"
         elif user["role"].startswith("cms") or user["role"] == "systemadmin":
-            role = "onemac-cms-user"
+            role = "none"
         elif user["role"] == "helpdesk":
             role = "onemac-helpdesk"
 

--- a/services/app-api/getAllByAuthorizedTerritories.js
+++ b/services/app-api/getAllByAuthorizedTerritories.js
@@ -77,6 +77,7 @@ async function stateSubmitterDynamoDbQuery(
 
 const usersWhoSeeEverything = new Set([
   USER_ROLE.HELPDESK,
+  USER_ROLE.DEFAULT_CMS_USER,
   USER_ROLE.CMS_REVIEWER,
   USER_ROLE.SYSTEM_ADMIN,
 ]);

--- a/services/app-api/getMyPackages.js
+++ b/services/app-api/getMyPackages.js
@@ -20,9 +20,9 @@ export const getMyPackages = async (email, group) => {
     .then((user) => {
       if (!user) throw RESPONSE_CODE.USER_NOT_AUTHORIZED;
 
-      const userRoleObj = getUserRoleObj(user?.roleList);
+      const userRoleObj = getUserRoleObj(user.roleList);
+      const territoryList = getActiveTerritories(user.roleList);
 
-      territoryList = getActiveTerritories(user?.roleList);
       if (!userRoleObj.canAccessDashboard || territoryList === []) {
         throw RESPONSE_CODE.USER_NOT_AUTHORIZED;
       }

--- a/services/app-api/getMyPackages.js
+++ b/services/app-api/getMyPackages.js
@@ -18,14 +18,13 @@ export const getMyPackages = async (email, group) => {
 
   return getUser(email)
     .then((user) => {
-      let territoryList = "this is for EUA users";
-      if (Object.keys(user).length > 0) {
-        const userRoleObj = getUserRoleObj(user?.roleList);
+      if (!user) throw RESPONSE_CODE.USER_NOT_AUTHORIZED;
 
-        territoryList = getActiveTerritories(user?.roleList);
-        if (!userRoleObj.canAccessDashboard || territoryList === []) {
-          throw RESPONSE_CODE.USER_NOT_AUTHORIZED;
-        }
+      const userRoleObj = getUserRoleObj(user?.roleList);
+
+      territoryList = getActiveTerritories(user?.roleList);
+      if (!userRoleObj.canAccessDashboard || territoryList === []) {
+        throw RESPONSE_CODE.USER_NOT_AUTHORIZED;
       }
 
       const baseParams = {

--- a/services/app-api/getUser.js
+++ b/services/app-api/getUser.js
@@ -2,7 +2,6 @@ import handler from "./libs/handler-lib";
 import dynamoDb from "./libs/dynamodb-lib";
 
 import { getUserRoleObj } from "cmscommonlib";
-import { ServerlessApplicationRepository } from "aws-sdk";
 
 /**
  * returns the User Table entry who's id is this email

--- a/services/app-api/getUser.js
+++ b/services/app-api/getUser.js
@@ -2,6 +2,7 @@ import handler from "./libs/handler-lib";
 import dynamoDb from "./libs/dynamodb-lib";
 
 import { getUserRoleObj } from "cmscommonlib";
+import { ServerlessApplicationRepository } from "aws-sdk";
 
 /**
  * returns the User Table entry who's id is this email
@@ -42,6 +43,10 @@ export const getUser = async (userEmail) => {
     cResult = await dynamoDb.get(cParams);
 
     result = await dynamoDb.query(params);
+
+    if (!result.Items) {
+      result = setTimeout(await dynamoDb.query(params), 1500);
+    }
   } catch (dbError) {
     console.log(`Error happened while reading from DB:  ${dbError}`);
     throw dbError;

--- a/services/app-api/one-seed.json
+++ b/services/app-api/one-seed.json
@@ -1,6 +1,51 @@
 [
   {
     "doneByName": "Teresa Test",
+    "status": "active",
+    "Latest": "3",
+    "GSI1sk": "Boss",
+    "email": "cmsreviewerrevoked@cms.hhs.local",
+    "fullName": "Ronald Revoked",
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "GSI1pk": "USER",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "sk": "v0#defaultcmsuser#N/A",
+    "pk": "cmsreviewerrevoked@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "cmsreviewerrevoked@cms.hhs.local",
+    "doneByName": "Ronald Revoked",
+    "date": "1617149285",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "active",
+    "sk": "v1#defaultcmsuser#N/A",
+    "pk": "cmsreviewerrevoked@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "doneByName": "Teresa Test",
+    "date": "1617149286",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "revoked",
+    "sk": "v2#defaultcmsuser#N/A",
+    "pk": "cmsreviewerrevoked@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "doneByName": "Teresa Test",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "active",
+    "sk": "v3#defaultcmsuser#N/A",
+    "pk": "cmsreviewerrevoked@cms.hhs.local"
+  },
+  {
+    "doneByName": "Teresa Test",
     "status": "revoked",
     "Latest": "1",
     "GSI1sk": "cmsroleapprover",
@@ -186,6 +231,41 @@
   },
   {
     "doneByName": "Systemadmin Nightwatch",
+    "status": "revoked",
+    "Latest": "2",
+    "GSI1sk": "Boss",
+    "email": "cmsreviewer@nightwatch.test",
+    "fullName": "CMSReviewer Nightwatch",
+    "doneByEmail": "systemadmin@nightwatch.test",
+    "GSI1pk": "USER",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "sk": "v0#defaultcmsuser#N/A",
+    "pk": "cmsreviewer@nightwatch.test"
+  },
+  {
+    "doneByEmail": "cmsreviewer@nightwatch.test",
+    "doneByName": "CMSReviewer Nightwatch",
+    "date": "1617148287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "active",
+    "sk": "v1#defaultcmsuser#N/A",
+    "pk": "cmsreviewer@nightwatch.test"
+  },
+  {
+    "doneByEmail": "systemadmin@nightwatch.test",
+    "doneByName": "Systemadmin Nightwatch",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "revoked",
+    "sk": "v2#defaultcmsuser#N/A",
+    "pk": "cmsreviewer@nightwatch.test"
+  },
+  {
+    "doneByName": "Systemadmin Nightwatch",
     "status": "active",
     "Latest": "2",
     "GSI1sk": "cmsroleapprover",
@@ -218,6 +298,31 @@
     "status": "active",
     "sk": "v2#cmsreviewer#N/A",
     "pk": "cmsreviewer@nightwatch.test"
+  },
+  {
+    "doneByName": "Teresa Test",
+    "status": "active",
+    "Latest": "1",
+    "GSI1sk": "Boss",
+    "email": "cmsreviewerpending@cms.hhs.local",
+    "fullName": "Pamela Pending",
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "GSI1pk": "USER",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "sk": "v0#defaultcmsuser#N/A",
+    "pk": "cmsreviewerpending@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "doneByName": "Teresa Test",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "active",
+    "sk": "v1#defaultcmsuser#N/A",
+    "pk": "cmsreviewerpending@cms.hhs.local"
   },
   {
     "doneByName": "Teresa Test",
@@ -316,6 +421,41 @@
   },
   {
     "doneByName": "Systemadmin Nightwatch",
+    "status": "revoked",
+    "Latest": "2",
+    "GSI1sk": "Boss",
+    "email": "cmsroleapprover@nightwatch.test",
+    "fullName": "CMSroleapprover Nightwatch",
+    "doneByEmail": "systemadmin@nightwatch.test",
+    "GSI1pk": "USER",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "sk": "v0#defaultcmsuser#N/A",
+    "pk": "cmsroleapprover@nightwatch.test"
+  },
+  {
+    "doneByEmail": "cmsroleapprover@nightwatch.test",
+    "doneByName": "CMSroleapprover Nightwatch",
+    "date": "1617148286",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "active",
+    "sk": "v1#defaultcmsuser#N/A",
+    "pk": "cmsroleapprover@nightwatch.test"
+  },
+  {
+    "doneByEmail": "systemadmin@nightwatch.test",
+    "doneByName": "Systemadmin Nightwatch",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "revoked",
+    "sk": "v2#defaultcmsuser#N/A",
+    "pk": "cmsroleapprover@nightwatch.test"
+  },
+  {
+    "doneByName": "Systemadmin Nightwatch",
     "status": "active",
     "Latest": "2",
     "GSI1sk": "Boss",
@@ -348,6 +488,41 @@
     "status": "active",
     "sk": "v2#cmsroleapprover#N/A",
     "pk": "cmsroleapprover@nightwatch.test"
+  },
+  {
+    "doneByName": "Teresa Test",
+    "status": "revoked",
+    "Latest": "1",
+    "GSI1sk": "Boss",
+    "email": "cmsroleapproveractive@cms.hhs.local",
+    "fullName": "Arnold Active",
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "GSI1pk": "USER",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "sk": "v0#defaultcmsuser#N/A",
+    "pk": "cmsroleapproveractive@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "cmsroleapproveractive@cms.hhs.local",
+    "doneByName": "Arnold Active",
+    "date": "1617149286",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "active",
+    "sk": "v1#defaultcmsuser#N/A",
+    "pk": "cmsroleapproveractive@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "doneByName": "Teresa Test",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "revoked",
+    "sk": "v2#defaultcmsuser#N/A",
+    "pk": "cmsroleapproveractive@cms.hhs.local"
   },
   {
     "doneByName": "Teresa Test",
@@ -511,8 +686,53 @@
   },
   {
     "doneByName": "Teresa Test",
+    "status": "active",
+    "Latest": "3",
+    "GSI1sk": "Boss",
+    "email": "cmsroleapproverrevoked@cms.hhs.local",
+    "fullName": "Rhonda Revoked",
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "GSI1pk": "USER",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "sk": "v0#defaultcmsuser#N/A",
+    "pk": "cmsroleapproverrevoked@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "doneByName": "Teresa Test",
+    "date": "1617147287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "active",
+    "sk": "v1#defaultcmsuser#N/A",
+    "pk": "cmsroleapproverrevoked@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "doneByName": "Teresa Test",
+    "date": "1617148287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
     "status": "revoked",
-    "Latest": "1",
+    "sk": "v2#defaultcmsuser#N/A",
+    "pk": "cmsroleapproverrevoked@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "doneByName": "Teresa Test",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "active",
+    "sk": "v3#defaultcmsuser#N/A",
+    "pk": "cmsroleapproverrevoked@cms.hhs.local"
+  },
+  {
+    "doneByName": "Teresa Test",
+    "status": "revoked",
+    "Latest": "3",
     "GSI1sk": "Boss",
     "email": "cmsroleapproverrevoked@cms.hhs.local",
     "fullName": "Rhonda Revoked",
@@ -527,11 +747,31 @@
   {
     "doneByEmail": "systemadmintest@cms.hhs.local",
     "doneByName": "Teresa Test",
+    "date": "1617147287",
+    "role": "cmsroleapprover",
+    "territory": "N/A",
+    "status": "pending",
+    "sk": "v1#cmsroleapprover#N/A",
+    "pk": "cmsroleapproverrevoked@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "doneByName": "Teresa Test",
+    "date": "1617148287",
+    "role": "cmsroleapprover",
+    "territory": "N/A",
+    "status": "active",
+    "sk": "v2#cmsroleapprover#N/A",
+    "pk": "cmsroleapproverrevoked@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "doneByName": "Teresa Test",
     "date": "1617149287",
     "role": "cmsroleapprover",
     "territory": "N/A",
     "status": "revoked",
-    "sk": "v1#cmsroleapprover#N/A",
+    "sk": "v3#cmsroleapprover#N/A",
     "pk": "cmsroleapproverrevoked@cms.hhs.local"
   },
   {
@@ -721,6 +961,31 @@
   },
   {
     "doneByName": "Teresa Test",
+    "status": "active",
+    "Latest": "3",
+    "GSI1sk": "Boss",
+    "email": "cmsreviewerdenied@cms.hhs.local",
+    "fullName": "Donny Denied",
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "GSI1pk": "USER",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "sk": "v0#defaultcmsuser#N/A",
+    "pk": "cmsreviewerdenied@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "cmsreviewerdenied@cms.hhs.local",
+    "doneByName": "Donny Denied",
+    "date": "1617148287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "active",
+    "sk": "v1#defaultcmsuser#N/A",
+    "pk": "cmsreviewerdenied@cms.hhs.local"
+  },
+  {
+    "doneByName": "Teresa Test",
     "status": "denied",
     "Latest": "1",
     "GSI1sk": "cmsroleapprover",
@@ -788,6 +1053,31 @@
     "status": "active",
     "sk": "v2#helpdesk#N/A",
     "pk": "helpdeskactive@cms.hhs.local"
+  },
+  {
+    "doneByName": "Teresa Test",
+    "status": "active",
+    "Latest": "1",
+    "GSI1sk": "Boss",
+    "email": "cmsroleapproverpending@cms.hhs.local",
+    "fullName": "Peter Pending",
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "GSI1pk": "USER",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "sk": "v0#defaultcmsuser#N/A",
+    "pk": "cmsroleapproverpending@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "cmsroleapproverpending@cms.hhs.local",
+    "doneByName": "Peter Pending",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "active",
+    "sk": "v1#defaultcmsuser#N/A",
+    "pk": "cmsroleapproverpending@cms.hhs.local"
   },
   {
     "doneByName": "Teresa Test",
@@ -873,6 +1163,41 @@
     "status": "pending",
     "sk": "v1#helpdesk#N/A",
     "pk": "helpdeskpending@cms.hhs.local"
+  },
+  {
+    "doneByName": "Teresa Test",
+    "status": "revoked",
+    "Latest": "2",
+    "GSI1sk": "Boss",
+    "email": "cmsrevieweractive@cms.hhs.local",
+    "fullName": "Amanda Active",
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "GSI1pk": "USER",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "sk": "v0#defaultcmsuser#N/A",
+    "pk": "cmsrevieweractive@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "cmsrevieweractive@cms.hhs.local",
+    "doneByName": "Amanda Active",
+    "date": "1617148287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "active",
+    "sk": "v1#defaultcmsuser#N/A",
+    "pk": "cmsrevieweractive@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "cmsrevieweractive@cms.hhs.local",
+    "doneByName": "Teresa Test",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "revoked",
+    "sk": "v2#defaultcmsuser#N/A",
+    "pk": "cmsrevieweractive@cms.hhs.local"
   },
   {
     "doneByName": "Teresa Test",
@@ -1183,6 +1508,31 @@
     "status": "revoked",
     "sk": "v3#helpdesk#N/A",
     "pk": "helpdeskrevoked@cms.hhs.local"
+  },
+  {
+    "doneByName": "Teresa Test",
+    "status": "active",
+    "Latest": "1",
+    "GSI1sk": "Boss",
+    "email": "cmsroleapproverdenied@cms.hhs.local",
+    "fullName": "Debbie Denied",
+    "doneByEmail": "systemadmintest@cms.hhs.local",
+    "GSI1pk": "USER",
+    "date": "1617149287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "sk": "v0#defaultcmsuser#N/A",
+    "pk": "cmsroleapproverdenied@cms.hhs.local"
+  },
+  {
+    "doneByEmail": "cmsroleapproverdenied@cms.hhs.local",
+    "doneByName": "Debbie Denied",
+    "date": "1617148287",
+    "role": "defaultcmsuser",
+    "territory": "N/A",
+    "status": "active",
+    "sk": "v1#defaultcmsuser#N/A",
+    "pk": "cmsroleapproverdenied@cms.hhs.local"
   },
   {
     "doneByName": "Teresa Test",

--- a/services/app-api/setContactInfo.js
+++ b/services/app-api/setContactInfo.js
@@ -1,8 +1,14 @@
-import { effectiveRoleForUser, RESPONSE_CODE, USER_ROLE } from "cmscommonlib";
+import {
+  effectiveRoleForUser,
+  RESPONSE_CODE,
+  USER_ROLE,
+  USER_STATUS,
+} from "cmscommonlib";
 
 import handler from "./libs/handler-lib";
 import { getUser } from "./getUser";
 import { newUser } from "./utils/newUser";
+import { changeUserStatus } from "./utils/changeUserStatus";
 
 export const setContactInfo = async (event) => {
   let body,

--- a/services/app-api/setContactInfo.js
+++ b/services/app-api/setContactInfo.js
@@ -33,8 +33,9 @@ export const setContactInfo = async (event) => {
     }
     if (
       !effectiveRoleForUser(existingUser?.roleList) &&
-      !body.cmsRoles.includes("onemac-stateuser") &&
-      !body.cmsRoles.includes("onemac-helpdesk")
+      (!body.cmsRoles ||
+        (!body.cmsRoles.includes("onemac-stateuser") &&
+          !body.cmsRoles.includes("onemac-helpdesk")))
     ) {
       await changeUserStatus({
         email: body.email,

--- a/services/app-api/setContactInfo.js
+++ b/services/app-api/setContactInfo.js
@@ -34,7 +34,7 @@ export const setContactInfo = async (event) => {
     if (
       !effectiveRoleForUser(existingUser?.roleList) &&
       (!body.cmsRoles ||
-        (!body.cmsRoles.includes("onemac-stateuser") &&
+        (!body.cmsRoles.includes("onemac-state-user") &&
           !body.cmsRoles.includes("onemac-helpdesk")))
     ) {
       await changeUserStatus({

--- a/services/app-api/setContactInfo.test.js
+++ b/services/app-api/setContactInfo.test.js
@@ -2,29 +2,54 @@ import { RESPONSE_CODE } from "cmscommonlib";
 import { main, setContactInfo } from "./setContactInfo";
 import { getUser } from "./getUser";
 import { newUser } from "./utils/newUser";
+import { changeUserStatus } from "./utils/changeUserStatus";
 
 jest.mock("./getUser");
 jest.mock("./utils/newUser");
+jest.mock("./utils/changeUserStatus");
 
-getUser.mockImplementation(() => {
-  return null;
-});
-newUser.mockImplementation(() => {
-  return null;
+beforeEach(() => {
+  getUser.mockImplementation(() => {
+    return null;
+  });
+  newUser.mockImplementation(() => {
+    return null;
+  });
+  changeUserStatus.mockImplementation(() => {
+    return null;
+  });
 });
 
 const testEvent = { body: '{"email":"testEmail"}' };
 
-it("errors when user exists", async () => {
+it("handles JSON.parse exceptions", async () => {
+  const badParse = "bleh";
+  const expectedReturn = RESPONSE_CODE.USER_SUBMISSION_FAILED;
+  expect(setContactInfo(badParse))
+    .resolves.toStrictEqual(expectedReturn)
+    .catch((error) => {
+      console.log("caught test error: ", error);
+    });
+});
+
+it("returns immediately when user exists", async () => {
   getUser.mockImplementationOnce(() => {
-    return { email: "testemail", fullName: "I exist" };
+    return {
+      email: "testemail",
+      fullName: "I exist",
+      roleList: [{ status: "aStatus", role: "aRole", territory: "N/A" }],
+    };
   });
 
   const expectedReturn = RESPONSE_CODE.USER_EXISTS;
-  expect(setContactInfo(testEvent)).resolves.toStrictEqual(expectedReturn);
+  expect(setContactInfo(testEvent))
+    .resolves.toStrictEqual(expectedReturn)
+    .catch((error) => {
+      console.log("caught test error: ", error);
+    });
 });
 
-it("returns User Submitted when complete", async () => {
+it("returns User Submitted with new state user", async () => {
   const expectedReturn = {
     statusCode: 200,
     body: JSON.stringify(RESPONSE_CODE.USER_SUBMITTED),
@@ -33,14 +58,31 @@ it("returns User Submitted when complete", async () => {
       "Access-Control-Allow-Credentials": true,
     },
   };
+  const validStateUserEvent = {
+    body: '{"email":"testEmail","cmsRoles":"onemac-stateuser"}',
+  };
 
-  expect(main(testEvent)).resolves.toStrictEqual(expectedReturn);
+  expect(main(validStateUserEvent))
+    .resolves.toStrictEqual(expectedReturn)
+    .catch((error) => {
+      console.log("caught test error: ", error);
+    });
 });
 
-it("handles JSON.parse exceptions", async () => {
-  const badParse = "bleh";
-  const expectedReturn = RESPONSE_CODE.USER_SUBMISSION_FAILED;
-  expect(setContactInfo(badParse))
+it("returns User Submitted with new cms user", async () => {
+  const expectedReturn = {
+    statusCode: 200,
+    body: JSON.stringify(RESPONSE_CODE.USER_SUBMITTED),
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Credentials": true,
+    },
+  };
+  const validStateUserEvent = {
+    body: '{"email":"testEmail","cmsRoles":"onemac-notstateuser"}',
+  };
+
+  expect(main(validStateUserEvent))
     .resolves.toStrictEqual(expectedReturn)
     .catch((error) => {
       console.log("caught test error: ", error);

--- a/services/app-api/updateUserStatus.js
+++ b/services/app-api/updateUserStatus.js
@@ -4,6 +4,7 @@ import {
   territoryMap,
   roleLabels,
   APPROVING_USER_ROLE,
+  USER_ROLE,
 } from "cmscommonlib";
 import handler from "./libs/handler-lib";
 import sendEmail from "./libs/email-lib";
@@ -105,6 +106,21 @@ export const updateUserStatus = async (event) => {
       if (role !== body.role && status === USER_STATUS.ACTIVE) {
         await doUpdate(
           { ...body, role, territory, status: USER_STATUS.REVOKED },
+          doneBy,
+          doneTo
+        );
+      }
+    }
+  }
+
+  if (
+    body.status === USER_STATUS.DENIED ||
+    body.status === USER_STATUS.REVOKED
+  ) {
+    for (const { role, territory } of doneTo.roleList) {
+      if (role === USER_ROLE.DEFAULT_CMS_USER) {
+        await doUpdate(
+          { ...body, role, territory, status: USER_STATUS.ACTIVE },
           doneBy,
           doneTo
         );

--- a/services/app-api/utils/changeUserStatus.js
+++ b/services/app-api/utils/changeUserStatus.js
@@ -5,10 +5,10 @@ export const buildSK = (role, territory) => {
   switch (role) {
     case USER_ROLE.STATE_SUBMITTER:
       return `${USER_ROLE.STATE_SYSTEM_ADMIN}#${territory}`;
-    case USER_ROLE.DEFAULT_CMS_USER:
     case USER_ROLE.CMS_REVIEWER:
     case USER_ROLE.STATE_SYSTEM_ADMIN:
       return USER_ROLE.CMS_ROLE_APPROVER;
+    case USER_ROLE.DEFAULT_CMS_USER:
     default:
       return "Boss";
   }

--- a/services/app-api/utils/changeUserStatus.js
+++ b/services/app-api/utils/changeUserStatus.js
@@ -1,12 +1,14 @@
 import dynamoDb from "../libs/dynamodb-lib";
+import { USER_ROLE, USER_STATUS } from "cmscommonlib";
 
 export const buildSK = (role, territory) => {
   switch (role) {
-    case "statesubmitter":
-      return `statesystemadmin#${territory}`;
-    case "cmsreviewer":
-    case "statesystemadmin":
-      return "cmsroleapprover";
+    case USER_ROLE.STATE_SUBMITTER:
+      return `${USER_ROLE.STATE_SYSTEM_ADMIN}#${territory}`;
+    case USER_ROLE.DEFAULT_CMS_USER:
+    case USER_ROLE.CMS_REVIEWER:
+    case USER_ROLE.STATE_SYSTEM_ADMIN:
+      return USER_ROLE.CMS_ROLE_APPROVER;
     default:
       return "Boss";
   }
@@ -23,8 +25,6 @@ export const changeUserStatus = async ({
   status,
 }) => {
   // add a new v0 and v latest
-
-  // update contactInfo GSI
   try {
     const updateParams = {
       TableName: process.env.oneMacTableName,
@@ -90,6 +90,7 @@ export const changeUserStatus = async ({
     throw e;
   }
 
+  // update contactInfo GSI
   const contactParams = {
     TableName: process.env.oneMacTableName,
     Key: {
@@ -97,7 +98,7 @@ export const changeUserStatus = async ({
       sk: "ContactInfo",
     },
   };
-  if (role !== "statesubmitter" && status === "active") {
+  if (role !== USER_ROLE.STATE_SUBMITTER && status === USER_STATUS.ACTIVE) {
     contactParams.UpdateExpression = "SET GSI1pk = :newPk, GSI1sk = :newSk";
     contactParams.ExpressionAttributeValues = {
       ":newPk": `${role}#${territory}`,

--- a/services/common/index.js
+++ b/services/common/index.js
@@ -70,6 +70,7 @@ export const USER_ROLE = {
   STATE_SUBMITTER: "statesubmitter",
   CMS_REVIEWER: "cmsreviewer",
   STATE_SYSTEM_ADMIN: "statesystemadmin",
+  DEFAULT_CMS_USER: "defaultcmsuser",
   CMS_ROLE_APPROVER: "cmsroleapprover",
   SYSTEM_ADMIN: "systemadmin",
   HELPDESK: "helpdesk",
@@ -79,6 +80,7 @@ export const APPROVING_USER_ROLE = {
   [USER_ROLE.STATE_SUBMITTER]: USER_ROLE.STATE_SYSTEM_ADMIN,
   [USER_ROLE.STATE_SYSTEM_ADMIN]: USER_ROLE.CMS_ROLE_APPROVER,
   [USER_ROLE.CMS_ROLE_APPROVER]: USER_ROLE.SYSTEM_ADMIN,
+  [USER_ROLE.DEFAULT_CMS_USER]: USER_ROLE.CMS_ROLE_APPROVER,
   [USER_ROLE.HELPDESK]: USER_ROLE.SYSTEM_ADMIN,
   [USER_ROLE.CMS_REVIEWER]: USER_ROLE.CMS_ROLE_APPROVER,
 };
@@ -86,28 +88,6 @@ export const APPROVING_USER_ROLE = {
 export const HELPING_USER_ROLE = {
   ...APPROVING_USER_ROLE,
   [USER_ROLE.SYSTEM_ADMIN]: USER_ROLE.HELP_DESK,
-};
-
-export const tableRoles = {
-  [USER_ROLE.STATE_SYSTEM_ADMIN]: [USER_ROLE.STATE_SUBMITTER],
-  [USER_ROLE.CMS_ROLE_APPROVER]: [
-    USER_ROLE.STATE_SYSTEM_ADMIN,
-    USER_ROLE.CMS_REVIEWER,
-  ],
-  [USER_ROLE.HELPDESK]: [
-    USER_ROLE.STATE_SUBMITTER,
-    USER_ROLE.CMS_REVIEWER,
-    USER_ROLE.STATE_SYSTEM_ADMIN,
-    USER_ROLE.CMS_ROLE_APPROVER,
-    USER_ROLE.HELPDESK,
-  ],
-  [USER_ROLE.SYSTEM_ADMIN]: [
-    USER_ROLE.STATE_SUBMITTER,
-    USER_ROLE.CMS_REVIEWER,
-    USER_ROLE.STATE_SYSTEM_ADMIN,
-    USER_ROLE.CMS_ROLE_APPROVER,
-    USER_ROLE.HELPDESK,
-  ],
 };
 
 /**
@@ -126,6 +106,7 @@ export const USER_STATUS = {
 export const roleLabels = {
   [USER_ROLE.STATE_SUBMITTER]: "State Submitter",
   [USER_ROLE.STATE_SYSTEM_ADMIN]: "State System Admin",
+  [USER_ROLE.DEFAULT_CMS_USER]: "CMS Read-only User",
   [USER_ROLE.CMS_ROLE_APPROVER]: "CMS Role Approver",
   [USER_ROLE.CMS_REVIEWER]: "CMS Reviewer",
   [USER_ROLE.SYSTEM_ADMIN]: "CMS System Admin",
@@ -178,6 +159,14 @@ export class Role {
 }
 
 class DefaultUser extends Role {
+  constructor() {
+    super();
+    this.canAccessDashboard = true;
+    this.canDownloadCsv = true;
+  }
+}
+
+class DefaultCMSUser extends Role {
   constructor() {
     super();
     this.canAccessDashboard = true;
@@ -299,6 +288,7 @@ export const getUserRoleObj = (roleInfo) => {
     [USER_ROLE.STATE_SUBMITTER]: StateSubmitter,
     [USER_ROLE.STATE_SYSTEM_ADMIN]: StateSystemAdmin,
     [USER_ROLE.CMS_ROLE_APPROVER]: CmsRoleApprover,
+    [USER_ROLE.DEFAULT_CMS_USER]: DefaultCMSUser,
     [USER_ROLE.SYSTEM_ADMIN]: SystemAdmin,
     [USER_ROLE.HELPDESK]: Helpdesk,
     [USER_ROLE.CMS_REVIEWER]: CmsReviewer,

--- a/services/common/index.js
+++ b/services/common/index.js
@@ -296,9 +296,9 @@ export const getUserRoleObj = (roleInfo) => {
 };
 
 export const getActiveTerritories = (roleList) => {
-  let activeTerritories = [];
+  let activeTerritories = ["N/A"];
 
-  if (roleList && Object.keys(roleList).length > 0) {
+  if (roleList && roleList.length > 0) {
     activeTerritories = roleList
       .filter(({ status }) => status === USER_STATUS.ACTIVE)
       .map(({ territory }) => territory);

--- a/services/ui-src/src/App.test.js
+++ b/services/ui-src/src/App.test.js
@@ -3,8 +3,10 @@ import { act } from "react-dom/test-utils";
 import { render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { Auth } from "aws-amplify";
+import UserDataApi from "./utils/UserDataApi";
 
 import { App } from "./App";
+import { RESPONSE_CODE } from "cmscommonlib";
 
 jest.mock("aws-amplify");
 jest.mock("./utils/UserDataApi");
@@ -16,6 +18,26 @@ beforeEach(() => {
     signInUserSession: { idToken: { payload: {} } },
   });
   Auth.configure.mockReturnValue({ oauth: {} });
+  UserDataApi.userProfile.mockResolvedValue({
+    phoneNumber: "555.12wer",
+    email: "anemail",
+    firstName: "Unita",
+    lastName: "Testing",
+    fullName: "Unita Testing",
+    roleList: [
+      { role: "cmsroleapprover", territory: "N/A", status: "revoked" },
+      { role: "defaultcmsuser", territory: "N/A", status: "active" },
+    ],
+    validRoutes: [
+      "/",
+      "/profile",
+      "/devlogin",
+      "/FAQ",
+      "/dashboard",
+      "/packagelist",
+    ],
+  });
+  UserDataApi.setContactInfo.mockResolvedValue(RESPONSE_CODE.USER_EXISTS);
 });
 
 it("renders without crashing", async () => {
@@ -28,6 +50,10 @@ it("renders without crashing", async () => {
 });
 
 it("handles error on fetch", async () => {
+  Auth.currentAuthenticatedUser.mockImplementationOnce(() => {
+    throw "an Error";
+  });
+
   render(
     <MemoryRouter>
       <App />

--- a/services/ui-src/src/App.tsx
+++ b/services/ui-src/src/App.tsx
@@ -113,11 +113,11 @@ export function App() {
           cmsRoles,
         });
         if (retResponse === RESPONSE_CODE.USER_SUBMITTED) {
-          window.location.reload();
+          await setUserInfo();
         }
       }
     })();
-  }, [email, firstName, lastName, cmsRoles]);
+  }, [email, firstName, lastName, cmsRoles, setUserInfo]);
 
   /**
    * Updates phone number in the user profile,

--- a/services/ui-src/src/App.tsx
+++ b/services/ui-src/src/App.tsx
@@ -117,7 +117,7 @@ export function App() {
         }
       }
     })();
-  }, [email, firstName, lastName]);
+  }, [email, firstName, lastName, cmsRoles]);
 
   /**
    * Updates phone number in the user profile,

--- a/services/ui-src/src/App.tsx
+++ b/services/ui-src/src/App.tsx
@@ -9,7 +9,11 @@ import UserDataApi from "./utils/UserDataApi";
 import { Routes } from "./Routes";
 import { Header } from "./components/Header";
 import { Footer } from "./components/Footer";
-import { effectiveRoleForUser, getActiveTerritories } from "cmscommonlib";
+import {
+  effectiveRoleForUser,
+  getActiveTerritories,
+  RESPONSE_CODE,
+} from "cmscommonlib";
 
 const DEFAULT_AUTH_STATE: Omit<
   AppContextValue,
@@ -96,11 +100,23 @@ export function App() {
     setUserInfo();
   }, [setUserInfo]);
 
-  const { email, firstName, lastName } = authState.userProfile;
+  const { email, firstName, lastName, cmsRoles } = authState.userProfile;
   useEffect(() => {
     // When user's email or name changes, create a record of their info if it
     // does not already exist
-    if (email) UserDataApi.setContactInfo({ email, firstName, lastName });
+    (async () => {
+      if (email) {
+        const retResponse = await UserDataApi.setContactInfo({
+          email,
+          firstName,
+          lastName,
+          cmsRoles,
+        });
+        if (retResponse === RESPONSE_CODE.USER_SUBMITTED) {
+          window.location.reload();
+        }
+      }
+    })();
   }, [email, firstName, lastName]);
 
   /**

--- a/services/ui-src/src/libs/devUsers.js
+++ b/services/ui-src/src/libs/devUsers.js
@@ -16,6 +16,6 @@ export const devUsers = [
   "cmsroleapproverdenied@cms.hhs.local",
   "cmsroleapproverrevoked@cms.hhs.local",
   "systemadmintest@cms.hhs.local",
-  "cmsroleapproverunregistered@cms.hhs.local",
+  "cmsuserunregistered@cms.hhs.local",
   "statesubmitter@nightwatch.test",
 ];

--- a/services/ui-src/src/libs/testDataAppContext.js
+++ b/services/ui-src/src/libs/testDataAppContext.js
@@ -279,14 +279,14 @@ export const cmsUserNoAuthState = {
   isLoggedInAsDeveloper: false,
   userProfile: {
     cmsRoles: "onemac-cms-user",
-    email: "cmsroleapproverunregistered@cms.hhs.local",
+    email: "cmsuserunregistered@cms.hhs.local",
     firstName: "Unit",
     lastName: "Tester",
     userData: {
       firstName: "Unita",
       lastName: "Goodcode",
       roleList: [],
-      email: "cmsroleapproverunregistered@cms.hhs.local",
+      email: "cmsuserunregistered@cms.hhs.local",
       validRoutes: [
         "/",
         "/profile",

--- a/services/ui-src/src/utils/tableListExportToCSV.js
+++ b/services/ui-src/src/utils/tableListExportToCSV.js
@@ -42,16 +42,16 @@ const rowTransformer = {
     submissionTypes[row.type],
     row.territory,
     serializeDate(row.submittedAt),
-    row.submitterName,
+    JSON.stringify(row.submitterName),
   ],
   "user-table": (row) => [
-    row.fullName,
+    JSON.stringify(row.fullName),
     row.email,
-    row.stateCode,
-    userStatus[row.latest.status],
+    row.territory,
+    userStatus[row.status],
     roleLabels[row.role],
-    serializeDate(row.latest.date * 1000),
-    JSON.stringify(row.latest.doneByName),
+    serializeDate(row.date * 1000),
+    JSON.stringify(row.doneByName),
   ],
 };
 

--- a/services/ui-src/src/utils/tableListExportToCSV.js
+++ b/services/ui-src/src/utils/tableListExportToCSV.js
@@ -42,10 +42,10 @@ const rowTransformer = {
     submissionTypes[row.type],
     row.territory,
     serializeDate(row.submittedAt),
-    JSON.stringify(row.user.firstName + " " + row.user.lastName),
+    row.submitterName,
   ],
   "user-table": (row) => [
-    JSON.stringify(row.firstName + " " + row.lastName),
+    row.fullName,
     row.email,
     row.stateCode,
     userStatus[row.latest.status],

--- a/services/ui-src/src/utils/tableListExportToCSV.test.js
+++ b/services/ui-src/src/utils/tableListExportToCSV.test.js
@@ -44,7 +44,7 @@ it("formats submission data", () => {
       territory: "ZZ",
 
       submittedAt: 1234567898765,
-      user: { firstName: "Me", lastName: "Myself" },
+      submitterName: "Me Myself",
     },
   ]);
   expect(output.split("\n")[1].trim()).toBe(
@@ -53,22 +53,18 @@ it("formats submission data", () => {
 });
 
 it("formats user data", () => {
-  // format for user data has changed, this test is no longer valid
-  // const output = tableToCSV("user-table", [
-  //   {
-  //     firstName: "You",
-  //     lastName: "Yourself",
-  //     email: "you@example.com",
-  //     stateCode: "ZZ",
-  //     latest: {
-  //       date: 987654321,
-  //       status: "pending",
-  //       doneByName: "Someone Else",
-  //     },
-  //     role: "statesubmitter",
-  //   },
-  // ]);
-  // expect(output.split("\n")[1].trim()).toBe(
-  //   '"You Yourself",you@example.com,ZZ,Pending,State Submitter,"Apr 19, 2001","Someone Else"'
-  // );
+  const output = tableToCSV("user-table", [
+    {
+      fullName: "You Yourself",
+      email: "you@example.com",
+      territory: "ZZ",
+      date: 987654321,
+      status: "pending",
+      doneByName: "Someone Else",
+      role: "statesubmitter",
+    },
+  ]);
+  expect(output.split("\n")[1].trim()).toBe(
+    '"You Yourself",you@example.com,ZZ,Pending,State Submitter,"Apr 19, 2001","Someone Else"'
+  );
 });


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-16707
Endpoint: https://d36mye51rm55p.cloudfront.net/

### Details
The CMS default user should be added as a new role in OneMAC in order for approval/revoking/default/fallthrough behaviors to match the other role types.

Also, a lot of problems arose because the default users were being shown an empty submissions list on their first access, which prompted them to ask for the CRA role (and then get denied)

### Changes
- added defaultcmsuser as a role
- Created label for role as "CMS Read-only User"
- "Approver" is CMS System Admin
- added a second query after a pause for the roleList if the first query comes up empty
- reload the app if the user was created.

### Implementation Notes
- had to do some extra checking to get rid of the "no submissions" screen
- so.... fixing the test coverage made it easy to find/fix the csv button, though I haven't tested that yet.....

### Test Plan

1. Login as an unregistered user
2. View the default CMS features (Dashboard, user profile)
3. Request the CMS Role Approver Role
4. Continue to see default CMS features
5. Use system admin to grant CRA role
6. See CRA features
7. Use system admin to revoke CRA role
8. See default features again
