### PR TITLE
OY2 16869: Export to Excel button not working from the User Management Page

### DIFF
--- a/services/common/changeRequest.js
+++ b/services/common/changeRequest.js
@@ -19,6 +19,17 @@ export const TYPE = {
   WAIVER_APP_K: "waiverappk",
 };
 
+export const LABEL = {
+  [TYPE.CHIP_SPA]: "CHIP SPA",
+  [TYPE.SPA]: "Medicaid SPA",
+  [TYPE.WAIVER_BASE]: "1915(b) Base Waiver",
+  [TYPE.WAIVER_RENEWAL]: "1915(b) Waiver Renewal",
+  [TYPE.WAIVER_APP_K]: "1915(c) Appendix K Amendment",
+  [TYPE.WAIVER_EXTENSION]: "1915(b) Temporary Extension",
+  [TYPE.WAIVER_AMENDMENT]: "1915(b) Amendment",
+  [TYPE.WAIVER_RAI]: "1915(b) RAI Response",
+};
+
 export const MY_PACKAGE_GROUP = {
   [TYPE.CHIP_SPA]: PACKAGE_GROUP.SPA,
   [TYPE.SPA]: PACKAGE_GROUP.SPA,

--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -104,17 +104,7 @@ const PackageList = () => {
   );
 
   const getType = useCallback(
-    ({ componentType }) =>
-      ({
-        [ChangeRequest.TYPE.CHIP_SPA]: "CHIP SPA",
-        [ChangeRequest.TYPE.SPA]: "Medicaid SPA",
-        [ChangeRequest.TYPE.WAIVER_BASE]: "1915(b) Base Waiver",
-        [ChangeRequest.TYPE.WAIVER_RENEWAL]: "1915(b) Waiver Renewal",
-        [ChangeRequest.TYPE.WAIVER_APP_K]: "1915(c) Appendix K Amendment",
-        [ChangeRequest.TYPE.WAIVER_EXTENSION]: "1915(b) Temporary Extension",
-        [ChangeRequest.TYPE.WAIVER_AMENDMENT]: "1915(b) Amendment",
-        [ChangeRequest.TYPE.WAIVER_RAI]: "1915(b) RAI Response",
-      }[componentType] ?? []),
+    ({ componentType }) => ChangeRequest.LABEL[componentType] ?? [],
     []
   );
 
@@ -332,7 +322,7 @@ const PackageList = () => {
       className="new-submission-button"
       onClick={(e) => {
         e.preventDefault();
-        tableListExportToCSV("submission-table", packageList, "SubmissionList");
+        tableListExportToCSV("package-dashboard", packageList, `${tab}List`);
       }}
       inversed
     >

--- a/services/ui-src/src/utils/tableListExportToCSV.js
+++ b/services/ui-src/src/utils/tableListExportToCSV.js
@@ -1,8 +1,10 @@
-import { roleLabels } from "cmscommonlib";
+import { roleLabels, ChangeRequest } from "cmscommonlib";
 import { format } from "date-fns";
 
 const CSV_HEADER = {
   "submission-table":
+    "SPA ID/Waiver Number,Type,State,Date Submitted,Submitted By",
+  "package-dashboard":
     "SPA ID/Waiver Number,Type,State,Date Submitted,Submitted By",
   "user-table": "Name,Email,State,Status,Role,Last Modified,Modified By",
 };
@@ -42,6 +44,13 @@ const rowTransformer = {
     submissionTypes[row.type],
     row.territory,
     serializeDate(row.submittedAt),
+    JSON.stringify(row.user.firstName + " " + row.user.lastName),
+  ],
+  "package-dashboard": (row) => [
+    row.componentId,
+    ChangeRequest.LABEL[row.componentType],
+    row.componentId ? row.componentId.toString().substring(0, 2) : "--",
+    serializeDate(row.submissionTimestamp),
     JSON.stringify(row.submitterName),
   ],
   "user-table": (row) => [


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-16869
Endpoint: https://d1tqzrme6sel0.cloudfront.net/

### Details
Changes made to the user tables broke the Export to Excel(CSV) button on the User Management page.  Fixes to that button broke the button on the Submission List Dashboard.  

### Changes
- added a new "export type" of package-dashboard
- returned the submission-list export type to use the same values as before
- modified the package dashboard to use the new export type

### Test Plan
1. Log in as a helpdesk or CMS system admin user
2. travel to Submission List dashboard and click "Export to Excel(CSV)"
3. Verify that the data matches the dashboard and is correctly labelled, etc
4. travel to the User Management dashboard and click "Export to Excel(CSV)"
5. Verify that the data matches the dashboard and is correctly labelled, etc
6. travel to the Package dashboard, SPA tab and click "Export to Excel(CSV)"
7. Verify that the data matches the dashboard and is correctly labelled, etc
8. travel to the Package dashboard, Waiver tab and click "Export to Excel(CSV)"
9. Verify that the data matches the dashboard and is correctly labelled, etc

