### PR TITLE
oy2-15452 - set 90 day as "Pending" on package/detail page for in rev…

### DIFF
--- a/services/common/changeRequest.js
+++ b/services/common/changeRequest.js
@@ -117,6 +117,24 @@ export const getWaiverRAIParent = (inId) => {
   return TYPE.WAIVER_BASE;
 };
 
+export const get90thDayText = (currentStatus, clockEndTimestamp) => {
+  switch (currentStatus) {
+    case ONEMAC_STATUS.RAI_ISSUED:
+      return "Clock Stopped";
+    case ONEMAC_STATUS.APPROVED:
+    case ONEMAC_STATUS.DISAPPROVED:
+    case ONEMAC_STATUS.TERMINATED:
+    case ONEMAC_STATUS.WITHDRAWN:
+      return "N/A";
+    case ONEMAC_STATUS.SUBMITTED:
+    case ONEMAC_STATUS.UNSUBMITTED:
+    case ONEMAC_STATUS.IN_REVIEW:
+      return "Pending";
+    default:
+      return clockEndTimestamp;
+  }
+};
+
 export const decodeId = (inId, inType) => {
   const returnInfo = {
     packageId: inId,

--- a/services/common/index.d.ts
+++ b/services/common/index.d.ts
@@ -96,4 +96,8 @@ export namespace ChangeRequest {
   }
 
   export const defaultActionsByStatus: Record<string, PACKAGE_ACTION[]>;
+  export const get90thDayText: (
+    currentStatus: String,
+    clockEndTimestamp: date
+  ) => string;
 }

--- a/services/ui-src/src/changeRequest/DetailView.tsx
+++ b/services/ui-src/src/changeRequest/DetailView.tsx
@@ -105,6 +105,11 @@ const DetailSection = ({
   const downloadInfoText =
     "Documents available on this page may not reflect the actual documents that were approved by CMS. Please refer to your CMS Point of Contact for the approved documents.";
 
+  const ninetyDayText = ChangeRequest.get90thDayText(
+    detail.currentStatus,
+    detail.clockEndTimestamp
+  );
+
   const onLinkActionWithdraw = useCallback(async () => {
     // For now, the second argument is constant.
     // When we add another action to the menu, we will need to look at the action taken here.
@@ -141,9 +146,11 @@ const DetailSection = ({
         <div className="detail-card">
           <section>
             <h2>{detail.currentStatus}</h2>
-            {detail.clockEndTimestamp && (
+            {ninetyDayText && ninetyDayText !== "N/A" && (
               <Review heading="90th Day">
-                {formatDetailViewDate(detail.clockEndTimestamp)}
+                {Number(ninetyDayText)
+                  ? formatDetailViewDate(new Date(ninetyDayText))
+                  : ninetyDayText ?? "N/A"}
               </Review>
             )}
             {ChangeRequest.MY_PACKAGE_GROUP[detail.componentType] ===

--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -242,19 +242,11 @@ const PackageList = () => {
         },
         {
           Header: "90th Day",
-          accessor: ({ clockEndTimestamp, currentStatus }) => {
-            switch (currentStatus) {
-              case ChangeRequest.ONEMAC_STATUS.RAI_ISSUED:
-                return "Clock Stopped";
-              case ChangeRequest.ONEMAC_STATUS.APPROVED:
-              case ChangeRequest.ONEMAC_STATUS.DISAPPROVED:
-                return "N/A";
-              case ChangeRequest.ONEMAC_STATUS.SUBMITTED:
-              case ChangeRequest.ONEMAC_STATUS.UNSUBMITTED:
-                return "Pending";
-              default:
-                return clockEndTimestamp ?? "N/A";
-            }
+          accessor: ({ currentStatus, clockEndTimestamp }) => {
+            return ChangeRequest.get90thDayText(
+              currentStatus,
+              clockEndTimestamp
+            );
           },
           id: "ninetiethDay",
           Cell: renderDate,


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-15452
Endpoint: https://d34jicl8rg41gf.cloudfront.net/

### Details

set 90 day property as "Pending" on package/detail page for in review items

### Changes

- moved logic for determining textual 90 day clock from  PackageList.js to changeRequest.js so it is reusable
- use new method for 90 day value on PackageList and DetailView

### Implementation Notes

- I left the common method in changeRequest unformatted when it is a date value because each usage may want to determine its own format; furthermore the current format on packagelist and detailview are slightly different

### Test Plan

1. Login as state submitter
2. Navigate to Package List
3. Verify any package in status "In Review" has the 90th day column has value "Pending"
4. Navigate to detail view from package list for a package in "In Review" status
5. Verify 90th day value in detail card has value "Pending"
