### PR TITLE
Fix for OY2-16707 CMS Users Denied a CRA Role loses Read Only Access to OneMAC Test

### DIFF
--- a/tests/cypress/cypress.json
+++ b/tests/cypress/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "https://d29q22ry23m267.cloudfront.net/",
+  "baseUrl": "https://d2dr7dgo9g0124.cloudfront.net/",
   "redirectionLimit": 20,
   "retries": 2,
   "watchForFileChanges": true,

--- a/tests/cypress/cypress/integration/OY2_16707_CMS_Users_Denied_a_CRA_Role_loses_Read_Only_Access_to_OneMAC.spec.feature
+++ b/tests/cypress/cypress/integration/OY2_16707_CMS_Users_Denied_a_CRA_Role_loses_Read_Only_Access_to_OneMAC.spec.feature
@@ -29,17 +29,15 @@ Feature: OY2-16707 CMS Users Denied a CRA Role loses Read Only Access to OneMAC
         And Click on User Management Tab
         And click the pending user action button
         And click the deny access button
-        And click confirm in the modal 
+        And click confirm in the modal
+        And verify success message for denied role
         Then Click on My Account
         And click the logout button
         Given I am on Login Page
         When Clicking on Development Login
         When Login as EUA CMS Read Only User
         Then Click on My Account
-        And click on Request a Role Change button
-        And click on the CMS Role Approver role
-        Then Click on My Account
-        And verify that Request a Role Change button does not exist
+        And verify that Request a Role Change button exists
         Then Click on Manage Profile
         When I am on My Profile Page
         And verify Profile Information is Displayed

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -1976,3 +1976,6 @@ And(
 And("verify the Proposed Effective Date is NA", () => {
   OneMacPackageDetailsPage.verifyproposedEffectiveDateHeaderContainsNA();
 });
+And("verify success message for denied role", () => {
+  OneMacDashboardPage.verifySuccessMessageIsDisplayedForRoleChange();
+});

--- a/tests/cypress/support/pages/oneMacDashboardPage.js
+++ b/tests/cypress/support/pages/oneMacDashboardPage.js
@@ -34,6 +34,7 @@ const spaIDLink =
 const uploadedAttachments =
   "div.header-and-content:nth-child(1) article.form-container div.read-only-submission section.choice-container.file-list-container:nth-child(3)";
 const logoutBtn = "//a[@id='logoutLink']";
+const rcSuccessMessage = "#alert-bar";
 
 export class oneMacDashboardPage {
   clickNewSubmission() {
@@ -130,6 +131,9 @@ export class oneMacDashboardPage {
   }
   clickLogoutBtn() {
     cy.xpath(logoutBtn).click();
+  }
+  verifySuccessMessageIsDisplayedForRoleChange() {
+    cy.get(rcSuccessMessage).contains("Status Change");
   }
 }
 export default oneMacDashboardPage;


### PR DESCRIPTION
Story: No story

### Details
This fixes issues with OY2-16707 automated testing

### Changes

- accidentally re-requested role change so it was forcing later tests to fail
- also added step to verify the success message


### Updated Test Plan

```
Feature: OY2-16707 CMS Users Denied a CRA Role loses Read Only Access to OneMAC

    Scenario: Denied EUA CMS user requests and denied but still see same info
        Given I am on Login Page
        When Clicking on Development Login
        When Login as EUA CMS Read Only User
        Then Click on My Account
        And click on Request a Role Change button
        And click on the CMS Role Approver role
        Then Click on My Account
        And verify that Request a Role Change button does not exist
        Then Click on Manage Profile
        When I am on My Profile Page
        And verify Profile Information is Displayed
        And Full Name text is Displayed
        And Actual Full Name is Displayed
        And Role text is Displayed
        And Actual Role is Displayed
        And Email text is Displayed
        And Actual Email is Displayed
        And Phone Number text is Displayed
        And Phone Number Add Button is Displayed
        And Status text is not displayed
        Then Click on My Account
        And click the logout button
        Given I am on Login Page
        When Clicking on Development Login
        When Login with cms System Admin
        And Click on User Management Tab
        And click the pending user action button
        And click the deny access button
        And click confirm in the modal
        And verify success message for denied role
        Then Click on My Account
        And click the logout button
        Given I am on Login Page
        When Clicking on Development Login
        When Login as EUA CMS Read Only User
        Then Click on My Account
        And verify that Request a Role Change button exists
        Then Click on Manage Profile
        When I am on My Profile Page
        And verify Profile Information is Displayed
        And Full Name text is Displayed
        And Actual Full Name is Displayed
        And Role text is Displayed
        And Actual Role is Displayed
        And Email text is Displayed
        And Actual Email is Displayed
        And Phone Number text is Displayed
        And Phone Number Add Button is Displayed
        And Status text is not displayed

```
