### PR TITLE
OY2-16976 Update test

### DIFF
--- a/tests/cypress/cypress/integration/OY2_16601_Update_Waiver_Form_Base_Waiver.spec.feature
+++ b/tests/cypress/cypress/integration/OY2_16601_Update_Waiver_Form_Base_Waiver.spec.feature
@@ -21,12 +21,12 @@ Feature: Update Waiver Form: Base Waiver
         And click on Base Waiver
         And Click on 1915 b 4 FFS Selective Contracting waivers under Waiver Authority
         And Type Unique Valid Base Waiver Number With SS.#####.R00.00 format
+        And select proposed effective date 3 months from today
         And Upload 1915 b 4 file
         And Type "This is just a test" in Summary Box
         And Click on Submit Button
         And verify submission Successful message
-        And click on Packages
-        And click on the Waivers tab
+        And verify the Waivers tab is selected
         And search for Unique Valid Base Waiver Number with 12 Characters
         And verify id number in the first row matches Unique Valid Base Waiver Number
   

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -2068,3 +2068,6 @@ And("verify the amendment details section exists", () => {
 And("verify success message for denied role", () => {
   OneMacDashboardPage.verifySuccessMessageIsDisplayedForRoleChange();
 });
+And("select proposed effective date 3 months from today", () => {
+  OneMacSubmitNewWaiverActionPage.setProposedEffectiveDateThreeMonthsAway();
+});

--- a/tests/cypress/support/pages/oneMacPackageDetailsPage.js
+++ b/tests/cypress/support/pages/oneMacPackageDetailsPage.js
@@ -13,7 +13,8 @@ const packageActionsHeader =
 const packageActionsList = "//ul[@class='action-list']";
 const respondToRAIAction = "//button[text()='Respond to RAI']";
 const withdrawPackageAction = "//button[text()='Withdraw']";
-const detailSection = "//h2[text()='Package Details']";
+const detailSection =
+  "//section[@class='detail-section']//h2[contains(text(),'Package')]";
 const CHIPSPAIDHeader = "//h3[contains(text(),'SPA ID')]";
 const typeHeader = "//h3[contains(text(),'Type')]";
 const stateHeader = "//h3[text()='State']";

--- a/tests/cypress/support/pages/oneMacSubmitNewWaiverActionPage.js
+++ b/tests/cypress/support/pages/oneMacSubmitNewWaiverActionPage.js
@@ -10,6 +10,7 @@ const commentsInputBox = "#field_2";
 const existingWaiverNumber = "MD.11223";
 const whatIsMyWaiverIDLink =
   "//body/reference[1]/div[1]/div[1]/div[4]/div[2]/form[1]/div[1]/div[3]/div[1]/div[2]/a[1]";
+const proposedEffectiveDate = "#proposed-effective-date";
 
 export class oneMacSubmitNewWaiverActionPage {
   inputWaiverNumber(s) {
@@ -77,6 +78,15 @@ export class oneMacSubmitNewWaiverActionPage {
         return false;
       }
     });
+  }
+  setProposedEffectiveDateThreeMonthsAway() {
+    var t = new Date();
+    var m = ("0" + (t.getMonth() + 1)).slice(-2);
+    var d = ("0" + t.getDate()).slice(-2);
+    var y = t.getFullYear();
+    var dt = y + "-" + m + "-" + d;
+
+    cy.get(proposedEffectiveDate).type(dt);
   }
 }
 export default oneMacSubmitNewWaiverActionPage;


### PR DESCRIPTION
- since this is navigation from the base waiver, it can be covered in the new base waiver form test.
- also added proposed effective date


### Test Plan

```
    Scenario: create base waiver from package dashboard and search it
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        Then click on New Submission
        And Click on Waiver Action
        And click on Base Waiver
        And Click on 1915 b 4 FFS Selective Contracting waivers under Waiver Authority
        And Type Unique Valid Base Waiver Number With SS.#####.R00.00 format
        And select proposed effective date 3 months from today
        And Upload 1915 b 4 file
        And Type "This is just a test" in Summary Box
        And Click on Submit Button
        And verify submission Successful message
        And verify the Waivers tab is selected
        And search for Unique Valid Base Waiver Number with 12 Characters
        And verify id number in the first row matches Unique Valid Base Waiver Number
  
```
