### PR TITLE
OY2_16332_Waiver_Mini_Dashboard_Temporary_Extension Test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -200,6 +200,7 @@ jobs:
             OY2_13923_Warning_Message_on_Package_Details_Page.spec.js,
             OY2_16707_CMS_Users_Denied_a_CRA_Role_loses_Read_Only_Access_to_OneMAC.spec.feature,
             OY2_15984_Updated_SPA_Package_Details_View_Additional_Information_Page.spec.js,
+            OY2_16332_Waiver_Mini_Dashboard_Temporary_Extension.spec.js,
           ]
     steps:
       - name: set branch_name

--- a/tests/cypress/cypress/integration/OY2_16332_Waiver_Mini_Dashboard_Temporary_Extension.spec.js
+++ b/tests/cypress/cypress/integration/OY2_16332_Waiver_Mini_Dashboard_Temporary_Extension.spec.js
@@ -1,0 +1,30 @@
+describe("Waiver Mini-Dashboard: Temporary Extension", () => {
+  beforeEach(() => {
+    cy.visit("/");
+    cy.get("#devloginBtn").click();
+    cy.get("#email").type("statesubmitter@nightwatch.test");
+    cy.get("#password").type("Passw0rd!");
+    cy.get("#loginDevUserBtn").click();
+  });
+
+  it("Screen Enhancement", () => {
+    /* ==== Generated with Cypress Studio ==== */
+    cy.get("#packageListLink").click();
+    cy.get("#show-waivers-button").click();
+    cy.get("#componentId-0 > a").click();
+    cy.get(".component-detail-wrapper").click();
+    cy.xpath('//a[text()="Temporary Extension"]').should("be.visible");
+    cy.xpath('//a[text()="Temporary Extension"]').click();
+    cy.xpath('//h2[text()="Temporary Extensions"]').should("be.visible");
+    cy.get("#componentIdColHeader")
+      .should("be.visible")
+      .and("have.text", "Extension Id");
+    cy.get("#currentStatusColHeader")
+      .should("be.visible")
+      .and("have.text", "Status");
+    cy.get("#packageActionsColHeader")
+      .should("be.visible")
+      .and("have.text", "Actions");
+    /* ==== End Cypress Studio ==== */
+  });
+});

--- a/tests/cypress/cypress/integration/OY2_16332_Waiver_Mini_Dashboard_Temporary_Extension.spec.js
+++ b/tests/cypress/cypress/integration/OY2_16332_Waiver_Mini_Dashboard_Temporary_Extension.spec.js
@@ -8,7 +8,6 @@ describe("Waiver Mini-Dashboard: Temporary Extension", () => {
   });
 
   it("Screen Enhancement", () => {
-    /* ==== Generated with Cypress Studio ==== */
     cy.get("#packageListLink").click();
     cy.get("#show-waivers-button").click();
     cy.get("#componentId-0 > a").click();
@@ -25,6 +24,5 @@ describe("Waiver Mini-Dashboard: Temporary Extension", () => {
     cy.get("#packageActionsColHeader")
       .should("be.visible")
       .and("have.text", "Actions");
-    /* ==== End Cypress Studio ==== */
   });
 });


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-16332

Decided to only test the page without mocked temp extensions (to avoid issues). Will add more when https://qmacbis.atlassian.net/browse/OY2-16333 is complete and I'm able to add temp extensions that appear in this table. 

### Test Plan

```
Log in as a state submitter
Locate a Base or Renewal Waiver without any temp extensions
Navigate to the Waiver package detail view
Verify left hand nav has a "Temporary Extensions" item under "Package Overview" section
Click the Temporary Extension left hand nav item
Verify there is a table with columns "Extension Id","Status","Actions"

```
