### PR TITLE
OY2 17595/6: Requiring SSL for requests and Server-side encryption on buckets

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -49,6 +49,10 @@ resources:
         WebsiteConfiguration:
           IndexDocument: index.html
           ErrorDocument: index.html
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
       DeletionPolicy: Delete
     BucketPolicy:
       Type: AWS::S3::BucketPolicy

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -72,6 +72,17 @@ resources:
                   Fn::GetAtt:
                     - CloudFrontOriginAccessIdentity
                     - S3CanonicalUserId
+            - Effect: Deny
+              Principal: "*"
+              Action: "s3:*"
+              Resource: !Join
+                - ""
+                - - "arn:aws:s3:::"
+                  - !Ref S3Bucket
+                  - /*
+              Condition:
+                Bool: 
+                  "aws:SecureTransport": "false"
         Bucket: !Ref S3Bucket
     CloudFrontWebAcl:
       Type: AWS::WAFv2::WebACL

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -200,6 +200,25 @@ resources:
           ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: AES256
+        # Policy to allow public read access to all attachments
+    ClamDefsBucketPolicy:
+      Type: AWS::S3::BucketPolicy
+      Properties:
+        Bucket:
+          Ref: ClamDefsBucket
+        PolicyDocument:
+          Statement:                 
+            - Effect: Deny
+              Principal: "*"
+              Action: "s3:*"
+              Resource: !Join
+                - ""
+                - - "arn:aws:s3:::"
+                  - !Ref ClamDefsBucket
+                  - /*
+              Condition:
+                Bool: 
+                  "aws:SecureTransport": "false"
     BucketAVScanRole:
       Type: "AWS::IAM::Role"
       Properties:

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -185,6 +185,10 @@ resources:
       Properties:
         BucketName: !Sub ${self:service.name}-${self:custom.stage}-avscan-${AWS::AccountId}
         AccessControl: Private
+        BucketEncryption:
+          ServerSideEncryptionConfiguration:
+            - ServerSideEncryptionByDefault:
+                SSEAlgorithm: AES256
     BucketAVScanRole:
       Type: "AWS::IAM::Role"
       Properties:

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -172,6 +172,17 @@ resources:
                 - !Sub arn:aws:s3:::${self:service.name}-${self:custom.stage}-attachments-${AWS::AccountId}/*.txt
                 - !Sub arn:aws:s3:::${self:service.name}-${self:custom.stage}-attachments-${AWS::AccountId}/*.xls
                 - !Sub arn:aws:s3:::${self:service.name}-${self:custom.stage}-attachments-${AWS::AccountId}/*.xlsx
+            - Effect: Deny
+              Principal: "*"
+              Action: "s3:*"
+              Resource: !Join
+                - ""
+                - - "arn:aws:s3:::"
+                  - !Ref S3Bucket
+                  - /*
+              Condition:
+                Bool: 
+                  "aws:SecureTransport": "false"
     LambdaInvokePermission:
       Type: AWS::Lambda::Permission
       Properties:

--- a/services/uploads/serverless.yml
+++ b/services/uploads/serverless.yml
@@ -178,7 +178,7 @@ resources:
               Resource: !Join
                 - ""
                 - - "arn:aws:s3:::"
-                  - !Ref S3Bucket
+                  - !Ref AttachmentsBucket
                   - /*
               Condition:
                 Bool: 


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-17595
https://qmacbis.atlassian.net/browse/OY2-17596
Endpoint: https://xxxx.cloudfront.net

### Details
added policies and parameters to the S3 buckets in ui and uploads to follow security guidelines.

### Changes
- Server-side encryption is now enabled through the .yml
- added a bucket policy to deny any requests from insecure sources (not using HTTPS)

### Test Plan
1. Look in AWS console to see the parameters and policies for ui- and uploads- match other buckets in the environment
2. Automated testing should work per usual