### PR TITLE
OY2-17614 && OY2-17653: ARIA labels for various buttons

### DIFF
--- a/services/ui-src/src/components/FileUploader.js
+++ b/services/ui-src/src/components/FileUploader.js
@@ -255,6 +255,9 @@ export default class FileUploader extends Component {
           </td>
           <td className="uploader-input-cell">
             <label
+              aria-label={`Add file${
+                uploader.allowMultiple ? "s" : ""
+              } of type ${uploader.title}`}
               className={
                 isDisabled
                   ? "uploader-input-label-disabled"

--- a/services/ui-src/src/components/PageTitleBar.js
+++ b/services/ui-src/src/components/PageTitleBar.js
@@ -54,6 +54,7 @@ const PageTitleBar = ({
         <div className="title-bar-left-content">
           {enableBackNav && (
             <Button
+              aria-label="Back to previous page"
               id="back-button"
               data-testid="back-button"
               className="title-bar-back-button"

--- a/services/ui-src/src/containers/Dashboard.js
+++ b/services/ui-src/src/containers/Dashboard.js
@@ -151,7 +151,13 @@ const Dashboard = () => {
           value: { link: link, raiId: row.original.transmittalNumber },
           handleSelected: onPopupAction,
         };
-        return <PopupMenu selectedRow={row} menuItems={[item]} />;
+        return (
+          <PopupMenu
+            buttonLabel={`Actions for ${row.original.transmittalNumber}`}
+            selectedRow={row}
+            menuItems={[item]}
+          />
+        );
       } else return <></>;
     },
     [onPopupAction]

--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -293,6 +293,10 @@ ul {
     margin-top: 0px;
     padding-top: 4px;
     padding-bottom: 4px;
+
+    &:focus-within {
+      @include focus-styles;
+    }
   }
 
   .uploader-input-label-active {


### PR DESCRIPTION
Stories: 
- https://qmacbis.atlassian.net/browse/OY2-17614
- https://qmacbis.atlassian.net/browse/OY2-17653
Endpoint: https://d1031h39uabus0.cloudfront.net/

### Details

Provide helpful descriptions for three types of button in the OneMAC application.

### Changes

- Back buttons are now `aria-label`ed with "Back to previous page"
- Actions buttons on Submission Dashboard are now `aria-label`ed with "Actions for <transmittal number>" as on Package Dashboard
- File upload buttons are now `aria-label`ed with "Add File(s) of type <upload type>"
- File upload buttons now receive the same focus styles as all other buttons and form fields

### Implementation Notes

- NB: Use `@include focus-styles;` if you need the stock CMSDS focus styles on anything. That is what they use internally.

### Test Plan

1. Ensure you have the Google Screen Reader extension installed. It does not always need to be enabled, but you will need to use it for each test case.
2. Log in as `statesubmitteractive` and go to the legacy Dashboard. Enable the screen reader and tab onto one of the Actions buttons. Ensure that it reads out "Actions for <transmittal number>" when it is focused.
3. Click the "New Submission" button. Tab onto the back button and ensure that you hear "Back to previous page".
4. Select one of the submission forms. Tab downward to the file upload section. When you reach the Add File buttons, ensure that they get the standard purple border, and that rather than just hearing "Add File" you hear "Add files of type <upload type>".
