### PR TITLE
add S3BucketCloudFrontLogs as output param

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -330,6 +330,8 @@ resources:
     S3BucketName:
       Value:
         Ref: S3Bucket
+    S3BucketCloudFrontLogsName:
+      Value: !Ref S3BucketCloudFrontLogs
     CloudFrontDistributionId:
       Value:
         Ref: CloudFrontDistribution


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-XXXX
Endpoint: https://xxxx.cloudfront.net

### Details

Need a way to capture the bucket name created for cloud front logs so that our bucket cleaner script can ......clean it

### Changes

- added output variable to serverless.yml so that we can capture the bucket name for the cloud front logs

### Test Plan

1. Verify the ui stack in cloud formation has an output variable named S3BucketCloudFrontLogsName and its value is the name of the bucket created
