### PR TITLE
OY2 18490: Migrate Data to Prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,6 +149,7 @@ jobs:
         if: ${{ env.branch_name != 'production'}}
         run: ./loadTestUsers.py $STAGE_PREFIX$branch_name
       - name: Migrate Data
+        if: ${{ env.branch_name != 'production'}}
         run: cd ./services/app-api && sls invoke -s $STAGE_PREFIX$branch_name -f migrate
   cypress-test:
     name: Cypress Tests

--- a/loadTestUsers.py
+++ b/loadTestUsers.py
@@ -125,7 +125,7 @@ def seed_cognito(test_users, user_pool_id, password):
         elif user["role"].startswith("state"):
             role = "onemac-state-user"
         elif user["role"].startswith("cms") or user["role"] == "systemadmin":
-            role = "none"
+            role = ""
         elif user["role"] == "helpdesk":
             role = "onemac-helpdesk"
 

--- a/services/app-api/migrate.js
+++ b/services/app-api/migrate.js
@@ -45,6 +45,8 @@ const createVersionedComponent = async (oldData) => {
     sk: `v1#${oldData.sk}`,
   };
 
+  console.log("Second Put params: ", putParams);
+
   await dynamoDb.put(putParams);
 };
 
@@ -152,7 +154,7 @@ export const main = handler(async (event) => {
 
         const result = await dynamoDb.update(updateParams);
         console.log("The updated record: ", result);
-        if (result) createVersionedComponent(result.Attributes);
+        if (result) await createVersionedComponent(result.Attributes);
       } catch (e) {
         console.log("update error: ", e.message);
       }

--- a/services/app-api/migrate.js
+++ b/services/app-api/migrate.js
@@ -95,7 +95,7 @@ export const main = handler(async (event) => {
       });
     }
     params.ExclusiveStartKey = results.LastEvaluatedKey;
-  } while (params.ExclusiveStartKey);
+  } while (params.ExclusiveStartKey && promiseItems.length < 20);
 
   params.ExpressionAttributeValues = {
     ":gsi1pk": `OneMAC#waiver`,
@@ -145,7 +145,7 @@ export const main = handler(async (event) => {
     }
 
     params.ExclusiveStartKey = results.LastEvaluatedKey;
-  } while (params.ExclusiveStartKey);
+  } while (params.ExclusiveStartKey && promiseItems.length < 20);
 
   await Promise.all(
     promiseItems.map(async (updateParams) => {

--- a/services/app-api/migrate.js
+++ b/services/app-api/migrate.js
@@ -95,7 +95,7 @@ export const main = handler(async (event) => {
       });
     }
     params.ExclusiveStartKey = results.LastEvaluatedKey;
-  } while (params.ExclusiveStartKey && promiseItems.length < 20);
+  } while (params.ExclusiveStartKey);
 
   params.ExpressionAttributeValues = {
     ":gsi1pk": `OneMAC#waiver`,
@@ -145,7 +145,7 @@ export const main = handler(async (event) => {
     }
 
     params.ExclusiveStartKey = results.LastEvaluatedKey;
-  } while (params.ExclusiveStartKey && promiseItems.length < 20);
+  } while (params.ExclusiveStartKey);
 
   await Promise.all(
     promiseItems.map(async (updateParams) => {


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-18490
Endpoint: https://d3hj9jj82d2jjt.cloudfront.net/

### Details
Create a lightweight way to migrate higher environments into the v0# style

### Changes
- limited the migration to not automatically run on production
- fixed the default for the CMS read-only test user, was different than the "real"
- practiced destroying and recreating the one table in develop

### Implementation Notes

### Test Plan
1. Tests look good
2. DynamoDB tables look good
3. Application shows data
