### PR TITLE
OY2-18525: Soft Delete Erroneous Submissions (really is: don't show inactivated submissions)

### DIFF
--- a/services/app-api/getAllByAuthorizedTerritories.js
+++ b/services/app-api/getAllByAuthorizedTerritories.js
@@ -6,9 +6,14 @@ import { getUser } from "./getUser";
 
 const commonQueryConfig = {
   TableName: process.env.tableName,
-  ExpressionAttributeNames: { "#type": "type", "#user": "user" },
+  ExpressionAttributeNames: {
+    "#type": "type",
+    "#user": "user",
+    "#state": "state",
+  },
+  FilterExpression: "#state = :submittedState",
   ProjectionExpression:
-    "transmittalNumber,#type,territory,submittedAt,#user.firstName,#user.lastName,#user.email,userId,id",
+    "transmittalNumber,#type,territory,submittedAt,#user.firstName,#user.lastName,#user.email,userId,id,#state",
 };
 
 /**
@@ -26,6 +31,9 @@ async function helpdeskOrReviewerDynamoDbQuery(
 ) {
   const results = await dynamoDb.scan({
     ...commonQueryConfig,
+    ExpressionAttributeValues: {
+      ":submittedState": "Submitted",
+    },
     ExclusiveStartKey: startingKey,
   });
   allResults.push(results);
@@ -62,6 +70,7 @@ async function stateSubmitterDynamoDbQuery(
     ExpressionAttributeValues: {
       ":v_territory": territory,
       ":v_submittedAt": 0,
+      ":submittedState": "Submitted",
     },
     ScanIndexForward: false, // sorts the results by submittedAt in descending order (most recent first)
   });


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-18525
Endpoint: https://d19grwyn42df01.cloudfront.net

### Details
Submissions that have the state "inactivated" should no longer show on the Submission Dashboard.
Packages with the currentStatus of "Inactivated" should not show on the Package Dashboard

### Changes
- added a filter on the state attribute for the submission query and scan
- created the currentStatus value of "Inactivated" for the package data

### Implementation Notes

- Developer focused info that may affect future work

### Test Plan

1. Test step 1
2. Test step 2
