### PR TITLE
remove no-paginate option from list-stack-resources

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -31,6 +31,7 @@ services=(
   'ui-waf-log-assoc'
   'ui-auth'
   'ui-src'
+  'admin'
 )
 
 set -e

--- a/destroy.sh
+++ b/destroy.sh
@@ -40,7 +40,7 @@ for i in "${filteredStackList[@]}"
 do
   echo 'starting destroy on stack: ' $i
   # Get list of buckets in this stack
-  filteredBucketList=(`aws cloudformation list-stack-resources --stack-name $i --no-paginate | jq -r ".StackResourceSummaries[] | select(.ResourceType==\"AWS::S3::Bucket\") | .PhysicalResourceId"`)
+  filteredBucketList=(`aws cloudformation list-stack-resources --stack-name $i | jq -r ".StackResourceSummaries[] | select(.ResourceType==\"AWS::S3::Bucket\") | .PhysicalResourceId"`)
   echo 'Turning off Versioning and Emptying buckets...'
   for x in "${filteredBucketList[@]}"
   do

--- a/destroy.sh
+++ b/destroy.sh
@@ -40,7 +40,7 @@ for i in "${filteredStackList[@]}"
 do
   echo 'starting destroy on stack: ' $i
   # Get list of buckets in this stack
-  filteredBucketList=(`aws cloudformation list-stack-resources --stack-name app-api-test-destroy-2 --output text --query 'StackResourceSummaries[?ResourceType==\`AWS::S3::Bucket\`].PhysicalResourceId'`)
+  filteredBucketList=(`aws cloudformation list-stack-resources --stack-name $i --output text --query 'StackResourceSummaries[?ResourceType==\`AWS::S3::Bucket\`].PhysicalResourceId'`)
   echo 'Turning off Versioning and Emptying buckets...'
   for x in "${filteredBucketList[@]}"
   do

--- a/destroy.sh
+++ b/destroy.sh
@@ -40,7 +40,7 @@ for i in "${filteredStackList[@]}"
 do
   echo 'starting destroy on stack: ' $i
   # Get list of buckets in this stack
-  filteredBucketList=(`aws cloudformation list-stack-resources --stack-name $i | jq -r ".StackResourceSummaries[] | select(.ResourceType==\"AWS::S3::Bucket\") | .PhysicalResourceId"`)
+  filteredBucketList=(`aws cloudformation list-stack-resources --stack-name app-api-test-destroy-2 --output text --query 'StackResourceSummaries[?ResourceType==\`AWS::S3::Bucket\`].PhysicalResourceId'`)
   echo 'Turning off Versioning and Emptying buckets...'
   for x in "${filteredBucketList[@]}"
   do


### PR DESCRIPTION
Had to switch to list-stack-resources (in last PR) as describe-stack-resources had 100 resource limit. The no-paginate option works on normal CLI but conflicts with the way jq works.