### PR TITLE
OY2-16792: Package Views - Needs to be Read-Only For CMS Users

### DIFF
--- a/services/ui-src/src/containers/DetailView.tsx
+++ b/services/ui-src/src/containers/DetailView.tsx
@@ -2,6 +2,7 @@ import React, { FC, useState, useCallback, useEffect, useMemo } from "react";
 import { useHistory, useParams, useLocation } from "react-router-dom";
 import { format, parseISO } from "date-fns";
 import classNames from "classnames";
+import { Column } from "react-table";
 
 import {
   Button,
@@ -427,8 +428,8 @@ const TemporaryExtensionSection: FC<{
     [onPopupActionWithdraw]
   );
 
-  const tempExtColumns = useMemo(
-    () => [
+  const tempExtColumns = useMemo(() => {
+    const theColumns: Column[] = [
       {
         Header: "Extension Id",
         accessor: "componentId",
@@ -437,15 +438,17 @@ const TemporaryExtensionSection: FC<{
         Header: "Status",
         accessor: "currentStatus",
       },
-      {
+    ];
+    if (userRoleObj.canAccessForms)
+      theColumns.push({
         Header: "Actions",
         accessor: "actions",
         id: "packageActions",
         Cell: renderActions,
-      },
-    ],
-    [renderActions]
-  );
+      });
+
+    return theColumns;
+  }, [renderActions, userRoleObj.canAccessForms]);
 
   return (
     <section id="temp-ext-base" className="read-only-submission ">


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-16792
Endpoint: https://xxxx.cloudfront.net

### Details
Read-Only users should not be able to take Actions

### Changes
- used userRoleObj.canAccessForms on the Actions column in the Temporary Extension mini-dashboard
- 

### Test Plan
1. Login as a Read-Only user
2. Navigate to packageList
3. Verify Actions column is not on SPA or Waivers Tabs
4. Select a Package to see it's details
5. Verify the Package Actions column is not there
6. Select a Package with a Temporary Extension child
7. Navigate to the temporary extension mini-dashboard
8. Verify there is no Actions column in the table
9. Test step 2
