### PR TITLE
update language for formal rai

### DIFF
--- a/services/common/changeRequest.js
+++ b/services/common/changeRequest.js
@@ -92,6 +92,7 @@ export const CONFIG = {
       __html: raiSubheaderMessage,
     },
     detailsHeader: "Formal CHIP SPA RAI",
+    readOnlyDetailsHeader: "CHIP SPA RAI",
     requiredUploads: [
       "Revised Amended State Plan Language",
       "Official RAI Response",
@@ -170,6 +171,7 @@ export const CONFIG = {
       __html: raiSubheaderMessage,
     },
     detailsHeader: "Formal Medicaid SPA RAI",
+    readOnlyDetailsHeader: "Medicaid SPA RAI",
     requiredUploads: ["RAI Response"],
     optionalUploads: ["Other"],
 
@@ -340,7 +342,7 @@ export const CONFIG = {
     subheaderMessage: {
       __html: commonSubheaderMessage,
     },
-    detailsHeader: "Request Temporary Extension",
+    detailsHeader: "Temporary Extension Request",
     requiredUploads: ["Waiver Extension Request"],
     optionalUploads: ["Other"],
 

--- a/services/common/changeRequest.js
+++ b/services/common/changeRequest.js
@@ -37,6 +37,11 @@ export const correspondingRAILink = {
 const commonSubheaderMessage =
   "Once you submit this form, a confirmation email is sent to you and to CMS. CMS will use this content to review your package, and you will not be able to edit this form. If CMS needs any additional information, they will follow up by email.<b> If you leave this page, you will lose your progress on this form.</b>";
 
+const raiSubheaderMessage =
+  commonSubheaderMessage +
+  "<br><br>" +
+  "<b>Please note:</b> Formal RAI Response selection should only be used only when submitting a response to a Formal RAI that would impact the clock.  If this submission is in response to informal questions and is not clock related, the state should be forwarding to the review team via email.";
+
 const waiverBaseTransmittalNumber = {
   idType: "waiver",
   idLabel: "Waiver Number",
@@ -81,12 +86,12 @@ export const CONFIG = {
   },
 
   [TYPE.CHIP_SPA_RAI]: {
-    pageTitle: "Respond to CHIP SPA RAI",
-    readOnlyPageTitle: "CHIP SPA RAI Response Details",
+    pageTitle: "Respond to Formal CHIP SPA RAI",
+    readOnlyPageTitle: "Formal CHIP SPA RAI Response Details",
     subheaderMessage: {
-      __html: commonSubheaderMessage,
+      __html: raiSubheaderMessage,
     },
-    detailsHeader: "CHIP SPA RAI",
+    detailsHeader: "Formal CHIP SPA RAI",
     requiredUploads: [
       "Revised Amended State Plan Language",
       "Official RAI Response",
@@ -159,12 +164,12 @@ export const CONFIG = {
   },
 
   [TYPE.SPA_RAI]: {
-    pageTitle: "Respond to Medicaid SPA RAI",
-    readOnlyPageTitle: "Medicaid SPA RAI Response Details",
+    pageTitle: "Respond to Formal Medicaid SPA RAI",
+    readOnlyPageTitle: "Medicaid SPA RAI Details",
     subheaderMessage: {
-      __html: commonSubheaderMessage,
+      __html: raiSubheaderMessage,
     },
-    detailsHeader: "Medicaid SPA RAI",
+    detailsHeader: "Formal Medicaid SPA RAI",
     requiredUploads: ["RAI Response"],
     optionalUploads: ["Other"],
 

--- a/services/ui-src/src/changeRequest/NewSPA.js
+++ b/services/ui-src/src/changeRequest/NewSPA.js
@@ -10,7 +10,7 @@ const SPA_CHOICES = [
     linkTo: "/spa",
   },
   {
-    title: "Respond to Medicaid SPA RAI",
+    title: "Respond to Formal Medicaid SPA RAI",
     description: "Submit additional information",
     linkTo: "/sparai",
   },
@@ -20,7 +20,7 @@ const SPA_CHOICES = [
     linkTo: "/chipspa",
   },
   {
-    title: "Respond to CHIP SPA RAI",
+    title: "Respond to Formal CHIP SPA RAI",
     description: "Submit additional information",
     linkTo: "/chipsparai",
   },

--- a/services/ui-src/src/changeRequest/SubmissionView.js
+++ b/services/ui-src/src/changeRequest/SubmissionView.js
@@ -79,7 +79,10 @@ const SubmissionView = ({ changeRequestType }) => {
               </section>
             )}
             <section>
-              <h2>{formInfo.detailsHeader} Details</h2>
+              <h2>
+                {formInfo.readOnlyDetailsHeader ?? formInfo.detailsHeader}{" "}
+                Details
+              </h2>
               {changeRequest.waiverAuthority && (
                 <Review heading="Waiver Authority">
                   {AUTHORITY_LABELS[changeRequest.waiverAuthority] ??

--- a/tests/cypress/cypress/integration/a11y/RespondToCHIPSPAPage.spec.js
+++ b/tests/cypress/cypress/integration/a11y/RespondToCHIPSPAPage.spec.js
@@ -9,7 +9,9 @@ describe("Respond To CHIP SPA Page 508 test", () => {
     cy.xpath(
       "//p[contains(text(),'Submit a new Medicaid & CHIP State Plan Amendments')]"
     ).click();
-    cy.xpath("//div[contains(text(),'Respond to CHIP SPA RAI')]").click();
+    cy.xpath(
+      "//div[contains(text(),'Respond to Formal CHIP SPA RAI')]"
+    ).click();
   });
 
   it("Check a11y on Respond to CHIP SPA Page", () => {

--- a/tests/cypress/cypress/integration/a11y/RespondToMedicaidSpaTest.spec.js
+++ b/tests/cypress/cypress/integration/a11y/RespondToMedicaidSpaTest.spec.js
@@ -9,7 +9,9 @@ describe("Respond To Medicaid SPA Page 508 test", () => {
     cy.xpath(
       "//p[contains(text(),'Submit a new Medicaid & CHIP State Plan Amendments')]"
     ).click();
-    cy.xpath("//div[contains(text(),'Respond to Medicaid SPA RAI')]").click();
+    cy.xpath(
+      "//div[contains(text(),'Respond to Formal Medicaid SPA RAI')]"
+    ).click();
   });
 
   it("Check a11y on Respond to Medicaid SPA Page", () => {

--- a/tests/cypress/support/pages/oneMacRespondToRAIPage.js
+++ b/tests/cypress/support/pages/oneMacRespondToRAIPage.js
@@ -1,4 +1,5 @@
-const pageHeader = "//h1[contains(text(),'Respond to Medicaid SPA RAI')]";
+const pageHeader =
+  "//h1[contains(text(),'Respond to Formal Medicaid SPA RAI')]";
 const backArrow = "#back-button";
 //Element is Xpath use cy.xpath instead of cy.get
 const leaveAnywaysBtn = "//button[text()='Leave Anyway']";

--- a/tests/cypress/support/pages/oneMacSubmissionTypePage.js
+++ b/tests/cypress/support/pages/oneMacSubmissionTypePage.js
@@ -15,9 +15,10 @@ const RequestTemporaryExtension = '//div[text()="Request Temporary Extension"]';
 //Element is Xpath use cy.xpath instead of cy.get
 const AppendixKAmendment = '//div[text()="Appendix K Amendment"]';
 //Element is Xpath use cy.xpath instead of cy.get
-const respondToMedicaidSPARAI = '//div[text()="Respond to Medicaid SPA RAI"]';
+const respondToMedicaidSPARAI =
+  '//div[text()="Respond to Formal Medicaid SPA RAI"]';
 //Element is Xpath use cy.xpath instead of cy.get
-const respondToCHIPSPARAI = '//div[text()="Respond to CHIP SPA RAI"]';
+const respondToCHIPSPARAI = '//div[text()="Respond to Formal CHIP SPA RAI"]';
 //Element is Xpath use cy.xpath instead of cy.get
 const respondToWaiverRAI = '//div[text()="Respond to Waiver RAI"]';
 //Element is Xpath use cy.xpath instead of cy.get


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-18690
Endpoint: https://d24vxtsjffgfad.cloudfront.net/

### Details

Update to language to specify RAIs are formal (they wear tuxedos?)

### Changes

- Added Please note: text to top Medicaid and CHIP RAI forms
- Updated Medicaid and CHIP RAI labels to include the term Formal


### Test Plan

1. Login as state submitter
2. Navigate to submission dashboard and click the New Submission button
3. Choose the State Plan Amendment (SPA) option
4. Verify "Respond to Medicaid SPA RAI" now says "Respond to Formal Medicaid SPA RAI"
5. Verify "Respond to CHIP SPA RAI" now says "Respond to Formal CHIP SPA RAI"
6. Navigate to each of the RAI response forms and verify the additional text appears above the form title
7. Verify the Form title and Details section references "Formal"
