### PR TITLE
oy2-16792 tests + fix flaky test steps

### DIFF
--- a/tests/cypress/cypress/integration/CMS_Read_Only_View.spec.feature
+++ b/tests/cypress/cypress/integration/CMS_Read_Only_View.spec.feature
@@ -1,0 +1,17 @@
+Feature: Package Dashboard Read Only View
+Background: Reoccuring Steps
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login as EUA CMS Read Only User
+
+Scenario: CMS Read Only user actions column unavailable in Package Dashboard
+And click on Packages
+And verify actions column is unavailable
+And click on the Waivers tab
+And verify actions column is unavailable
+
+Scenario: CMS Read Only user actions column unavailable in Package Mini-Dashboard
+And click on Packages
+And click on the Waivers tab
+And click the Waiver Number link in the first row
+And verify the package actions section is unavailable

--- a/tests/cypress/cypress/integration/CMS_Read_Only_View.spec.feature
+++ b/tests/cypress/cypress/integration/CMS_Read_Only_View.spec.feature
@@ -1,17 +1,17 @@
 Feature: Package Dashboard Read Only View
-Background: Reoccuring Steps
+    Background: Reoccuring Steps
         Given I am on Login Page
         When Clicking on Development Login
         When Login as EUA CMS Read Only User
 
-Scenario: CMS Read Only user actions column unavailable in Package Dashboard
-And click on Packages
-And verify actions column is unavailable
-And click on the Waivers tab
-And verify actions column is unavailable
+    Scenario: CMS Read Only user actions column unavailable in Package Dashboard
+        And click on Packages
+        And verify actions column is unavailable
+        And click on the Waivers tab
+        And verify actions column is unavailable
 
-Scenario: CMS Read Only user actions column unavailable in Package Mini-Dashboard
-And click on Packages
-And click on the Waivers tab
-And click the Waiver Number link in the first row
-And verify the package actions section is unavailable
+    Scenario: CMS Read Only user actions column unavailable in Package Mini-Dashboard
+        And click on Packages
+        And click on the Waivers tab
+        And click the Waiver Number link in the first row
+        And verify the package actions section is unavailable

--- a/tests/cypress/cypress/integration/Submission_Dashboard_New_Submission_File_Upload.spec.feature
+++ b/tests/cypress/cypress/integration/Submission_Dashboard_New_Submission_File_Upload.spec.feature
@@ -72,8 +72,7 @@ Feature: OY2_5869_FileUpload_Attachment_Types
                 And Click on Submit Button
                 And verify submission Successful message
                 And verify SPA ID 2 EXISTS
-                And verify submission date
-                And Verify submission type
+                And Verify submission type for SPA ID 2
                 And verify Submission List is Displayed
                 And Click on the SPA ID Link
                 And Verify "15MB.pdf" exists in the attachments

--- a/tests/cypress/cypress/integration/Submission_Dashboard_Respond_to_RAI.spec.feature
+++ b/tests/cypress/cypress/integration/Submission_Dashboard_Respond_to_RAI.spec.feature
@@ -42,7 +42,7 @@ Feature: OY2-15647 State User can Respond to RAI
         And verify submission Successful message
         And verify SPA ID for RAI 1 EXISTS
         And verify submission date
-        And Verify submission type
+        And Verify submission type for RAI 1 parent SPA
         And click on spa Respond to RAI
         And Add file for RAI Response
         And Add Additional Comments

--- a/tests/cypress/cypress/integration/Submission_Dashboard_Withdraw_RAI_Responses.spec.feature
+++ b/tests/cypress/cypress/integration/Submission_Dashboard_Withdraw_RAI_Responses.spec.feature
@@ -34,11 +34,11 @@ Feature: State should not be able to withdraw RAI Responses in OneMAC
         And verify submission Successful message
         And verify SPA ID for RAI 2 EXISTS
         And verify submission date
-        And Verify submission type
+        And Verify submission type of SPA ID for RAI 2
         And click on spa Respond to RAI
         And Add file for RAI Response
         And Add Additional Comments
         And Click on Submit Button
         And verify submission Successful message after RAI
-        And Verify submission typeRAI
+        And Verify submission type SPA RAI
         And verify the actions button is unavailable

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -213,6 +213,17 @@ And("Verify submission type", () => {
   OneMacDashboardPage.verifyType("Medicaid SPA");
 });
 
+And("Verify submission type for SPA ID 2", () => {
+  cy.fixture("submissionDashboardSPAIDs.json").then((d) => {
+    OneMacDashboardPage.verifyTypeForID(d.attachmentsSPAID2, "Medicaid SPA");
+  });
+});
+And("Verify submission type for RAI 1 parent SPA", () => {
+  cy.fixture("submissionDashboardSPAIDs.json").then((d) => {
+    OneMacDashboardPage.verifyTypeForID(d.SPAIDforRAI1, "Medicaid SPA");
+  });
+});
+
 And("Verify submission Waiver type", () => {
   OneMacDashboardPage.verifyType("Waiver");
 });
@@ -232,16 +243,24 @@ And("Add Additional Comments", () => {
 And("verify submission Successful message after RAI", () => {
   OneMacDashboardPage.verifySuccessMessageIsDisplayedAfterRAIResponse();
 });
-And("Verify submission typeRAI", () => {
-  OneMacDashboardPage.verifyType("SPA RAI");
+And("Verify submission type SPA RAI", () => {
+  cy.fixture("submissionDashboardSPAIDs.json").then((d) => {
+    OneMacDashboardPage.verifyTypeForID(d.SPAIDforRAI2, "SPA RAI");
+  });
 });
 
 And("Verify submission type Waiver RAI", () => {
-  OneMacDashboardPage.verifyType("Waiver RAI");
+  cy.fixture("submissionDashboardWaiverNumbers.json").then((d) => {
+    OneMacSubmitNewWaiverActionPage.verifyTypeForID(
+      d.newWaiverNumber3,
+      "Waiver RAI"
+    );
+  });
 });
-
-And("Verify submission type CHIP SPA RAI", () => {
-  OneMacDashboardPage.verifyType("CHIP SPA RAI");
+And("Verify submission type of SPA ID for RAI 2", () => {
+  cy.fixture("submissionDashboardSPAIDs.json").then((d) => {
+    OneMacDashboardPage.verifyIDNumber(d.SPAIDforRAI2, "Medicaid SPA");
+  });
 });
 
 //this is for the oy2 8616
@@ -1928,6 +1947,9 @@ And("verify package actions header is visible", () => {
 And("verify there are no package actions available", () => {
   OneMacPackageDetailsPage.verifyNoPackageActionsAvailable();
 });
+And("verify the package actions section is unavailable", () => {
+  OneMacPackageDetailsPage.verifyPackageActionsSectionDoesNotExist();
+});
 And("verify Respond to RAI action exists", () => {
   OneMacPackageDetailsPage.verifyRespondtoRAIActionExists();
 });
@@ -2177,4 +2199,7 @@ And("reset EUA CMS Read Only User state if needed", () => {
 
 And("verify the actions button is unavailable", () => {
   OneMacDashboardPage.verifyActionsBtnUnvailableOnFirstRow();
+});
+And("verify actions column is unavailable", () => {
+  OneMacPackagePage.verifyActionsColumnDoesNotExist();
 });

--- a/tests/cypress/support/pages/oneMacDashboardPage.js
+++ b/tests/cypress/support/pages/oneMacDashboardPage.js
@@ -60,7 +60,9 @@ export class oneMacDashboardPage {
   verifyType(s) {
     cy.xpath(Type).contains(s);
   }
-
+  verifyTypeForID(s, e) {
+    cy.xpath(IDNUMBER(s)).next("td").contains(e);
+  }
   verifyDate() {
     cy.get(date).should("be.visible");
   }

--- a/tests/cypress/support/pages/oneMacPackageDetailsPage.js
+++ b/tests/cypress/support/pages/oneMacPackageDetailsPage.js
@@ -62,6 +62,9 @@ export class oneMacPackageDetailsPage {
   verifyNoPackageActionsAvailable() {
     cy.xpath(packageActionsList).should("be.visible");
   }
+  verifyPackageActionsSectionDoesNotExist() {
+    cy.xpath(packageActionsList).should("not.exist");
+  }
   verifyRespondtoRAIActionExists() {
     cy.xpath(respondToRAIAction).should("be.visible");
   }

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -871,5 +871,8 @@ export class oneMacPackagePage {
         cy.writeFile(f, { savedID: text });
       });
   }
+  verifyActionsColumnDoesNotExist() {
+    cy.get(actionsColumn).should("not.exist");
+  }
 }
 export default oneMacPackagePage;


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-16792

### Changes

- adds tests and also fix flaky test steps

### Test Plan

```
Feature: Package Dashboard Read Only View
    Background: Reoccuring Steps
        Given I am on Login Page
        When Clicking on Development Login
        When Login as EUA CMS Read Only User

    Scenario: CMS Read Only user actions column unavailable in Package Dashboard
        And click on Packages
        And verify actions column is unavailable
        And click on the Waivers tab
        And verify actions column is unavailable

    Scenario: CMS Read Only user actions column unavailable in Package Mini-Dashboard
        And click on Packages
        And click on the Waivers tab
        And click the Waiver Number link in the first row
        And verify the package actions section is unavailable
```
