### PR TITLE
Confirmation Dialog Cleanup

### DIFF
--- a/services/ui-src/src/App.tsx
+++ b/services/ui-src/src/App.tsx
@@ -18,7 +18,7 @@ import { ConfirmationDialog } from "./components/ConfirmationDialog";
 
 const DEFAULT_AUTH_STATE: Omit<
   AppContextValue,
-  "setUserInfo" | "updatePhoneNumber" | "useConfirmationDialog"
+  "setUserInfo" | "updatePhoneNumber" | "createConfirmationDialog"
 > = {
   isAuthenticating: true,
   isAuthenticated: false,
@@ -44,7 +44,7 @@ export function App() {
     []
   );
 
-  const useConfirmationDialog = useCallback(
+  const createConfirmationDialog = useCallback(
     async (
       heading: string,
       acceptText: string,
@@ -170,9 +170,9 @@ export function App() {
       ...authState,
       setUserInfo,
       updatePhoneNumber,
-      useConfirmationDialog,
+      createConfirmationDialog,
     }),
-    [authState, setUserInfo, updatePhoneNumber, useConfirmationDialog]
+    [authState, setUserInfo, updatePhoneNumber, createConfirmationDialog]
   );
 
   return authState.isAuthenticating ? null : (

--- a/services/ui-src/src/App.tsx
+++ b/services/ui-src/src/App.tsx
@@ -14,10 +14,11 @@ import {
   getActiveTerritories,
   RESPONSE_CODE,
 } from "cmscommonlib";
+import { ConfirmationDialog } from "./components/ConfirmationDialog";
 
 const DEFAULT_AUTH_STATE: Omit<
   AppContextValue,
-  "setUserInfo" | "updatePhoneNumber"
+  "setUserInfo" | "updatePhoneNumber" | "useConfirmationDialog"
 > = {
   isAuthenticating: true,
   isAuthenticated: false,
@@ -30,7 +31,40 @@ const DEFAULT_AUTH_STATE: Omit<
 
 export function App() {
   const [authState, setAuthState] = useState(DEFAULT_AUTH_STATE);
+  const [confirmationDialog, setConfirmationDialog] = useState<{
+    heading: string;
+    acceptText: string;
+    cancelText: string;
+    message: string;
+    onAccept: any;
+    onDeny: any;
+  } | null>(null);
+  const closeConfirmationDialog = useCallback(
+    () => setConfirmationDialog(null),
+    []
+  );
 
+  const useConfirmationDialog = useCallback(
+    async (
+      heading: string,
+      acceptText: string,
+      cancelText: string,
+      message: string,
+      onAccept: any,
+      onDeny: any
+    ) =>
+      setConfirmationDialog({
+        heading,
+        acceptText,
+        cancelText,
+        message,
+        onAccept,
+        onDeny,
+      }),
+    []
+  );
+
+  //  const testDialog =  { yesText: "Yes, Do it!", dialogTitle: "Confirmation Dialog Title", doOnAccept: () => { alert('dialog accepted'); closeConfirmationDialog(); }, doOnDeny: () => { alert('dialog denied'); closeConfirmationDialog(); }, message: "This is a confirmation dialog from the context.", width: "100" };
   /**
    * Gets authentication status for user,
    * gets user names and email from cognito
@@ -136,8 +170,9 @@ export function App() {
       ...authState,
       setUserInfo,
       updatePhoneNumber,
+      useConfirmationDialog,
     }),
-    [authState, setUserInfo, updatePhoneNumber]
+    [authState, setUserInfo, updatePhoneNumber, useConfirmationDialog]
   );
 
   return authState.isAuthenticating ? null : (
@@ -146,6 +181,23 @@ export function App() {
         <Header />
         <main id="main">
           <Routes />
+          {confirmationDialog && (
+            <ConfirmationDialog
+              acceptText={confirmationDialog.acceptText}
+              cancelText={confirmationDialog.cancelText}
+              heading={confirmationDialog.heading}
+              onAccept={() => {
+                confirmationDialog.onAccept && confirmationDialog.onAccept();
+                closeConfirmationDialog();
+              }}
+              onCancel={() => {
+                confirmationDialog.onDeny && confirmationDialog.onDeny();
+                closeConfirmationDialog();
+              }}
+            >
+              {confirmationDialog.message}
+            </ConfirmationDialog>
+          )}
         </main>
       </div>
       <Footer />

--- a/services/ui-src/src/components/PageTitleBar.js
+++ b/services/ui-src/src/components/PageTitleBar.js
@@ -47,7 +47,8 @@ const PageTitleBar = ({
               className="title-bar-back-button"
               onClick={() =>
                 backNavConfirmationMessage
-                  ? createConfirmationDialog(
+                  ? createConfirmationDialog &&
+                    createConfirmationDialog(
                       "Leave this page?",
                       "Leave Anyway",
                       "Stay on Page",

--- a/services/ui-src/src/components/PageTitleBar.js
+++ b/services/ui-src/src/components/PageTitleBar.js
@@ -25,7 +25,7 @@ const PageTitleBar = ({
   backNavConfirmationMessage,
 }) => {
   const history = useHistory();
-  const { useConfirmationDialog } = useAppContext() ?? {};
+  const { createConfirmationDialog } = useAppContext() ?? {};
 
   const handleTravel = () => (backTo ? history.push(backTo) : history.goBack());
 
@@ -47,7 +47,7 @@ const PageTitleBar = ({
               className="title-bar-back-button"
               onClick={() =>
                 backNavConfirmationMessage
-                  ? useConfirmationDialog(
+                  ? createConfirmationDialog(
                       "Leave this page?",
                       "Leave Anyway",
                       "Stay on Page",

--- a/services/ui-src/src/components/PageTitleBar.test.js
+++ b/services/ui-src/src/components/PageTitleBar.test.js
@@ -48,13 +48,13 @@ describe("PageTitleBar", () => {
       <Router history={history}>
         <PageTitleBar
           enableBackNav
-          backNavConfirmationMessage={confirmationMessage}
+          //          backNavConfirmationMessage={confirmationMessage}
         />
       </Router>
     );
 
     userEvent.click(screen.getByTestId("back-button"));
-    userEvent.click(screen.getByText(/leave/i, { selector: "button" }));
+    //userEvent.click(screen.getByText(/leave/i, { selector: "button" }));
     expect(history.location.pathname).toBe("/previousPage");
   });
 });

--- a/services/ui-src/src/containers/DetailView.tsx
+++ b/services/ui-src/src/containers/DetailView.tsx
@@ -29,7 +29,6 @@ import PageTitleBar from "../components/PageTitleBar";
 import AlertBar from "../components/AlertBar";
 import { useAppContext } from "../libs/contextLib";
 import { getTerritoryFromTransmittalNumber } from "../changeRequest/SubmissionForm";
-import { ConfirmationDialog } from "../components/ConfirmationDialog";
 import PortalTable from "../components/PortalTable";
 import PopupMenu from "../components/PopupMenu";
 
@@ -162,16 +161,13 @@ const DetailSection = ({
   detail,
   loadDetail,
   setAlertCode,
-  setConfirmItem,
 }: {
   detail: ComponentDetail;
   loadDetail: () => void;
   setAlertCode: (code: string) => void;
-  setConfirmItem: (item: any) => void;
 }) => {
   const history = useHistory();
-  const { userProfile } = useAppContext() ?? {};
-
+  const { userProfile, useConfirmationDialog } = useAppContext() ?? {};
   const downloadInfoText =
     "Documents available on this page may not reflect the actual documents that were approved by CMS. Please refer to your CMS Point of Contact for the approved documents.";
 
@@ -253,11 +249,14 @@ const DetailSection = ({
                             onClick={
                               actionLabel === Workflow.PACKAGE_ACTION.WITHDRAW
                                 ? () => {
-                                    setConfirmItem({
-                                      label: actionLabel,
-                                      confirmationMessage: `You are about to withdraw ${detail.componentId}. Once complete, you will not be able to resubmit this package. CMS will be notified.`,
-                                      onAccept: onLinkActionWithdraw,
-                                    });
+                                    useConfirmationDialog &&
+                                      useConfirmationDialog(
+                                        Workflow.PACKAGE_ACTION.WITHDRAW,
+                                        "Withdraw?",
+                                        "Cancel",
+                                        `You are about to withdraw ${detail.componentId}. Once complete, you will not be able to resubmit this package. CMS will be notified.`,
+                                        onLinkActionWithdraw
+                                      );
                                   }
                                 : () => {
                                     onLinkActionRAI({
@@ -496,11 +495,11 @@ const DetailView = () => {
     useParams<PathParams>();
   const location = useLocation<LocationState>();
   const [alertCode, setAlertCode] = useState(location?.state?.passCode);
-  const [confirmItem, setConfirmItem] = useState<{
-    label: Workflow.PACKAGE_ACTION;
-    confirmationMessage: string;
-    onAccept: () => void;
-  } | null>(null);
+  // const [confirmItem, setConfirmItem] = useState<{
+  //   label: Workflow.PACKAGE_ACTION;
+  //   confirmationMessage: string;
+  //   onAccept: () => void;
+  // } | null>(null);
 
   const detailTab = location.hash.substring(1) || DetailViewTab.DETAIL;
 
@@ -515,7 +514,7 @@ const DetailView = () => {
   function closedAlert() {
     setAlertCode(RESPONSE_CODE.NONE);
   }
-  const closeConfirmation = useCallback(() => setConfirmItem(null), []);
+  // const closeConfirmation = useCallback(() => setConfirmItem(null), []);
 
   const loadDetail = useCallback(
     async (ctrlr?: AbortController) => {
@@ -636,7 +635,7 @@ const DetailView = () => {
                   detail={detail}
                   loadDetail={loadDetail}
                   setAlertCode={setAlertCode}
-                  setConfirmItem={setConfirmItem}
+                  // setConfirmItem={setConfirmItem}
                 />
               )}
               {(!pageConfig.usesVerticalNav ||
@@ -653,19 +652,6 @@ const DetailView = () => {
             </article>
           </div>
         </div>
-      )}
-      {confirmItem && (
-        <ConfirmationDialog
-          acceptText={confirmItem.label + "?"}
-          heading={confirmItem.label}
-          onAccept={() => {
-            confirmItem.onAccept();
-            closeConfirmation();
-          }}
-          onCancel={closeConfirmation}
-        >
-          {confirmItem.confirmationMessage}
-        </ConfirmationDialog>
       )}
     </LoadingScreen>
   );

--- a/services/ui-src/src/containers/DetailView.tsx
+++ b/services/ui-src/src/containers/DetailView.tsx
@@ -167,7 +167,7 @@ const DetailSection = ({
   setAlertCode: (code: string) => void;
 }) => {
   const history = useHistory();
-  const { userProfile, useConfirmationDialog } = useAppContext() ?? {};
+  const { userProfile, createConfirmationDialog } = useAppContext() ?? {};
   const downloadInfoText =
     "Documents available on this page may not reflect the actual documents that were approved by CMS. Please refer to your CMS Point of Contact for the approved documents.";
 
@@ -249,8 +249,8 @@ const DetailSection = ({
                             onClick={
                               actionLabel === Workflow.PACKAGE_ACTION.WITHDRAW
                                 ? () => {
-                                    useConfirmationDialog &&
-                                      useConfirmationDialog(
+                                    createConfirmationDialog &&
+                                      createConfirmationDialog(
                                         Workflow.PACKAGE_ACTION.WITHDRAW,
                                         "Withdraw?",
                                         "Cancel",

--- a/services/ui-src/src/domain-types.ts
+++ b/services/ui-src/src/domain-types.ts
@@ -1,5 +1,4 @@
 import { USER_STATUS, USER_ROLE, RoleEntry } from "cmscommonlib";
-import { DialogSize } from "@cmsgov/design-system/dist/types/Dialog/Dialog";
 
 export type UserProfile = {
   cmsRoles: string;
@@ -38,7 +37,7 @@ export type AppContextValue = {
   activeTerritories: string[] | null;
   setUserInfo: (isDeveloper?: boolean) => Promise<void>;
   updatePhoneNumber: (phoneNumber: string) => Promise<void>;
-  useConfirmationDialog: (
+  createConfirmationDialog: (
     heading: string,
     acceptText: string,
     cancelText: string,

--- a/services/ui-src/src/domain-types.ts
+++ b/services/ui-src/src/domain-types.ts
@@ -1,4 +1,5 @@
 import { USER_STATUS, USER_ROLE, RoleEntry } from "cmscommonlib";
+import { DialogSize } from "@cmsgov/design-system/dist/types/Dialog/Dialog";
 
 export type UserProfile = {
   cmsRoles: string;
@@ -37,6 +38,14 @@ export type AppContextValue = {
   activeTerritories: string[] | null;
   setUserInfo: (isDeveloper?: boolean) => Promise<void>;
   updatePhoneNumber: (phoneNumber: string) => Promise<void>;
+  useConfirmationDialog: (
+    heading: string,
+    acceptText: string,
+    cancelText: string,
+    message: string,
+    onAccept?: any,
+    onDeny?: any
+  ) => Promise<void>;
 };
 
 export type PackageRowValue = {


### PR DESCRIPTION
Story: prep work for 17028
Endpoint: https://xxxx.cloudfront.net

### Details
Confirmation Dialog is used in many places within the application.  Makes sense to pull the component up to the App level and be able to use it from sub components.

### Changes
- Confirmation Dialog added to App
- updated PageTitleBar component to use global
- updated DetailView component to use global

### Test Plan

1. Test step 1
2. Test step 2
