### PR TITLE
fix typo in nav header

### DIFF
--- a/services/ui-src/src/page/DetailViewDefaults.tsx
+++ b/services/ui-src/src/page/DetailViewDefaults.tsx
@@ -87,7 +87,7 @@ export const defaultPackageOverviewNavItems: DetailNavItem[] = [
   additionalInfoSectionNavItem,
 ];
 
-export const defaultPackageOverviewLabel: string = "PackageOverview";
+export const defaultPackageOverviewLabel: string = "Package Overview";
 
 export const defaultDetail: OneMACDetail = {
   actionLabel: "Package Actions",


### PR DESCRIPTION
Fixed a Typo in the details view left nav header. PackageOverview => Package Overview