### PR TITLE
Temporary Extension details test

### DIFF
--- a/tests/cypress/cypress/integration/Package_Dashboard_Temporary_Extension_Form.spec.feature
+++ b/tests/cypress/cypress/integration/Package_Dashboard_Temporary_Extension_Form.spec.feature
@@ -19,6 +19,14 @@ Feature: OY2-16333 Update Waiver Form: Temporary Extension
         And click the Waiver Number link in the first row
         And click on the Temporary Extension nav button
         And verify the temporary extension exists
+        And click on the link for temporary extension number 1
+        And verify the details section exists
+        And verify there is a Type header in the details section
+        And verify the type is 1915(b) Temporary Extension
+        And verify there is a State header in the details section
+        And verify a state exists for the State
+        And verify there is a Date Submitted header in the details section
+        And verify a date exists for the Date Submitted
 
     Scenario: Verify user can withdraw temporary extension from mini-dashboard page
         Then click on New Submission

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -2039,6 +2039,9 @@ And("verify the type is Base Waiver", () => {
 And("verify the type is Waiver Renewal", () => {
   OneMacPackageDetailsPage.verifyTypeContainsWaiverRenewal();
 });
+And("verify the type is 1915(b) Temporary Extension", () => {
+  OneMacPackageDetailsPage.verifyTypeContainsTempExtension();
+});
 And("verify there is a State header in the details section", () => {
   OneMacPackageDetailsPage.verifyStateHeaderExists();
 });
@@ -2199,6 +2202,13 @@ And("select proposed effective date 3 months from today", () => {
 And("Type Temporary Extension Number 1 With 5 Characters", () => {
   cy.fixture("packageDashboardWaiverNumbers.json").then((data) => {
     OneMacSubmitNewWaiverActionPage.inputWaiverNumber(
+      data.newTemporaryExtensionNumber1
+    );
+  });
+});
+And("click on the link for temporary extension number 1", () => {
+  cy.fixture("packageDashboardWaiverNumbers.json").then((data) => {
+    OneMacPackageDetailsPage.clickTempExtensionID(
       data.newTemporaryExtensionNumber1
     );
   });

--- a/tests/cypress/support/pages/oneMacPackageDetailsPage.js
+++ b/tests/cypress/support/pages/oneMacPackageDetailsPage.js
@@ -95,6 +95,9 @@ export class oneMacPackageDetailsPage {
   verifyTypeContainsWaiverRenewal() {
     cy.xpath(typeHeader).next().contains("Waiver Renewal");
   }
+  verifyTypeContainsTempExtension() {
+    cy.xpath(typeHeader).next().contains("1915(b) Temporary Extension");
+  }
   verifyStateHeaderExists() {
     cy.xpath(stateHeader).should("be.visible");
   }
@@ -200,6 +203,9 @@ export class oneMacPackageDetailsPage {
   }
   verifyTempExtensionIDExists(num) {
     cy.xpath(tempExtensionID).contains(num).should("be.visible");
+  }
+  clickTempExtensionID(num) {
+    cy.xpath(tempExtensionID).contains(num).click();
   }
   clickTempExtensionActionBtn(num) {
     cy.xpath(tempExtensionID).contains(num).next().next().click();


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-16334
Update the creation scenario to include verifying the Temp Ext. Details page.
### Test Plan

```
    Scenario: Verify user can create a temporary extension and that it is in the temporary extensions list
        Then click on New Submission
        And Click on Waiver Action
        And Click on Request Temporary Extension
        And Type Temporary Extension Number 1 With 5 Characters
        And upload Waiver Extension Request
        And Type "This is just a test" in Summary Box
        And Click on Submit Button
        And click on Packages
        And click on the Waivers tab
        And search for Base Waiver Number 1 with 12 Characters
        And click the Waiver Number link in the first row
        And click on the Temporary Extension nav button
        And verify the temporary extension exists
        And click on the link for temporary extension number 1
        And verify the details section exists
        And verify there is a Type header in the details section
        And verify the type is 1915(b) Temporary Extension
        And verify there is a State header in the details section
        And verify a state exists for the State
        And verify there is a Date Submitted header in the details section
        And verify a date exists for the Date Submitted
```
