### PR TITLE
OY2-19124 Add CHIP SPA RAI Package Form

### DIFF
--- a/services/app-api/one-seed.json
+++ b/services/app-api/one-seed.json
@@ -2540,6 +2540,214 @@
     "submissionId": "7a50e650-5d03-11ec-ac34-4373607d3ed6"
   },
   {
+    "pk": "MD-22-2345",
+    "sk": "v0#chipspa",
+    "devComment": "Package added via seed data for application testing",
+    "submitterId": "us-east-1:afa582ca-4e4c-4d3b-be9b-d2dbc24c3d1a",
+    "componentType": "chipspa",
+    "currentStatus": "RAI Issued",
+    "attachments": [
+      {
+        "s3Key": "1639695907350/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Current State Plan",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-states-of-withdrawal-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3Aafa582ca-4e4c-4d3b-be9b-d2dbc24c3d1a/1639695907350/picture.jpg"
+      },
+      {
+        "s3Key": "1639695907351/adobe.pdf",
+        "filename": "adobe.pdf",
+        "title": "Amended State Plan Language",
+        "contentType": "application/pdf",
+        "url": "https://uploads-states-of-withdrawal-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3Aafa582ca-4e4c-4d3b-be9b-d2dbc24c3d1a/1639695907351/adobe.pdf"
+      },
+      {
+        "s3Key": "1639695907351/adobe.pdf",
+        "filename": "adobe.pdf",
+        "title": "Cover Letter",
+        "contentType": "application/pdf",
+        "url": "https://uploads-states-of-withdrawal-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3Aafa582ca-4e4c-4d3b-be9b-d2dbc24c3d1a/1639695907351/adobe.pdf"
+      }
+    ],
+    "GSI1sk": "MD-22-2345",
+    "additionalInformation": "This is just a test",
+    "submissionTimestamp": 1639695908900,
+    "Latest": 1,
+    "GSI1pk": "OneMAC#spa",
+    "clockEndTimestamp": 1646941106000,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "componentId": "MD-22-2345",
+    "submitterName": "StateSubmitter Nightwatch",
+    "submissionId": "9d1ac120-5ec4-11ec-b2ea-eb35c89f340d"
+  },
+  {
+    "pk": "MD-22-2345",
+    "sk": "v1#chipspa",
+    "devComment": "Package added via seed data for application testing",
+    "submitterId": "us-east-1:afa582ca-4e4c-4d3b-be9b-d2dbc24c3d1a",
+    "componentType": "chipspa",
+    "currentStatus": "RAI Issued",
+    "attachments": [
+      {
+        "s3Key": "1639695907350/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Current State Plan",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-states-of-withdrawal-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3Aafa582ca-4e4c-4d3b-be9b-d2dbc24c3d1a/1639695907350/picture.jpg"
+      },
+      {
+        "s3Key": "1639695907351/adobe.pdf",
+        "filename": "adobe.pdf",
+        "title": "Amended State Plan Language",
+        "contentType": "application/pdf",
+        "url": "https://uploads-states-of-withdrawal-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3Aafa582ca-4e4c-4d3b-be9b-d2dbc24c3d1a/1639695907351/adobe.pdf"
+      },
+      {
+        "s3Key": "1639695907351/adobe.pdf",
+        "filename": "adobe.pdf",
+        "title": "Cover Letter",
+        "contentType": "application/pdf",
+        "url": "https://uploads-states-of-withdrawal-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3Aafa582ca-4e4c-4d3b-be9b-d2dbc24c3d1a/1639695907351/adobe.pdf"
+      }
+    ],
+    "additionalInformation": "This is just a test",
+    "submissionTimestamp": 1639695908900,
+    "Latest": 1,
+    "clockEndTimestamp": 1646941106000,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "componentId": "MD-22-2345",
+    "submitterName": "StateSubmitter Nightwatch",
+    "submissionId": "9d1ac120-5ec4-11ec-b2ea-eb35c89f340d"
+  },
+  {
+    "pk": "MD-22-2345",
+    "sk": "v0#chipsparai#1639604007869",
+    "devComment": "Package added via seed data for application testing",
+    "submitterId": "us-east-1:3211a6ff-043f-436b-8313-1b314582b2a5",
+    "componentType": "chipsparai",
+    "currentStatus": "Submitted",
+    "attachments": [
+      {
+        "s3Key": "1639503005592/CMS 179 Form Acronym Removal Signed.pdf",
+        "filename": "CMS 179 Form Acronym Removal Signed.pdf",
+        "title": "CMS Form 179",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A3211a6ff-043f-436b-8313-1b314582b2a5/1639503005592/CMS%20179%20Form%20Acronym%20Removal%20Signed.pdf"
+      },
+      {
+        "s3Key": "1639503005594/Attachment 3.1-A, #4b, Page 3f Track.pdf",
+        "filename": "Attachment 3.1-A, #4b, Page 3f Track.pdf",
+        "title": "SPA Pages",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A3211a6ff-043f-436b-8313-1b314582b2a5/1639503005594/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Track.pdf"
+      }
+    ],
+    "GSI1sk": "MD-22-2345",
+    "additionalInformation": "What is the response",
+    "submissionTimestamp": 1639604007869,
+    "GSI1pk": "OneMAC#chipsparai",
+    "Latest": 1,
+    "submitterEmail": "statesubmitteractive@cms.hhs.local",
+    "componentId": "MD-22-2345",
+    "submitterName": "Angie Active",
+    "submissionId": "7a50e650-5d03-11ec-ac34-4373607d3ed6"
+  },
+  {
+    "pk": "MD-22-2345",
+    "sk": "v1#chipsparai#1639604007869",
+    "devComment": "Package added via seed data for application testing",
+    "submitterId": "us-east-1:3211a6ff-043f-436b-8313-1b314582b2a5",
+    "componentType": "chipsparai",
+    "currentStatus": "Submitted",
+    "attachments": [
+      {
+        "s3Key": "1639503005592/CMS 179 Form Acronym Removal Signed.pdf",
+        "filename": "CMS 179 Form Acronym Removal Signed.pdf",
+        "title": "CMS Form 179",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A3211a6ff-043f-436b-8313-1b314582b2a5/1639503005592/CMS%20179%20Form%20Acronym%20Removal%20Signed.pdf"
+      },
+      {
+        "s3Key": "1639503005594/Attachment 3.1-A, #4b, Page 3f Track.pdf",
+        "filename": "Attachment 3.1-A, #4b, Page 3f Track.pdf",
+        "title": "SPA Pages",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A3211a6ff-043f-436b-8313-1b314582b2a5/1639503005594/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Track.pdf"
+      }
+    ],
+    "additionalInformation": "What is the response",
+    "submissionTimestamp": 1639604007869,
+    "Latest": 1,
+    "submitterEmail": "statesubmitteractive@cms.hhs.local",
+    "componentId": "MD-22-2345",
+    "submitterName": "Angie Active",
+    "submissionId": "7a50e650-5d03-11ec-ac34-4373607d3ed6"
+  },
+  {
+    "pk": "MD-22-2345",
+    "sk": "v0#chipsparai#1639503006869",
+    "devComment": "Package added via seed data for application testing",
+    "submitterId": "us-east-1:3211a6ff-043f-436b-8313-1b314582b2a5",
+    "componentType": "chipsparai",
+    "currentStatus": "Submitted",
+    "attachments": [
+      {
+        "s3Key": "1639503005592/CMS 179 Form Acronym Removal Signed.pdf",
+        "filename": "CMS 179 Form Acronym Removal Signed.pdf",
+        "title": "CMS Form 179",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A3211a6ff-043f-436b-8313-1b314582b2a5/1639503005592/CMS%20179%20Form%20Acronym%20Removal%20Signed.pdf"
+      },
+      {
+        "s3Key": "1639503005594/Attachment 3.1-A, #4b, Page 3f Track.pdf",
+        "filename": "Attachment 3.1-A, #4b, Page 3f Track.pdf",
+        "title": "SPA Pages",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A3211a6ff-043f-436b-8313-1b314582b2a5/1639503005594/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Track.pdf"
+      }
+    ],
+    "GSI1sk": "MD-22-2345",
+    "additionalInformation": "What is the response",
+    "submissionTimestamp": 1639503006869,
+    "GSI1pk": "OneMAC#chipsparai",
+    "Latest": 1,
+    "submitterEmail": "statesubmitteractive@cms.hhs.local",
+    "componentId": "MD-22-2345",
+    "submitterName": "Angie Active",
+    "submissionId": "7a50e650-5d03-11ec-ac34-4373607d3ed6"
+  },
+  {
+    "pk": "MD-22-2345",
+    "sk": "v1#chipsparai#1639503006869",
+    "devComment": "Package added via seed data for application testing",
+    "submitterId": "us-east-1:3211a6ff-043f-436b-8313-1b314582b2a5",
+    "componentType": "chipsparai",
+    "currentStatus": "Submitted",
+    "attachments": [
+      {
+        "s3Key": "1639503005592/CMS 179 Form Acronym Removal Signed.pdf",
+        "filename": "CMS 179 Form Acronym Removal Signed.pdf",
+        "title": "CMS Form 179",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A3211a6ff-043f-436b-8313-1b314582b2a5/1639503005592/CMS%20179%20Form%20Acronym%20Removal%20Signed.pdf"
+      },
+      {
+        "s3Key": "1639503005594/Attachment 3.1-A, #4b, Page 3f Track.pdf",
+        "filename": "Attachment 3.1-A, #4b, Page 3f Track.pdf",
+        "title": "SPA Pages",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A3211a6ff-043f-436b-8313-1b314582b2a5/1639503005594/Attachment%203.1-A%2C%20%234b%2C%20Page%203f%20Track.pdf"
+      }
+    ],
+    "additionalInformation": "What is the response",
+    "submissionTimestamp": 1639503006869,
+    "Latest": 1,
+    "submitterEmail": "statesubmitteractive@cms.hhs.local",
+    "componentId": "MD-22-2345",
+    "submitterName": "Angie Active",
+    "submissionId": "7a50e650-5d03-11ec-ac34-4373607d3ed6"
+  },
+  {
     "pk": "VA.1117.R00.00",
     "sk": "v0#waivernew",
     "submitterId": "us-east-1:3211a6ff-043f-436b-8313-1b314582b2a5",

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -152,6 +152,16 @@ functions:
           cors: true
           authorizer: aws_iam
 
+  submitCHIPSPARAIResponse:
+    handler: form/submitCHIPSPARAIResponse.main
+    role: LambdaApiRole
+    events:
+      - http:
+          path: submitCHIPSPARAIResponse
+          method: post
+          cors: true
+          authorizer: aws_iam
+
   submitWaiverExtension:
     handler: form/submitWaiverExtension.main
     role: LambdaApiRole

--- a/services/common/routes.js
+++ b/services/common/routes.js
@@ -46,6 +46,7 @@ export const ONEMAC_ROUTES = {
   MEDICAID_SPA_RAI: "/medicaid-spa-rai",
   CHIP_SPA: "/chip-spa",
   CHIP_SPA_DETAIL: "/detail/chip-spa",
+  CHIP_SPA_RAI: "/chip-spa-rai",
   BASE_WAIVER: "/base-waiver",
   BASE_WAIVER_DETAIL: "/detail/base-waiver",
   WAIVER_RENEWAL: "/waiver-renewal",
@@ -72,7 +73,7 @@ export const TYPE_TO_DETAIL_ROUTE = {
 
 export const TYPE_TO_RAI_ROUTE = {
   [ONEMAC_TYPE.MEDICAID_SPA]: ONEMAC_ROUTES.MEDICAID_SPA_RAI,
-  [ONEMAC_TYPE.CHIP_SPA]: "",
+  [ONEMAC_TYPE.CHIP_SPA]: ONEMAC_ROUTES.CHIP_SPA_RAI,
   [ONEMAC_TYPE.WAIVER_BASE]: "",
   [ONEMAC_TYPE.WAIVER_RENEWAL]: "",
   [ONEMAC_TYPE.WAIVER_AMENDMENT]: "",

--- a/services/ui-src/src/Routes.tsx
+++ b/services/ui-src/src/Routes.tsx
@@ -44,6 +44,7 @@ import MedicaidSPADetail from "./page/medicaid-spa/MedicaidSPADetail";
 import ChipSpaForm from "./page/chip-spa/ChipSpaForm";
 import CHIPSPADetail from "./page/chip-spa/CHIPSPADetail";
 import MedicaidSPARAIForm from "./page/medicaid-spa/MedicaidSPARAIForm";
+import CHIPSPARAIForm from "./page/chip-spa/CHIPSPARAIForm";
 
 // this is legacy and should not be touched!
 const FORM_TYPES = {
@@ -205,6 +206,7 @@ const ROUTE_LIST: RouteSpec[] = [
     { path: ONEMAC_ROUTES.MEDICAID_SPA, component: MedicaidSpaForm },
     { path: ONEMAC_ROUTES.CHIP_SPA, component: ChipSpaForm },
     { path: ONEMAC_ROUTES.MEDICAID_SPA_RAI, component: MedicaidSPARAIForm },
+    { path: ONEMAC_ROUTES.CHIP_SPA_RAI, component: CHIPSPARAIForm },
     { path: ONEMAC_ROUTES.BASE_WAIVER, component: BaseWaiverForm },
     {
       path: ONEMAC_ROUTES.TEMPORARY_EXTENSION,

--- a/services/ui-src/src/libs/detailLib.ts
+++ b/services/ui-src/src/libs/detailLib.ts
@@ -1,4 +1,4 @@
-import { ROUTES, Workflow } from "cmscommonlib";
+import { Workflow } from "cmscommonlib";
 
 export type AttributeDetail = {
   heading: string;
@@ -15,7 +15,6 @@ export type OneMACDetail = {
   show90thDayInfo: boolean;
   showEffectiveDate: boolean;
   actionsByStatus: Record<string, Workflow.PACKAGE_ACTION[]>;
-  raiLink: string;
   detailHeader?: string;
   detailSection: AttributeDetail[];
   allowWaiverExtension: boolean;
@@ -104,7 +103,6 @@ export const defaultDetail: OneMACDetail = {
   show90thDayInfo: true,
   showEffectiveDate: false,
   detailHeader: "Package",
-  raiLink: ROUTES.WAIVER_RAI,
   defaultTitle: null,
   allowWaiverExtension: false,
   detailSection: [

--- a/services/ui-src/src/libs/formLib.tsx
+++ b/services/ui-src/src/libs/formLib.tsx
@@ -3,7 +3,6 @@ import {
   IdValidation,
   SelectOption,
   FileUploadProps,
-  Workflow,
   ONEMAC_ROUTES,
 } from "cmscommonlib";
 
@@ -14,7 +13,6 @@ export type OneMACFormConfig = {
   pageTitle: string;
   addlIntroJSX?: string;
   detailsHeader?: string;
-  actionsByStatus: Record<string, Workflow.PACKAGE_ACTION[]>;
   landingPage: string;
   confirmSubmit?: boolean;
   proposedEffectiveDate?: boolean;
@@ -23,9 +21,12 @@ export type OneMACFormConfig = {
   Partial<WaiverPackageType>;
 
 export const defaultOneMACFormConfig = {
-  actionsByStatus: Workflow.defaultActionsByStatus,
-  proposedEffectiveDate: false,
+  idFormat: "",
+  idFieldHint: [],
+  idFAQLink: "",
+  addlIntroJSX: "",
   landingPage: ONEMAC_ROUTES.PACKAGE_LIST,
+  proposedEffectiveDate: false,
   confirmSubmit: false,
 };
 

--- a/services/ui-src/src/page/base-waiver/BaseWaiverDetail.tsx
+++ b/services/ui-src/src/page/base-waiver/BaseWaiverDetail.tsx
@@ -12,7 +12,7 @@ import {
   defaultPackageOverviewLabel,
   tempExtensionSectionNavItem,
 } from "../../libs/detailLib";
-import { ROUTES, baseWaiver, Workflow } from "cmscommonlib";
+import { baseWaiver, Workflow } from "cmscommonlib";
 
 export const baseWaiverDetail: OneMACDetail = {
   ...defaultDetail,
@@ -30,7 +30,6 @@ export const baseWaiverDetail: OneMACDetail = {
     submissionDateDefault,
     proposedEffectiveDateDefault,
   ],
-  raiLink: ROUTES.WAIVER_RAI,
   actionsByStatus: Workflow.baseWaiverActionsByStatus,
 };
 

--- a/services/ui-src/src/page/chip-spa/CHIPSPADetail.tsx
+++ b/services/ui-src/src/page/chip-spa/CHIPSPADetail.tsx
@@ -6,7 +6,6 @@ import { chipSPA } from "cmscommonlib";
 export const chipSPADetail: OneMACDetail = {
   ...defaultDetail,
   ...chipSPA,
-  raiLink: "",
 };
 
 const CHIPSPADetail: FC = () => {

--- a/services/ui-src/src/page/chip-spa/CHIPSPARAIForm.test.js
+++ b/services/ui-src/src/page/chip-spa/CHIPSPARAIForm.test.js
@@ -1,0 +1,66 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryHistory } from "history";
+import { Router } from "react-router-dom";
+import { stateSubmitterInitialAuthState } from "../../libs/testDataAppContext";
+
+import { ONEMAC_ROUTES } from "cmscommonlib";
+import CHIPSPARAIForm from "./CHIPSPARAIForm";
+import { AppContext } from "../../libs/contextLib";
+
+jest.mock("../../utils/ChangeRequestDataApi");
+
+window.HTMLElement.prototype.scrollIntoView = jest.fn();
+window.scrollTo = jest.fn();
+
+describe("CHIP SPA RAI Form", () => {
+  let history;
+
+  const testComponentId = "MD-1234";
+
+  beforeEach(() => {
+    history = createMemoryHistory();
+    history.push(ONEMAC_ROUTES.CHIP_SPA_RAI, {
+      componentId: testComponentId,
+    });
+  });
+
+  it("has the submit button disabled on initial load", async () => {
+    const handleSubmit = jest.fn();
+
+    render(
+      <AppContext.Provider
+        value={{
+          ...stateSubmitterInitialAuthState,
+        }}
+      >
+        <Router history={history}>
+          <CHIPSPARAIForm />
+        </Router>
+      </AppContext.Provider>
+    );
+
+    const submitButtonEl = screen.getByText("Submit");
+
+    userEvent.click(submitButtonEl);
+    expect(handleSubmit).not.toBeCalled();
+  });
+
+  it("has the parent spa listed as text on the page", async () => {
+    render(
+      <AppContext.Provider
+        value={{
+          ...stateSubmitterInitialAuthState,
+        }}
+      >
+        <Router history={history}>
+          <CHIPSPARAIForm />
+        </Router>
+      </AppContext.Provider>
+    );
+
+    //verify spa id appears as text element
+    screen.getByText(testComponentId);
+  });
+});

--- a/services/ui-src/src/page/chip-spa/CHIPSPARAIForm.tsx
+++ b/services/ui-src/src/page/chip-spa/CHIPSPARAIForm.tsx
@@ -1,23 +1,23 @@
 import React, { FC } from "react";
 import OneMACForm from "../OneMACForm";
 import { defaultOneMACFormConfig, OneMACFormConfig } from "../../libs/formLib";
-import { ONEMAC_ROUTES, medicaidSPARAIResponse } from "cmscommonlib";
+import { ONEMAC_ROUTES, chipSPARAIResponse } from "cmscommonlib";
 import { FormLocationState } from "../../domain-types";
 import { useLocation } from "react-router-dom";
 
-const MedicaidSPARAIForm: FC = () => {
+const CHIPSPARAIForm: FC = () => {
   const location = useLocation<FormLocationState>();
-  const medicaidSPARAIFormInfo: OneMACFormConfig = {
+  const chipSPARAIFormInfo: OneMACFormConfig = {
     ...defaultOneMACFormConfig,
-    ...medicaidSPARAIResponse,
+    ...chipSPARAIResponse,
     pageTitle: "Formal Request for Additional Information Response",
-    detailsHeader: "Medicaid SPA RAI",
+    detailsHeader: "Formal CHIP SPA RAI",
     landingPage:
-      ONEMAC_ROUTES.MEDICAID_SPA_DETAIL + `/${location.state?.componentId}`,
+      ONEMAC_ROUTES.CHIP_SPA_DETAIL + `/${location.state?.componentId}`,
     confirmSubmit: true,
   };
 
-  return <OneMACForm formConfig={medicaidSPARAIFormInfo} />;
+  return <OneMACForm formConfig={chipSPARAIFormInfo} />;
 };
 
-export default MedicaidSPARAIForm;
+export default CHIPSPARAIForm;

--- a/services/ui-src/src/page/chip-spa/ChipSpaForm.tsx
+++ b/services/ui-src/src/page/chip-spa/ChipSpaForm.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import OneMACForm from "../OneMACForm";
 import { defaultOneMACFormConfig, OneMACFormConfig } from "../../libs/formLib";
-import { ROUTES, ONEMAC_ROUTES, chipSPA, Workflow } from "cmscommonlib";
+import { ROUTES, ONEMAC_ROUTES, chipSPA } from "cmscommonlib";
 
 const idFormat: string = "SS-YY-NNNN-xxxx";
 
@@ -15,7 +15,6 @@ const chipSpaFormInfo: OneMACFormConfig = {
   proposedEffectiveDate: true,
   idFAQLink: ROUTES.FAQ_SPA_ID,
   idFormat: idFormat,
-  actionsByStatus: Workflow.defaultActionsByStatus,
   landingPage: ONEMAC_ROUTES.PACKAGE_LIST_SPA,
 };
 

--- a/services/ui-src/src/page/medicaid-spa/MedicaidSPADetail.tsx
+++ b/services/ui-src/src/page/medicaid-spa/MedicaidSPADetail.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from "react";
 import DetailView from "../DetailView";
-import { Workflow, medicaidSPA, ONEMAC_ROUTES } from "cmscommonlib";
+import { Workflow, medicaidSPA } from "cmscommonlib";
 import { OneMACDetail, defaultDetail } from "../../libs/detailLib";
 
 export const medicaidSPADetail: OneMACDetail = {
@@ -8,7 +8,6 @@ export const medicaidSPADetail: OneMACDetail = {
   ...medicaidSPA,
   usesVerticalNav: true,
   actionsByStatus: Workflow.defaultActionsByStatus,
-  raiLink: ONEMAC_ROUTES.MEDICAID_SPA_RAI,
 };
 
 const MedicaidSPADetail: FC = () => {

--- a/services/ui-src/src/page/section/DetailSection.tsx
+++ b/services/ui-src/src/page/section/DetailSection.tsx
@@ -20,6 +20,7 @@ import { ComponentDetail } from "../DetailView";
 import { OneMACDetail } from "../../libs/detailLib";
 import FileList from "../../components/FileList";
 import { AdditionalInfoSection } from "./AdditionalInfoSection";
+import { TYPE_TO_RAI_ROUTE } from "cmscommonlib/routes";
 
 export const DetailSection = ({
   pageConfig,
@@ -121,7 +122,9 @@ export const DetailSection = ({
                                   Workflow.PACKAGE_ACTION.RESPOND_TO_RAI
                                 ? () => {
                                     onLinkAction({
-                                      href: pageConfig.raiLink,
+                                      href: TYPE_TO_RAI_ROUTE[
+                                        detail.componentType
+                                      ],
                                       state: {
                                         componentId: detail.componentId,
                                       },

--- a/services/ui-src/src/page/temporary-extension/TemporaryExtensionDetail.tsx
+++ b/services/ui-src/src/page/temporary-extension/TemporaryExtensionDetail.tsx
@@ -23,7 +23,6 @@ export const waiverTemporaryExtensionDetail: OneMACDetail = {
   usesVerticalNav: false,
   actionsByStatus: Workflow.waiverExtensionActionsByStatus,
   show90thDayInfo: false,
-  raiLink: "",
   detailSection: [parentIdDetail, typeDefault, submissionDateDefault],
 };
 

--- a/services/ui-src/src/page/temporary-extension/TemporaryExtensionForm.tsx
+++ b/services/ui-src/src/page/temporary-extension/TemporaryExtensionForm.tsx
@@ -6,7 +6,6 @@ import {
   waiverTemporaryExtension,
   ONEMAC_ROUTES,
   TYPE_TO_DETAIL_ROUTE,
-  Workflow,
 } from "cmscommonlib";
 import { FormLocationState } from "../../domain-types";
 import { useLocation } from "react-router-dom";
@@ -29,7 +28,6 @@ const TemporaryExtensionForm: FC = () => {
       },
     ],
     idFormat: idFormat,
-    actionsByStatus: Workflow.defaultActionsByStatus,
     landingPage:
       location.state?.parentType && location.state?.parentId
         ? TYPE_TO_DETAIL_ROUTE[location.state?.parentType] +

--- a/services/ui-src/src/page/waiver-amendment/WaiverAmendmentDetail.tsx
+++ b/services/ui-src/src/page/waiver-amendment/WaiverAmendmentDetail.tsx
@@ -5,7 +5,7 @@ import {
   defaultDetail,
   waiverAuthorityDefault,
 } from "../../libs/detailLib";
-import { ROUTES, waiverAmendment } from "cmscommonlib";
+import { waiverAmendment } from "cmscommonlib";
 
 export const waiverAmendmentDetail: OneMACDetail = {
   ...defaultDetail,
@@ -23,7 +23,6 @@ export const waiverAmendmentDetail: OneMACDetail = {
     },
     waiverAuthorityDefault,
   ],
-  raiLink: ROUTES.WAIVER_RAI,
 };
 
 const WaiverAmendmentDetail: FC = () => {


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-19124
Endpoint: https://d18wzhqs2csgp4.cloudfront.net/

### Details

Build CHIP SPA RAI Response form for package view.

### Changes

- Add form
- Added TYPE_TO_RAI_ROUTE config
- Removed rai config from detail config and pointed detail page link to common TYPE_TO_RAI_ROUTE lookup

### Test Plan

1. Login as state submitter
2. Navigate to a CHIP SPA that is in status RAI Issued
3. Verify Respond to RAI is action option from package list (ellipse action menu) and that clicking the action takes you to the CHIP SPA RAI Response form
4. Verify Respond to RAI is an action option from the CHIP SPA details page in the Actions section and that clicking the action link takes you to the CHIP SPA RAI Response form
5. Verify the CHIP SPA RAI Response form has the parent CHIP SPA ID as uneditable text
6. Verify the CHIP SPA RAI Response form has the appropriate required attachments
7. Verify upon submit of the CHIP SPA RAI Response form that a confirmation popup appears
8. Verify upon selecting Yes on the popup navigates back to the parent CHIP SPA with a green success banner
9. Verify the newly submitted CHIP SPA RAI Response is on the details tab of the parent CHIP SPA in the RAI Responses section
