### PR TITLE
Oy2 19034

### DIFF
--- a/services/ui-src/.gitignore
+++ b/services/ui-src/.gitignore
@@ -30,5 +30,3 @@ yarn-debug.log*
 yarn-error.log*
 
 .idea/
-env-config.js
-public/env-config.js

--- a/services/ui-src/public/env-config.js
+++ b/services/ui-src/public/env-config.js
@@ -1,0 +1,16 @@
+window._env_ = {
+  SASS_PATH: "node_modules",
+  API_REGION: "us-east-1",
+  API_URL: "http://localhost:3001/dev",
+  COGNITO_REGION: "us-east-1",
+  COGNITO_IDENTITY_POOL_ID: "us-east-1:0209bcbc-4eb4-40c9-8a2f-bef3c123c4ec",
+  COGNITO_USER_POOL_ID: "us-east-1_KDU39SsRi",
+  COGNITO_USER_POOL_CLIENT_ID: "51g7i130aruj9gugt31mosvfj1",
+  COGNITO_USER_POOL_CLIENT_DOMAIN:
+    "develop-login-51g7i130aruj9gugt31mosvfj1.auth.us-east-1.amazoncognito.com",
+  S3_ATTACHMENTS_BUCKET_REGION: "us-east-1",
+  S3_ATTACHMENTS_BUCKET_NAME: "uploads-develop-attachments-116229642442",
+  ALLOW_DEV_LOGIN: "true",
+  METRICS_USERS: "placeholder",
+  IS_OFFLINE: "true",
+};

--- a/services/ui-src/src/page/section/DetailSection.tsx
+++ b/services/ui-src/src/page/section/DetailSection.tsx
@@ -185,7 +185,7 @@ export const DetailSection = ({
         </section>
         {detail.raiResponses && (
           <section className="detail-section">
-            <h2>RAI Responses</h2>
+            <h2>Formal RAI Responses</h2>
             <Accordion>
               {detail.raiResponses?.map((raiResponse, index) => {
                 return (


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-19034
Endpoint: https://d3a20rfdxsu8bx.cloudfront.net/

### Details

As a OneMAC CMS User, I want the ability to view the details of Medicaid formal RAI Response on SPAs in Package View, so that CMS has all the information needed to make a decision.

### Changes

- Changed details section header from 'RAI Responses' to 'Formal RAI Responses'
- Date formatting carried over from previous story - 19216

### Test Plan

1. Login as state submitter
2. Navigate to Packages > Medicaid Spa with RAI Issued 
3. Check header of the details section is correct
4. Check date format on details
