### PR TITLE
OY2-19124, OY2-19216, and OY2-19034 tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -175,7 +175,7 @@ jobs:
             Package_Dashboard_Filter_options_that_include_Dates.spec.feature,
             Package_Dashboard_Filter.spec.feature,
             Package_Dashboard_Search_Bar.spec.feature,
-            Package_Dashboard_SPA_RAI_Response.spec.feature,
+            Package_Dashboard_Medicaid_SPA_RAI_Response.spec.feature,
             Package_Dashboard_Tabs.spec.feature,
             Package_Dashboard_Waiver_Family_Column.spec.feature,
             Package_Dashboard_Withdraw_Package.spec.feature,
@@ -207,6 +207,7 @@ jobs:
             Package_Dashboard_Appendix_K.spec.feature,
             Package_Dashboard_Waiver_Amendment.spec.feature,
             Package_Dashboard_Base_Waiver_Renewal.spec.feature,
+            Package_Dashboard_CHIP_SPA_RAI_Response.spec.feature,
           ]
     steps:
       - name: set branch_name

--- a/tests/cypress/cypress/integration/Package_Dashboard_CHIP_SPA_RAI_Response.spec.feature
+++ b/tests/cypress/cypress/integration/Package_Dashboard_CHIP_SPA_RAI_Response.spec.feature
@@ -1,0 +1,57 @@
+Feature: RAI Response for CHIP SPA package view
+    Background: Reoccuring Steps
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And Click on Filter Button
+        And click on Type
+        And click Medicaid SPA check box
+        And click on Type
+        And click on Status
+        And click all of the status checkboxes
+        And click RAI Issued checkbox
+        And Click on Filter Button
+
+    Scenario: Respond to RAI from the Package details page and then verify RAI info in package details page
+        And copy the ID from the link in the first row
+        And click the SPA ID link in the first row
+        And verify Respond to RAI action exists
+        And click on Respond to RAI package action
+        And verify the form is titled Formal Request for Additional Information Response
+        And Add file for Revised Amended State Plan Language
+        And Add file for Official RAI Response
+        And Click the Submit Button without waiting
+        And click yes, submit RAI response button
+        And click on Packages
+        And search for the ID copied from the link in the first row
+        And click the SPA ID link in the first row
+        And verify RAI Responses header exists
+        And verify the first RAI Response header is titled
+        And verify the CHIP RAI Responses caret at the top of the list exists and is enabled
+        And verify the title of the CHIP RAI Responses caret at the top of the list is in Submitted on format
+        And verify the CHIP RAI response card at the top of the list exists
+        And verify the download button for the CHIP RAI response at the top of the list exists
+        And verify the first RAI response does not have Additional Info
+
+    Scenario: Respond to RAI from the Package page and then verify RAI info in package details page
+        And copy the ID from the link in the first row
+        And click the actions button in row one
+        And verify the Respond to RAI button is displayed
+        And click the Respond to RAI button
+        And verify the form is titled Formal Request for Additional Information Response
+        And Add file for Revised Amended State Plan Language
+        And Add file for Official RAI Response
+        And Type Additonal Info Comments in new form
+        And Click the Submit Button without waiting
+        And click yes, submit RAI response button
+        And click on Packages
+        And search for the ID copied from the link in the first row
+        And click the SPA ID link in the first row
+        And verify RAI Responses header exists
+        And verify the first RAI Response header is titled
+        And verify the CHIP RAI Responses caret at the top of the list exists and is enabled
+        And verify the title of the CHIP RAI Responses caret at the top of the list is in Submitted on format
+        And verify the CHIP RAI response card at the top of the list exists
+        And verify the download button for the CHIP RAI response at the top of the list exists
+        And verify the first RAI response has Additional Info

--- a/tests/cypress/cypress/integration/Package_Dashboard_Medicaid_SPA_RAI_Response.spec.feature
+++ b/tests/cypress/cypress/integration/Package_Dashboard_Medicaid_SPA_RAI_Response.spec.feature
@@ -1,10 +1,13 @@
-Feature: RAI Response for SPA package view
+Feature: RAI Response for Medicaid SPA package view
     Background: Reoccuring Steps
         Given I am on Login Page
         When Clicking on Development Login
         When Login with state submitter user
         And click on Packages
         And Click on Filter Button
+        And click on Type
+        And click CHIP SPA check box
+        And click on Type
         And click on Status
         And click all of the status checkboxes
         And click RAI Issued checkbox
@@ -15,6 +18,7 @@ Feature: RAI Response for SPA package view
         And click the SPA ID link in the first row
         And verify Respond to RAI action exists
         And click on Respond to RAI package action
+        And verify the form is titled Formal Request for Additional Information Response
         And Add file for RAI Response
         And Click the Submit Button without waiting
         And click yes, submit RAI response button
@@ -22,9 +26,11 @@ Feature: RAI Response for SPA package view
         And search for the ID copied from the link in the first row
         And click the SPA ID link in the first row
         And verify RAI Responses header exists
-        And verify the RAI Responses caret at the top of the list exists and is enabled
-        And verify the RAI response card at the top of the list exists
-        And verify the download button for the RAI response at the top of the list exists
+        And verify the first RAI Response header is titled
+        And verify the Medicaid RAI Responses caret at the top of the list exists and is enabled
+        And verify the title of the Medicaid RAI Responses caret at the top of the list is in Submitted on format
+        And verify the Medicaid RAI response card at the top of the list exists
+        And verify the download button for the Medicaid RAI response at the top of the list exists
         And verify the first RAI response does not have Additional Info
 
     Scenario: Respond to RAI from the Package page and then verify RAI info in package details page
@@ -32,6 +38,7 @@ Feature: RAI Response for SPA package view
         And click the actions button in row one
         And verify the Respond to RAI button is displayed
         And click the Respond to RAI button
+        And verify the form is titled Formal Request for Additional Information Response
         And Add file for RAI Response
         And Type Additonal Info Comments in new form
         And Click the Submit Button without waiting
@@ -40,7 +47,9 @@ Feature: RAI Response for SPA package view
         And search for the ID copied from the link in the first row
         And click the SPA ID link in the first row
         And verify RAI Responses header exists
-        And verify the RAI Responses caret at the top of the list exists and is enabled
-        And verify the RAI response card at the top of the list exists
-        And verify the download button for the RAI response at the top of the list exists
+        And verify the first RAI Response header is titled
+        And verify the Medicaid RAI Responses caret at the top of the list exists and is enabled
+        And verify the title of the Medicaid RAI Responses caret at the top of the list is in Submitted on format
+        And verify the Medicaid RAI response card at the top of the list exists
+        And verify the download button for the Medicaid RAI response at the top of the list exists
         And verify the first RAI response has Additional Info

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -2106,9 +2106,12 @@ And("verify there is a Date Submitted header in the details section", () => {
 And("verify a date exists for the Date Submitted", () => {
   OneMacPackageDetailsPage.verifyDateExists();
 });
-And("verify the Respond to RAI form loads", () => {
-  OneMacRespondToRAIPage.verifyPageLoads();
-});
+And(
+  "verify the form is titled Formal Request for Additional Information Response",
+  () => {
+    OneMacRespondToRAIPage.verifyPageHeader();
+  }
+);
 And("click back arrow", () => {
   OneMacRespondToRAIPage.clickBackArrow();
 });
@@ -2134,18 +2137,48 @@ And("verify RAI Responses header exists", () => {
   OneMacPackageDetailsPage.verifyRaiResponseHeaderExists();
 });
 And(
-  "verify the RAI Responses caret at the top of the list exists and is enabled",
+  "verify the Medicaid RAI Responses caret at the top of the list exists and is enabled",
   () => {
-    OneMacPackageDetailsPage.verifyTopRaiRespCaretExistsAndEnabled();
+    OneMacPackageDetailsPage.verifyMedicaidTopRaiRespCaretExistsAndEnabled();
   }
 );
-And("verify the RAI response card at the top of the list exists", () => {
-  OneMacPackageDetailsPage.verifyTopRaiRespCardExists();
+And(
+  "verify the CHIP RAI Responses caret at the top of the list exists and is enabled",
+  () => {
+    OneMacPackageDetailsPage.verifyCHIPTopRaiRespCaretExistsAndEnabled();
+  }
+);
+And(
+  "verify the title of the Medicaid RAI Responses caret at the top of the list is in Submitted on format",
+  () => {
+    OneMacPackageDetailsPage.verifyMedicaidTopRaiRespCaretTitle();
+  }
+);
+And(
+  "verify the title of the CHIP RAI Responses caret at the top of the list is in Submitted on format",
+  () => {
+    OneMacPackageDetailsPage.verifyCHIPTopRaiRespCaretTitle();
+  }
+);
+And(
+  "verify the Medicaid RAI response card at the top of the list exists",
+  () => {
+    OneMacPackageDetailsPage.verifyMedicaidTopRaiRespCardExists();
+  }
+);
+And("verify the CHIP RAI response card at the top of the list exists", () => {
+  OneMacPackageDetailsPage.verifyCHIPTopRaiRespCardExists();
 });
 And(
-  "verify the download button for the RAI response at the top of the list exists",
+  "verify the download button for the Medicaid RAI response at the top of the list exists",
   () => {
-    OneMacPackageDetailsPage.verifyTopRaiRespDownloadBtnExistsAndEnabled();
+    OneMacPackageDetailsPage.verifyMedicaidTopRaiRespDownloadBtnExistsAndEnabled();
+  }
+);
+And(
+  "verify the download button for the CHIP RAI response at the top of the list exists",
+  () => {
+    OneMacPackageDetailsPage.verifyCHIPTopRaiRespDownloadBtnExistsAndEnabled();
   }
 );
 And("verify the first RAI response does not have Additional Info", () => {
@@ -2356,4 +2389,7 @@ And("verify the actions button is unavailable", () => {
 });
 And("verify actions column is unavailable", () => {
   OneMacPackagePage.verifyActionsColumnDoesNotExist();
+});
+And("verify the first RAI Response header is titled", () => {
+  OneMacPackageDetailsPage.verifyRaiResponseHeaderTitle();
 });

--- a/tests/cypress/support/pages/oneMacPackageDetailsPage.js
+++ b/tests/cypress/support/pages/oneMacPackageDetailsPage.js
@@ -1,7 +1,10 @@
-const topRaiRespCaret = "#medicaidsparai0_caret-button";
-const topRaiRespDownloadBtn = "#dl_medicaidsparai0";
-const topRaiRespCard = "#medicaidsparai0_caret";
+const medicaidTopRaiRespCaret = "#medicaidsparai0_caret-button";
+const medicaidTopRaiRespDownloadBtn = "#dl_medicaidsparai0";
+const medicaidTopRaiRespCard = "#medicaidsparai0_caret";
 const topRaiRespAddInfo = "#addl-info-rai-0";
+const chipTopRaiRespCaret = "#chipsparai0_caret-button";
+const chipTopRaiRespDownloadBtn = "#dl_chipsparai0";
+const chipTopRaiRespCard = "#chipsparai0_caret";
 
 //Elements are Xpath use cy.xpath instead of cy.xpath
 const detailsPage = "//div[@class='form-container']";
@@ -21,7 +24,7 @@ const CHIPSPAIDHeader = "//h3[contains(text(),'SPA ID')]";
 const typeHeader = "//h3[contains(text(),'Type')]";
 const stateHeader = "//h3[text()='State']";
 const dateSubmittedHeader = "//h3[text()='Date Submitted']";
-const raiResponsesHeader = "//section//h2[text()='RAI Responses']";
+const raiResponsesHeader = "//section//h2[text()='Formal RAI Responses']";
 const packageOverviewNavBtn = "//button[text()='Package Overview']";
 const packageDetailsNavBtn =
   "//li[contains(@class, 'nav')]//a[text()='Package Details']";
@@ -121,16 +124,36 @@ export class oneMacPackageDetailsPage {
   verifyRaiResponseHeaderExists() {
     cy.xpath(raiResponsesHeader).scrollIntoView().should("be.visible");
   }
-  verifyTopRaiRespCaretExistsAndEnabled() {
-    cy.get(topRaiRespCaret).scrollIntoView().should("be.visible");
-    cy.get(topRaiRespCaret).should("be.enabled");
+  verifyRaiResponseHeaderTitle() {
+    cy.xpath(raiResponsesHeader).scrollIntoView().should("be.visible");
   }
-  verifyTopRaiRespCardExists() {
-    cy.get(topRaiRespCard).scrollIntoView().should("be.visible");
+  verifyCHIPTopRaiRespCaretExistsAndEnabled() {
+    cy.get(chipTopRaiRespCaret).scrollIntoView().should("be.visible");
+    cy.get(chipTopRaiRespCaret).should("be.enabled");
   }
-  verifyTopRaiRespDownloadBtnExistsAndEnabled() {
-    cy.get(topRaiRespDownloadBtn).scrollIntoView().should("be.visible");
-    cy.get(topRaiRespDownloadBtn).should("be.enabled");
+  verifyMedicaidTopRaiRespCaretExistsAndEnabled() {
+    cy.get(medicaidTopRaiRespCaret).scrollIntoView().should("be.visible");
+    cy.get(medicaidTopRaiRespCaret).should("be.enabled");
+  }
+  verifyCHIPTopRaiRespCaretTitle() {
+    cy.get(chipTopRaiRespCaret).scrollIntoView().contains("Submitted on");
+  }
+  verifyMedicaidTopRaiRespCaretTitle() {
+    cy.get(medicaidTopRaiRespCaret).scrollIntoView().contains("Submitted on");
+  }
+  verifyCHIPTopRaiRespCardExists() {
+    cy.get(chipTopRaiRespCard).scrollIntoView().should("be.visible");
+  }
+  verifyMedicaidTopRaiRespCardExists() {
+    cy.get(medicaidTopRaiRespCard).scrollIntoView().should("be.visible");
+  }
+  verifyCHIPTopRaiRespDownloadBtnExistsAndEnabled() {
+    cy.get(chipTopRaiRespDownloadBtn).scrollIntoView().should("be.visible");
+    cy.get(chipTopRaiRespDownloadBtn).should("be.enabled");
+  }
+  verifyMedicaidTopRaiRespDownloadBtnExistsAndEnabled() {
+    cy.get(medicaidTopRaiRespDownloadBtn).scrollIntoView().should("be.visible");
+    cy.get(medicaidTopRaiRespDownloadBtn).should("be.enabled");
   }
   verifyTopRaiRespAddInfoDoesNotExist() {
     cy.get(topRaiRespAddInfo).should("not.exist");

--- a/tests/cypress/support/pages/oneMacRespondToRAIPage.js
+++ b/tests/cypress/support/pages/oneMacRespondToRAIPage.js
@@ -1,12 +1,12 @@
 const pageHeader =
-  "//h1[contains(text(),'Respond to Formal Medicaid SPA RAI')]";
+  "//h1[contains(text(),'Formal Request for Additional Information Response')]";
 const backArrow = "#back-button";
 //Element is Xpath use cy.xpath instead of cy.get
 const leaveAnywaysBtn = "//button[text()='Leave Anyway']";
 const yesSubmitBtn = "//button[text()='Yes, Submit']";
 
 export class oneMacRespondToRAIPage {
-  verifyPageLoads() {
+  verifyPageHeader() {
     cy.xpath(pageHeader).should("be.visible");
   }
 


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-19124
https://qmacbis.atlassian.net/browse/OY2-19216
https://qmacbis.atlassian.net/browse/OY2-19034


### Changes

- Tests were pointing at medicaid since CHIP RAI response in package view wasn't built out. Decided to redefine medicaid specific elements and steps and then add new CHIP ones. 


### Test Plan

```
Feature: RAI Response for CHIP SPA package view
    Background: Reoccuring Steps
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And Click on Filter Button
        And click on Type
        And click Medicaid SPA check box
        And click on Type
        And click on Status
        And click all of the status checkboxes
        And click RAI Issued checkbox
        And Click on Filter Button

    Scenario: Respond to RAI from the Package details page and then verify RAI info in package details page
        And copy the ID from the link in the first row
        And click the SPA ID link in the first row
        And verify Respond to RAI action exists
        And click on Respond to RAI package action
        And verify the form is titled Formal Request for Additional Information Response
        And Add file for Revised Amended State Plan Language
        And Add file for Official RAI Response
        And Click the Submit Button without waiting
        And click yes, submit RAI response button
        And click on Packages
        And search for the ID copied from the link in the first row
        And click the SPA ID link in the first row
        And verify RAI Responses header exists
        And verify the first RAI Response header is titled
        And verify the CHIP RAI Responses caret at the top of the list exists and is enabled
        And verify the title of the CHIP RAI Responses caret at the top of the list is in Submitted on format
        And verify the CHIP RAI response card at the top of the list exists
        And verify the download button for the CHIP RAI response at the top of the list exists
        And verify the first RAI response does not have Additional Info

    Scenario: Respond to RAI from the Package page and then verify RAI info in package details page
        And copy the ID from the link in the first row
        And click the actions button in row one
        And verify the Respond to RAI button is displayed
        And click the Respond to RAI button
        And verify the form is titled Formal Request for Additional Information Response
        And Add file for Revised Amended State Plan Language
        And Add file for Official RAI Response
        And Type Additonal Info Comments in new form
        And Click the Submit Button without waiting
        And click yes, submit RAI response button
        And click on Packages
        And search for the ID copied from the link in the first row
        And click the SPA ID link in the first row
        And verify RAI Responses header exists
        And verify the first RAI Response header is titled
        And verify the CHIP RAI Responses caret at the top of the list exists and is enabled
        And verify the title of the CHIP RAI Responses caret at the top of the list is in Submitted on format
        And verify the CHIP RAI response card at the top of the list exists
        And verify the download button for the CHIP RAI response at the top of the list exists
        And verify the first RAI response has Additional Info

Feature: RAI Response for Medicaid SPA package view
    Background: Reoccuring Steps
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And Click on Filter Button
        And click on Type
        And click CHIP SPA check box
        And click on Type
        And click on Status
        And click all of the status checkboxes
        And click RAI Issued checkbox
        And Click on Filter Button

    Scenario: Respond to RAI from the Package details page and then verify RAI info in package details page
        And copy the ID from the link in the first row
        And click the SPA ID link in the first row
        And verify Respond to RAI action exists
        And click on Respond to RAI package action
        And verify the form is titled Formal Request for Additional Information Response
        And Add file for RAI Response
        And Click the Submit Button without waiting
        And click yes, submit RAI response button
        And click on Packages
        And search for the ID copied from the link in the first row
        And click the SPA ID link in the first row
        And verify RAI Responses header exists
        And verify the first RAI Response header is titled
        And verify the Medicaid RAI Responses caret at the top of the list exists and is enabled
        And verify the title of the Medicaid RAI Responses caret at the top of the list is in Submitted on format
        And verify the Medicaid RAI response card at the top of the list exists
        And verify the download button for the Medicaid RAI response at the top of the list exists
        And verify the first RAI response does not have Additional Info

    Scenario: Respond to RAI from the Package page and then verify RAI info in package details page
        And copy the ID from the link in the first row
        And click the actions button in row one
        And verify the Respond to RAI button is displayed
        And click the Respond to RAI button
        And verify the form is titled Formal Request for Additional Information Response
        And Add file for RAI Response
        And Type Additonal Info Comments in new form
        And Click the Submit Button without waiting
        And click yes, submit RAI response button
        And click on Packages
        And search for the ID copied from the link in the first row
        And click the SPA ID link in the first row
        And verify RAI Responses header exists
        And verify the first RAI Response header is titled
        And verify the Medicaid RAI Responses caret at the top of the list exists and is enabled
        And verify the title of the Medicaid RAI Responses caret at the top of the list is in Submitted on format
        And verify the Medicaid RAI response card at the top of the list exists
        And verify the download button for the Medicaid RAI response at the top of the list exists
        And verify the first RAI response has Additional Info

```
