### PR TITLE
oy2-19299: changed ID format and related text for App K waivers

### DIFF
--- a/services/common/changeRequest.js
+++ b/services/common/changeRequest.js
@@ -318,19 +318,19 @@ export const CONFIG = {
     transmittalNumber: {
       idType: "waiverappk",
       idLabel: "Waiver Number",
-      idFAQLink: ROUTES.FAQ_WAIVER_ID,
+      idFAQLink: ROUTES.FAQ_WAIVER_APP_K_ID,
       idFieldHint: [
         {
-          text: "Must follow the format SS.####.R##.## or SS.#####.R##.## (use R00 for waivers without renewals)",
+          text: "Must follow the format SS-####.R##.## or SS-#####.R##.## (use R00 for waivers without renewals)",
         },
       ],
-      idFormat: "SS.####.R##.## or SS.#####.R##.##",
-      idRegex: "(^[A-Z]{2}[.][0-9]{4,5}[.]R[0-9]{2}[.][0-9]{2}$)",
+      idFormat: "SS-####.R##.## or SS-#####.R##.##",
+      idRegex: "(^[A-Z]{2}[-][0-9]{4,5}[.]R[0-9]{2}[.][0-9]{2}$)",
       idExistValidations: [
         {
           idMustExist: true,
           errorLevel: "warn",
-          existenceRegex: "^[A-Z]{2}[.][0-9]{4,5}",
+          existenceRegex: "^[A-Z]{2}[-][0-9]{4,5}",
         },
       ],
     },

--- a/services/common/routes.js
+++ b/services/common/routes.js
@@ -15,6 +15,7 @@ export const ROUTES = {
   FAQ_TOP: "/FAQ/#top",
   FAQ_SPA_ID: "/FAQ#spa-id-format",
   FAQ_WAIVER_ID: "/FAQ#waiver-id-format",
+  FAQ_WAIVER_APP_K_ID: "/FAQ#waiver-c-id",
   HOME: "/",
   PROFILE: "/profile",
   METRICS: "/metrics",

--- a/services/ui-src/src/libs/faqContent.tsx
+++ b/services/ui-src/src/libs/faqContent.tsx
@@ -498,8 +498,8 @@ export const oneMACFAQContent: FAQContent[] = [
         answerJSX: (
           <>
             <p>
-              Waiver number must follow the format SS.####.R##.## or
-              SS.#####.R##.## to include:
+              Waiver number must follow the format SS-####.R##.## or
+              SS-#####.R##.## to include:
             </p>
             <ul>
               <li>SS = 2 character state abbreviation</li>
@@ -511,8 +511,9 @@ export const oneMACFAQContent: FAQContent[] = [
               <li>## = appendix K amendment number (01)</li>
             </ul>
             <p>
-              All separated by periods (.). For example, the waiver number
-              KY.0003.R02.02 is a waiver for the state of Kentucky, with a base
+              State abbreviation is followed by a dash (-). All other sections
+              are separated by periods (.). For example, the waiver number
+              KY-0003.R02.02 is a waiver for the state of Kentucky, with a base
               waiver number of 0003, the second renewal (R02) and the second
               appendix K amendment (02). Base waivers without renewals should
               use “R00” as their renewal number.


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-19299
Endpoint: https://d34gw6v64dy81e.cloudfront.net/

### Details

As a OneMAC State User, I need the approved Appendix K ID format to be explained and validated upon submission so that I understand how to correctly submit an Appendix K, which will streamline adjudication.R.

### Changes

- For App K Waivers: changed instructions (subtext that notates correct format), field label hint, Validation Error Message, and FAQ section to reflect this new/correct ID formats (SS-#####.R##.##, SS-####.R##.##)

