### PR TITLE
oy2-19568 - changing the FAQLib text for 1915(b) Waiver Request for T…

### DIFF
--- a/services/ui-src/src/libs/faqContent.tsx
+++ b/services/ui-src/src/libs/faqContent.tsx
@@ -658,10 +658,10 @@ export const oneMACFAQContent: FAQContent[] = [
                 <tr>
                   <td>Waiver Extension Request*</td>
                   <td>
-                    A formal letter addressed to the Deputy Director of the
-                    Division of Disabled and Elderly Health Programs Group
-                    (DEHPG) requesting a temporary extension beyond the current
-                    approved waiver period
+                    A formal letter addressed to Carrie Smith, Deputy Director
+                    of the Disabled and Elderly Health Program Group (DEHPG),
+                    requesting a temporary extension beyond the current approved
+                    waiver period.
                   </td>
                 </tr>
                 <tr>


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-19568
Endpoint: https://d2dr7dgo9g0124.cloudfront.net/

### Details

As a State 1915(b) Submitter in OneMAC, I want to know exactly how to address my TE request, so that submissions are less likely to be erroneous and cause errors in the adjudication process.

### Changes

- For FAQ 'What are the attachments for a 1915(b) Waiver - Request for Temporary Extension?' changed the text to make it more explicit to avoid errors for the user

