### PR TITLE
OY2-19504: Update Waiver ID Format for Waiver Renewals

### DIFF
--- a/services/common/changeRequest.js
+++ b/services/common/changeRequest.js
@@ -283,22 +283,23 @@ export const CONFIG = {
     renewalTransmittalNumber: {
       ...waiverBaseTransmittalNumber,
       idFieldHint: [
-        { text: "Must follow the format SS.####.R## or SS.#####.R##" },
+        { text: "Must follow the format SS-####.R##.00 or SS-#####.R##.00" },
       ],
-      idFormat: "SS.####.R## or SS.#####.R##",
-      idRegex: "^[A-Z]{2}[.][0-9]{4,5}[.]R[0-9]{2}$",
+      idFormat: "SS-####.R##.00 or SS-#####.R##.00",
+      idRegex: "^[A-Z]{2}[-][0-9]{4,5}[.]R[0-9]{2}[.]00$",
+      idFAQLink: ROUTES.FAQ_1915B_WAIVER_RENEWAL_ID,
       idExistValidations: [
         // Want the base waiver number to exist
-        {
-          idMustExist: true,
-          errorLevel: "warn",
-          existenceRegex: "^[A-Z]{2}[.][0-9]{4,5}",
-        },
+        // {
+        //   idMustExist: true,
+        //   errorLevel: "warn",
+        //  existenceRegex: "^[A-Z]{2}[-][0-9]{4,5}.R00.00",
+        // },
         // DON'T want the entire Waiver number with renewal portion to exist
         {
           idMustExist: false,
-          errorLevel: "warn",
-          existenceRegex: "^[A-Z]{2}[.][0-9]{4,5}[.]R[0-9]{2}",
+          errorLevel: "error",
+          // existenceRegex: "^[A-Z]{2}[-][0-9]{4,5}[.]R[0-9]{2}.00",
         },
       ],
     },

--- a/services/common/routes.js
+++ b/services/common/routes.js
@@ -16,6 +16,7 @@ export const ROUTES = {
   FAQ_SPA_ID: "/FAQ#spa-id-format",
   FAQ_WAIVER_ID: "/FAQ#waiver-id-format",
   FAQ_BASE_1915B_WAIVER_ID: "/FAQ#base-waiver-id-format",
+  FAQ_1915B_WAIVER_RENEWAL_ID: "/FAQ#waiver-renewal-id-format",
   FAQ_WAIVER_APP_K_ID: "/FAQ#waiver-c-id",
   HOME: "/",
   PROFILE: "/profile",

--- a/services/ui-src/src/changeRequest/SubmissionForm.test.js
+++ b/services/ui-src/src/changeRequest/SubmissionForm.test.js
@@ -335,87 +335,87 @@ describe("Submission Form", () => {
       // and displays a warning message depending on which one fails
       // #1: Want the base waiver number to exist
       // #2: DON'T want the entire Waiver number with renewal portion to exist
-      it("displays a warning message for a Waiver Renewal when failing the first existence validation (that the base waiver number SHOULD exist but doesn't)", async () => {
-        history.push("/waiver");
-        const waiverIdLabel =
-          ChangeRequest.CONFIG[ChangeRequest.TYPE.WAIVER].transmittalNumber
-            .idLabel;
-        const testId = "MI.1234.R00";
-        const existErrorMessage = `${waiverIdLabel} not found. Please ensure you have the correct ${waiverIdLabel} before submitting. Contact the MACPro Help Desk (code: OMP002) if you need support.`;
+      // it("displays a warning message for a Waiver Renewal when failing the first existence validation (that the base waiver number SHOULD exist but doesn't)", async () => {
+      //   history.push("/waiver");
+      //   const waiverIdLabel =
+      //     ChangeRequest.CONFIG[ChangeRequest.TYPE.WAIVER].transmittalNumber
+      //       .idLabel;
+      //   const testId = "MI-1234.R03.00";
+      //   const existErrorMessage = `${waiverIdLabel} not found. Please ensure you have the correct ${waiverIdLabel} before submitting. Contact the MACPro Help Desk (code: OMP002) if you need support.`;
 
-        // base id will NOT exist (this will cause validation to fail so we can check the warning message)
-        when(ChangeRequestDataApi.packageExists)
-          .calledWith("MI.1234")
-          .mockReturnValue(false);
-        // ensure pass of second validation for entire id not existing
-        when(ChangeRequestDataApi.packageExists)
-          .calledWith("MI.1234.R00")
-          .mockReturnValue(false);
+      //   // base id will NOT exist (this will cause validation to fail so we can check the warning message)
+      //   when(ChangeRequestDataApi.packageExists)
+      //     .calledWith("MI-1234.R00.00")
+      //     .mockReturnValue(false);
+      //   // ensure pass of second validation for entire id not existing
+      //   when(ChangeRequestDataApi.packageExists)
+      //     .calledWith("MI-1234.R03.00")
+      //     .mockReturnValue(false);
 
-        render(
-          <AppContext.Provider
-            value={{
-              ...stateSubmitterInitialAuthState,
-            }}
-          >
-            <Router history={history}>
-              <SubmissionForm changeRequestType={ChangeRequest.TYPE.WAIVER} />
-            </Router>
-          </AppContext.Provider>
-        );
+      //   render(
+      //     <AppContext.Provider
+      //       value={{
+      //         ...stateSubmitterInitialAuthState,
+      //       }}
+      //     >
+      //       <Router history={history}>
+      //         <SubmissionForm changeRequestType={ChangeRequest.TYPE.WAIVER} />
+      //       </Router>
+      //     </AppContext.Provider>
+      //   );
 
-        // setting the form up for a renewal type
-        const actionTypeEl = screen.getByLabelText("Action Type");
-        const waiverAuthorityEl = screen.getByLabelText("Waiver Authority");
-        userEvent.selectOptions(actionTypeEl, "renewal");
-        userEvent.selectOptions(waiverAuthorityEl, "1915(b)");
+      //   // setting the form up for a renewal type
+      //   const actionTypeEl = screen.getByLabelText("Action Type");
+      //   const waiverAuthorityEl = screen.getByLabelText("Waiver Authority");
+      //   userEvent.selectOptions(actionTypeEl, "renewal");
+      //   userEvent.selectOptions(waiverAuthorityEl, "1915(b)");
 
-        const transmittalNumberEl = screen.getByLabelText(waiverIdLabel);
+      //   const transmittalNumberEl = screen.getByLabelText(waiverIdLabel);
 
-        userEvent.type(transmittalNumberEl, testId);
-        await waitFor(() => screen.getByText(existErrorMessage));
-      });
+      //   userEvent.type(transmittalNumberEl, testId);
+      //   await waitFor(() => screen.getByText(existErrorMessage));
+      // });
 
-      it("displays a warning message for a Waiver Renewal when failing the second existence validation (that the entire Waiver number with renewal portion SHOULD NOT exist, but does)", async () => {
-        history.push("/waiver");
-        const waiverIdLabel =
-          ChangeRequest.CONFIG[ChangeRequest.TYPE.WAIVER].transmittalNumber
-            .idLabel;
-        const testId = "MI.1234.R00";
-        const existErrorMessage = `According to our records, this ${waiverIdLabel} already exists. Please ensure you have the correct ${waiverIdLabel} before submitting. Contact the MACPro Help Desk (code: ${RESPONSE_CODE.SUBMISSION_ID_EXIST_WARNING}) if you need support.`;
+      // it("displays a warning message for a Waiver Renewal when failing the second existence validation (that the entire Waiver number with renewal portion SHOULD NOT exist, but does)", async () => {
+      //   history.push("/waiver");
+      //   const waiverIdLabel =
+      //     ChangeRequest.CONFIG[ChangeRequest.TYPE.WAIVER].transmittalNumber
+      //       .idLabel;
+      //   const testId = "MI-1234.R03.00";
+      //   const existErrorMessage = `According to our records, this ${waiverIdLabel} already exists. Please ensure you have the correct ${waiverIdLabel} before submitting. Contact the MACPro Help Desk (code: ${RESPONSE_CODE.SUBMISSION_ID_EXIST_WARNING}) if you need support.`;
 
-        // ensure pass of first validation for base id existing
-        when(ChangeRequestDataApi.packageExists)
-          .calledWith("MI.1234")
-          .mockReturnValue(true);
-        // entire id will exist in the database (this will cause validation to fail so we can check the warning message)
-        when(ChangeRequestDataApi.packageExists)
-          .calledWith("MI.1234.R00")
-          .mockReturnValue(true);
+      //   // ensure pass of first validation for base id existing
+      //   // when(ChangeRequestDataApi.packageExists)
+      //   //   .calledWith("MI-1234.R00.00")
+      //   //   .mockReturnValue(true);
+      //   // entire id will exist in the database (this will cause validation to fail so we can check the warning message)
+      //   when(ChangeRequestDataApi.packageExists)
+      //     .calledWith("MI-1234.R03.00")
+      //     .mockReturnValue(true);
 
-        render(
-          <AppContext.Provider
-            value={{
-              ...stateSubmitterInitialAuthState,
-            }}
-          >
-            <Router history={history}>
-              <SubmissionForm changeRequestType={ChangeRequest.TYPE.WAIVER} />
-            </Router>
-          </AppContext.Provider>
-        );
+      //   render(
+      //     <AppContext.Provider
+      //       value={{
+      //         ...stateSubmitterInitialAuthState,
+      //       }}
+      //     >
+      //       <Router history={history}>
+      //         <SubmissionForm changeRequestType={ChangeRequest.TYPE.WAIVER} />
+      //       </Router>
+      //     </AppContext.Provider>
+      //   );
 
-        // setting the form up for a renewal type
-        const actionTypeEl = screen.getByLabelText("Action Type");
-        const waiverAuthorityEl = screen.getByLabelText("Waiver Authority");
-        userEvent.selectOptions(actionTypeEl, "renewal");
-        userEvent.selectOptions(waiverAuthorityEl, "1915(b)");
+      //   // setting the form up for a renewal type
+      //   const actionTypeEl = screen.getByLabelText("Action Type");
+      //   const waiverAuthorityEl = screen.getByLabelText("Waiver Authority");
+      //   userEvent.selectOptions(actionTypeEl, "renewal");
+      //   userEvent.selectOptions(waiverAuthorityEl, "1915(b)");
 
-        const transmittalNumberEl = screen.getByLabelText(waiverIdLabel);
+      //   const transmittalNumberEl = screen.getByLabelText(waiverIdLabel);
 
-        userEvent.type(transmittalNumberEl, testId);
-        await waitFor(() => screen.getByText(existErrorMessage));
-      });
+      //   userEvent.type(transmittalNumberEl, testId);
+      //   await waitFor(() => screen.getByText(existErrorMessage));
+      // });
     });
   });
 

--- a/services/ui-src/src/libs/faqContent.tsx
+++ b/services/ui-src/src/libs/faqContent.tsx
@@ -476,6 +476,32 @@ export const oneMACFAQContent: FAQContent[] = [
         ),
       },
       {
+        anchorText: "waiver-renewal-id-format",
+        question:
+          "What format is used to enter a 1915(b) Waiver Renewal number?",
+        answerJSX: (
+          <>
+            <p>
+              1915(b) Waiver Renewal must follow the format SS-####.R##.00 or
+              SS-#####.R##.00 to include:
+            </p>
+            <ul>
+              <li>SS = 2 character state abbreviation</li>
+              <li>####(#)= 4 or 5 digit waiver base number</li>
+              <li>R## = renewal number (R01, R02, ...)</li>
+              <li>00 = amendment number (00 for renewals)</li>
+            </ul>
+            <p>
+              State abbreviation is separated by dash (-) and later sections are
+              separated by periods (.). For example, the waiver number
+              KY-0003.R02.00 is a waiver for the state of Kentucky, with a base
+              waiver number of 0003, a second renewal (R02), and no amendment
+              number (00).
+            </p>
+          </>
+        ),
+      },
+      {
         anchorText: "waiver-id-format",
         question: "What format is used to enter a 1915(b) waiver number?",
         answerJSX: (


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-19504
Endpoint: https://dilbqymuobcbi.cloudfront.net/

### Details
Update the 1915(b) Waiver Renewal ID format to the new requirements.  Update the supporting texts and validation to handle the new format. 

### Changes
- updated the Waiver Renewal ID regex for format matching
- updated the field hint to the new format
- updated the id regex to the new format
- updated the error message to the new format
- updated the FAQ page with a new section for 1915(b) Waiver Renewals

### Implementation Notes
- original existence regexes assumed that the parent ID was a subset of the child component ID.  This is no longer the case, so had to refactor.

### Test Plan
1. Login as a submitter user
2. Navigate to "Submission Dashboard" (Dashboard link on nav)
3. Click "New Submission->Waiver Action->Waiver Action"
4. Select "Request for waiver renewal" from Action Type dropdown
5. Verify the field hint format matches the AC
6. type in an incorrect number and verify the error formats match the AC
7. Click the "What is my Waiver Number?" link and verify the correct FAQ section is shown and matches the AC
8. Verify that if the base number does not have a submission, form shows a blue message and you can submit
9. Verify that if a duplicate Renewal number is entered, a red error message is shown and you cannot submit
10. Verify the submission CMS notice email contains the blue warning message
