### PR TITLE
remove the character counter and relevant styles

### DIFF
--- a/services/ui-src/src/changeRequest/SubmissionForm.tsx
+++ b/services/ui-src/src/changeRequest/SubmissionForm.tsx
@@ -457,9 +457,6 @@ export const SubmissionForm: React.FC<{
               value={changeRequest.summary}
               maxLength={config.MAX_ADDITIONAL_INFO_LENGTH}
             ></TextField>
-            <div className="char-count">
-              {changeRequest.summary.length}/{config.MAX_ADDITIONAL_INFO_LENGTH}
-            </div>
           </div>
           <div className="form-buttons">
             <p className="submission-message">

--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -634,10 +634,6 @@ input[type="file"] {
     @extend .ds-u-margin-bottom--5;
   }
 
-  .char-count {
-    @extend .ds-u-margin-bottom--7;
-  }
-
   #additional-information-label {
     span {
       display: block;
@@ -1338,10 +1334,6 @@ article.form-container {
       @extend .ds-u-margin-bottom--1;
     }
   }
-}
-
-.char-count {
-  text-align: right;
 }
 
 .display-errors input:invalid,

--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -472,10 +472,6 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
             value={oneMacFormData.additionalInformation}
             maxLength={config.MAX_ADDITIONAL_INFO_LENGTH}
           ></TextField>
-          <div className="char-count">
-            {oneMacFormData.additionalInformation.length}/
-            {config.MAX_ADDITIONAL_INFO_LENGTH}
-          </div>
           <p id="form-submit-instructions">
             <i>
               Once you submit this form, a confirmation email is sent to you and


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-19662
Endpoint: https://xxxx.cloudfront.net

### Details
The character count feature in the Additional Information text area was triggering for every character typed and reading aloud the character count and the character limit.  This is very distracting and it was decided that the character counter should be removed (though the character limit is still 4000 chars)

### Changes
- Removed the div containing the character count and limit
- updated the style sheet to remove the styles associated with that div
- this was done for ALL forms, both Submission and Package

### Test Plan
1. Login as a submitter user
2. Navigate to Dashboard (Submission)
3. Click "New Submission" and travel to a new form
4. turn on a screen reader
5. type in the Additional information box
6. Verify it says what letters you are typing, but does not tell you how many characters are left til the limit
7. Do the same for the Packages forms
