### PR TITLE
oy2-19627 - adding the raiSubheaderMessage to Respond to Waiver RAI Form

### DIFF
--- a/services/common/changeRequest.js
+++ b/services/common/changeRequest.js
@@ -375,7 +375,7 @@ export const CONFIG = {
     pageTitle: "Respond to Waiver RAI",
     readOnlyPageTitle: "Waiver RAI Response Details",
     subheaderMessage: {
-      __html: commonSubheaderMessage,
+      __html: raiSubheaderMessage,
     },
     detailsHeader: "Waiver RAI",
     requiredUploads: ["Waiver RAI Response"],


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-19627
Endpoint: https://dd27gk5s2axdo.cloudfront.net/

### Details

As a OneMAC submitter, I want the application to give me instructions on where to find the correct submission ID, so that the RAI submission process is easier.

### Changes

- On the Formal RAI Response Form Page for any 1915(b) waiver type in Submission View the header text was edited
- (Added text) - 'Please note: Formal RAI Response selection should only be used when submitting a response to a Formal RAI that would impact the clock. If this submission is in response to informal questions and is not clock related, the state should be forwarding to the review team via email.'

### Implementation Notes

- in 'changeRequest.js' in common - for 'TYPE.WAIVER_RAI': subheaderMessage was changed from 'commonSubheaderMessage' to 'raiSubheaderMessage'

