### PR TITLE
Bug: blue messages should not get priority over red

### DIFF
--- a/services/ui-src/src/changeRequest/SubmissionForm.tsx
+++ b/services/ui-src/src/changeRequest/SubmissionForm.tsx
@@ -217,7 +217,8 @@ export const SubmissionForm: React.FC<{
       warningMessageCode: "",
     };
 
-    let existMessages: Message[] = [];
+    let redMessages: Message[] = [];
+    let blueMessages: Message[] = [];
     let result = false;
     try {
       if (
@@ -277,16 +278,20 @@ export const SubmissionForm: React.FC<{
                 statusMessage: tempMessage as string,
                 warningMessageCode: tempCode,
               };
-              tempMessage && existMessages.push(messageToAdd);
+              if (tempMessage) {
+                if (messageToAdd.statusLevel === "error")
+                  redMessages.push(messageToAdd);
+                else blueMessages.push(messageToAdd);
+              }
             });
           })
           .then(() => {
-            if (existMessages.length > 0) {
-              displayMessage = existMessages[0];
-              setTransmittalNumberStatusMessage(displayMessage);
-            } else {
-              setTransmittalNumberStatusMessage(displayMessage);
+            if (redMessages.length > 0) {
+              displayMessage = redMessages[0];
+            } else if (blueMessages.length > 0) {
+              displayMessage = blueMessages[0];
             }
+            setTransmittalNumberStatusMessage(displayMessage);
           });
       } else {
         displayMessage = formatMessage;


### PR DESCRIPTION
Story: BUG found in a meeting about IDs
Endpoint: https://d1w47fkcenmnej.cloudfront.net/

### Details
While going over the Waiver Renewal ID validations, we noticed that the blue "waiver not found" message was being shown when the full number was a duplicate (and the parent was not findable), this condition should show the red "duplicate ID" message first... basically, all red messages should have priority over all blue messages.

### Changes
- split messages array into red and blue
- updated logic so that red shows first, then blue (note, format messages are checked outside of the the exist messages)

### Test Plan
1. Login as a submitting user
2. Navigate to "Dashboard->New Submission->Waiver Action->Waiver Action"
3. Select "renewal" action
4. try to use an id that exists in the dashboard as a renewal, but does not have a base waiver
5. Verify that the red message is shown
