### PR TITLE
oy2-19842 added the section for 1915c Waiver Request for Temp Extensi…

### DIFF
--- a/services/ui-src/src/libs/faqContent.tsx
+++ b/services/ui-src/src/libs/faqContent.tsx
@@ -754,6 +754,41 @@ export const oneMACFAQContent: FAQContent[] = [
         ),
       },
       {
+        anchorText: "waiverc-extension-attachments",
+        question:
+          "What are the attachments for a 1915(c) Waiver - Request for Temporary Extension",
+        answerJSX: (
+          <>
+            <p>Note: “*” indicates a required attachment.</p>
+            <table className="faq-table">
+              <thead>
+                <tr>
+                  <th>Attachment Name</th>
+                  <th>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Waiver Extension Request*</td>
+                  <td>
+                    A formal letter addressed to George Failla, Director of the
+                    Division of HCBS Operations & Oversight requesting a
+                    temporary extension beyond the current approved waiver
+                    period.
+                  </td>
+                </tr>
+                <tr>
+                  <td>Other</td>
+                  <td>
+                    Supplemental documents for the Waiver Extension Request
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </>
+        ),
+      },
+      {
         anchorText: "appk",
         question: "Can I submit Appendix K amendments in OneMAC?",
         answerJSX: (


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-19842
Endpoint: https://d2jw1vf7tere0n.cloudfront.net/

### Details

As a OneMAC State user, I need the language in the FAQ to be specific as to what attachments are required for a 1915(c) Waiver Temporary Extension request, so that it is clear to me and the adjudication process is streamlined.

### Changes

- FAQ was added for - "What are the attachments for a 1915(c) Waiver - Request for temporary extension"

### Implementation Notes

- Added FAQ section to 'faqContent.tsx'
