### PR TITLE
OY2-19988 - added ability to append additional error message information per submission type

### DIFF
--- a/services/common/changeRequest.js
+++ b/services/common/changeRequest.js
@@ -48,6 +48,9 @@ const waiverBaseTransmittalNumber = {
   idFAQLink: ROUTES.FAQ_WAIVER_ID,
 };
 
+const waiverAddtionalErrorMessage =
+  "\nFor amendments, the last two digits start with “01” and ascends.";
+
 export const CONFIG = {
   [TYPE.CHIP_SPA]: {
     pageTitle: "Submit New CHIP SPA",
@@ -273,6 +276,7 @@ export const CONFIG = {
         { text: "Must follow the format SS-####.R##.## or SS-#####.R##.##" },
       ],
       idFormat: "SS-####.R##.## or SS-#####.R##.##",
+      idAddtionalErrorMessage: waiverAddtionalErrorMessage,
       idRegex: "^[A-Z]{2}[-][0-9]{4,5}[.]R[0-9]{2}[.](0[1-9]|[1-9][0-9])$",
       idFAQLink: ROUTES.FAQ_1915B_WAIVER_AMENDMENT_ID,
       idExistValidations: [
@@ -338,6 +342,7 @@ export const CONFIG = {
       ],
       idFormat: "SS-####.R##.## or SS-#####.R##.##",
       idRegex: "(^[A-Z]{2}[-][0-9]{4,5}[.]R[0-9]{2}[.][0-9]{2}$)",
+      idAddtionalErrorMessage: waiverAddtionalErrorMessage,
       idExistValidations: [
         {
           idMustExist: true,

--- a/services/common/index.d.ts
+++ b/services/common/index.d.ts
@@ -72,6 +72,7 @@ export namespace ChangeRequest {
   type TransmittalNumberInfo = {
     idLabel: string;
     idRegex: string;
+    idAddtionalErrorMessage?: string;
     idFormat: string;
     idFieldHint: FieldHint[];
     idFAQLink: string;

--- a/services/ui-src/src/changeRequest/SubmissionForm.tsx
+++ b/services/ui-src/src/changeRequest/SubmissionForm.tsx
@@ -140,7 +140,7 @@ export const SubmissionForm: React.FC<{
       ) {
         errorMessage =
           `The ${transmittalNumberDetails.idLabel} must be in the format of ${transmittalNumberDetails.idFormat}` +
-            transmittalNumberDetails.idAddtionalErrorMessage ?? "";
+          (transmittalNumberDetails.idAddtionalErrorMessage ?? "");
       }
 
       return errorMessage;

--- a/services/ui-src/src/changeRequest/SubmissionForm.tsx
+++ b/services/ui-src/src/changeRequest/SubmissionForm.tsx
@@ -138,7 +138,9 @@ export const SubmissionForm: React.FC<{
         transmittalNumberDetails.idRegex &&
         !matchesRegex(newTransmittalNumber, transmittalNumberDetails.idRegex)
       ) {
-        errorMessage = `The ${transmittalNumberDetails.idLabel} must be in the format of ${transmittalNumberDetails.idFormat}`;
+        errorMessage =
+          `The ${transmittalNumberDetails.idLabel} must be in the format of ${transmittalNumberDetails.idFormat}` +
+            transmittalNumberDetails.idAddtionalErrorMessage ?? "";
       }
 
       return errorMessage;

--- a/services/ui-src/src/components/TransmittalNumber.tsx
+++ b/services/ui-src/src/components/TransmittalNumber.tsx
@@ -57,7 +57,9 @@ const TransmittalNumber: React.FC<{
       </div>
       {statusMessage && (
         <div id="transmittalNumberStatusMsg" className={statusMsgClass}>
-          {statusMessage}
+          {statusMessage.split("\n").map((m) => (
+            <div>{m}</div>
+          ))}
         </div>
       )}
       <input


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-19988
Endpoint: https://d1cwt4cui1vr0t.cloudfront.net/

### Details

Needed to add additiional error information displayed to user for Waiver Amendment and App K Amendments when format is not correct.

### Changes

- Updated TransmittalNumber component to parse the error message for newline characters and render each section in its own div
- Added new field to each submission type in ChangeRequest.js config for the additional error text (including the newline so that it will be displayed on an additional line to prevent long line wrapping.

### Implementation Notes

- While I feel the way I implemented this is semi-hacky (by parsing for newline characters in the TransmittalNumber component); I felt that was better than restructuring the entire error handling mechanism to allow arrays in every submission view form and in the TransmittalNumber component. If this were for package view I probably would have done the restructure of how errors are handled.
- Alternatively I could have just appended the message to the current message for those types and let it wrap but it looked odd because it went far past the input box. 

### Test Plan

1. Login as state submitter
2. Go to Submission Dashboard
3. New Submission -> Waiver Action -> Waiver Action
4. Select Waiver Amendment for Action Type
5. Type only the State portion of the amendment number
6. Verify the error message has the additional error text as described in AC.
7. Verify after typing a valid waiver number that the error disappears.
8. Repeat steps 5-7 for New Submission -> Waiver Action -> Appendix K Amendment
