### PR TITLE
Testing tests

### DIFF
--- a/github-actions-reporter
+++ b/github-actions-reporter
@@ -1,0 +1,36 @@
+class GithubActionsReporter {
+  constructor(globalConfig, options) {
+    this._globalConfig = globalConfig;
+    this._options = options;
+  }
+
+  onRunComplete(contexts, results) {
+    results.testResults.forEach((testResultItem) => {
+      const testFilePath = testResultItem.testFilePath;
+
+      testResultItem.testResults.forEach((result) => {
+        if (result.status !== "failed") {
+          return;
+        }
+
+        result.failureMessages.forEach((failureMessages) => {
+          const newLine = "%0A";
+          const message = failureMessages.replace(/\n/g, newLine);
+          const captureGroup = message.match(/:([0-9]+):([0-9]+)/);
+
+          if (!captureGroup) {
+            console.log("Unable to extract line number from call stack");
+            return;
+          }
+
+          const [, line, col] = captureGroup;
+          console.log(
+            `::error file=${testFilePath},line=${line},col=${col}::${message}`
+          );
+        });
+      });
+    });
+  }
+}
+
+module.exports = GithubActionsReporter;

--- a/services/common/idValidation.test.js
+++ b/services/common/idValidation.test.js
@@ -14,7 +14,7 @@ describe("Waiver Number Useful Functions", () => {
     expect(getWaiverFamily("MI.77777.R00.M01")).toStrictEqual("MI.77777");
     expect(getWaiverFamily("MI.77777.R01.00")).toStrictEqual("MI.77777");
     expect(getWaiverFamily("MI.77777.R01.01")).toStrictEqual("MI.77777");
-    expect(getWaiverFamily()).toStrictEqual("MI.77777");
+    expect(getWaiverFamily()).toBeNull();
   });
 
   it("gets the Parent Waiver Number and Type", () => {

--- a/services/common/idValidation.test.js
+++ b/services/common/idValidation.test.js
@@ -14,7 +14,7 @@ describe("Waiver Number Useful Functions", () => {
     expect(getWaiverFamily("MI.77777.R00.M01")).toStrictEqual("MI.77777");
     expect(getWaiverFamily("MI.77777.R01.00")).toStrictEqual("MI.77777");
     expect(getWaiverFamily("MI.77777.R01.01")).toStrictEqual("MI.77777");
-    expect(getWaiverFamily()).toBeNull();
+    expect(getWaiverFamily()).toStrictEqual("MI.77777");
   });
 
   it("gets the Parent Waiver Number and Type", () => {

--- a/unit-test.sh
+++ b/unit-test.sh
@@ -8,7 +8,7 @@ for d in services/*/; do
     npm clean-install
 
     # if tests fail for any one of the packages, record the failure and test the rest
-    if ! npm test -- --coverage; then
+    if ! npm test -- --coverage --ci --reporters='default' --reporters='../../github-actions-reporter'; then
       RET=1
     fi
   fi


### PR DESCRIPTION
Story: Devops
Endpoint: Should we get rid of this from the template now that the bot will post the endpoint?

### Details

Add a jest runner that will add an annotation for each failed unit test

### Changes

- Added github-actions-reporter
- use reporter flags when running npm test

### Test Plan

1. commit a failed test
2. verify the action is annotated with the name and line of the test that failed

Note: you can reference my failed test in previous action deploy run:
https://github.com/CMSgov/onemac/actions/runs/2843033705