### PR TITLE
CC param type - val

### DIFF
--- a/services/app-api/resources/ssm-params.yml
+++ b/services/app-api/resources/ssm-params.yml
@@ -34,7 +34,7 @@ Resources:
   CmsSpaFormChipCcEmail:
     Type: AWS::SSM::Parameter
     Properties:
-      Type: StringList
+      Type: String
       Description: Branch specific email addresses of recipients for CC on cms chip spa form submission emails
       Name: !Sub /configuration/${self:custom.stage}/email/cms_chip_form_cc_email
       Value: "OneMAC@cms.hhs.gov"


### PR DESCRIPTION
Story: None
Endpoint: https://d2srxwir5k1v93.cloudfront.net

### Details

A deploy to Prod revealed that a StringList param type will attempt to be loaded as a string array when multiple values including commas are used as the param value. This param specifically is then used to load as an environment variable into a lambda which cannot handle a string array. Therefore we need to use a basic String type and rely on the app to parse the values. This was not discovered in lower environments given the format difference of the specific email list used only in production.

### Changes

- update CmsSpaFormCmsEmail to `Type: String`
`
### Implementation Notes

- We will want in the future to change all other email based params (or any being used as env var in lambda) to also be String type.

### Test Plan

1. After deploy replace the default value with an email list that includes commas in the value
2. Submit a chip spa and ensure the email is delivered