### PR TITLE
OY2 20237: Update first Waiver card text in Submission View

### DIFF
--- a/services/ui-src/src/changeRequest/NewSubmission.js
+++ b/services/ui-src/src/changeRequest/NewSubmission.js
@@ -11,7 +11,7 @@ const choices = [
     linkTo: ROUTES.NEW_SPA,
   },
   {
-    title: "1915(b) Waiver Action",
+    title: "Waiver Action",
     description:
       "Submit Waivers, Amendments, Renewals, RAI, or Temp. Extension",
     linkTo: ROUTES.NEW_WAIVER,


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-20237
Endpoint: See github-actions bot comment

### Details
Fix text error noticed during demo

### Changes
- Updated text on submission cards

### Test Plan
1. Login as submitting user
2. Navigate to submission dashboard
3. Click New Submission
4. Verify Waiver Action no longer says 1915(b) Waiver Action
