### PR TITLE
OY2-11589 Tests

### DIFF
--- a/tests/cypress/cypress/integration/Mini_Dashboard_Package_Details_Waivers.spec.feature
+++ b/tests/cypress/cypress/integration/Mini_Dashboard_Package_Details_Waivers.spec.feature
@@ -136,7 +136,7 @@ Feature: OY2-11585 Waiver Package Details View: Initial Waivers and Waiver Renew
         And verify there is a State header in the details section
         And verify a state exists for the State
         And verify there is an Amendment Title in the details section
-        And verify the Amendment Title is Appendix K Amendment
+        And verify the Amendment Title is "Appendix K Amendment"
         And verify there is an Initial Submission Date header in the details section
         And verify a date exists for the Initial Submission Date
         And verify there is a Proposed Effective Date header in the details section

--- a/tests/cypress/cypress/integration/Package_Dashboard_Appendix_K.spec.feature
+++ b/tests/cypress/cypress/integration/Package_Dashboard_Appendix_K.spec.feature
@@ -1,10 +1,41 @@
 Feature: Appendix K Waiver Type Selection
-
-    Scenario: Screen Enhance - Appendix K
+    Background: Reoccurring steps
         Given I am on Login Page
         When Clicking on Development Login
         When Login with state submitter user
         And click on Packages
         Then click on New Submission
         And Click on Waiver Action
+
+    Scenario: Screen Enhance - Appendix K
         And verify Appendix K is a clickable option
+        And Click on Appendix K Amendment
+        And verify user is on new Appendix K page
+
+    Scenario: create Appendix K from package dashboard and search it
+        And Click on Appendix K Amendment
+        And type Appendix K Submission 1 into Amendment Title field
+        And type in Waiver Number with 5 characters on new Appendix K Amendment Page
+        And select proposed effective date 3 months from today
+        And Add file for 1915c Appendix K Amendment Waiver Template
+        And Type Additonal Info Comments in new form
+        And Click on Submit Button
+        And verify submission successful message in the alert bar
+        And verify the Waivers tab is selected
+        And search for Appendix K number
+        And verify id number in the first row matches Appendix K number
+        And click the Waiver Number link in the first row
+        And verify the package details page is visible
+        And verify action card exists
+        And verify the status on the card is "Submitted"
+        And verify withdraw package action exists
+        And verify package actions header is visible
+        And verify the details section exists
+        And verify the waiver authority header exists
+        And verify there is a State header in the details section
+        And verify a state exists for the State
+        And verify there is an Amendment Title in the details section
+        And verify the Amendment Title is "Appendix K Submission 1"
+        And verify there is an Initial Submission Date header in the details section
+        And verify a date exists for the Initial Submission Date
+        And verify there is a Proposed Effective Date header in the details section

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -697,6 +697,12 @@ And(
     OneMacAppendixKAmendmentPage.inputWaiverNumber(`MD-10330.R00.12`);
   }
 );
+And(
+  "type in Waiver Number with 5 characters on new Appendix K Amendment Page",
+  () => {
+    OneMacAppendixKAmendmentPage.inputWaiverNumberNewForms(`MD-10330.R00.12`);
+  }
+);
 
 And("type in invalid Waiver Number On Appendix K Amendment Page", () => {
   OneMacAppendixKAmendmentPage.inputWaiverNumber("MD.123");
@@ -1902,6 +1908,10 @@ And("search for {string}", (part) => {
   OneMacPackagePage.searchFor(part);
   cy.wait(1000);
 });
+And("search for Appendix K number", () => {
+  OneMacPackagePage.searchFor("MD-10330.R00.12");
+  cy.wait(1000);
+});
 And("verify parent row expander exists", () => {
   OneMacPackagePage.verifyFirstParentRowExpanderExists();
 });
@@ -2118,7 +2128,7 @@ And("verify a state exists for the State", () => {
 And("verify there is an Amendment Title in the details section", () => {
   OneMacPackageDetailsPage.verifyStateHeaderExists();
 });
-And("verify the Amendment Title is Appendix K Amendment", () => {
+And("verify the Amendment Title is {string}", () => {
   OneMacPackageDetailsPage.verifyStateExists();
 });
 And(
@@ -2153,6 +2163,9 @@ And("verify user is on new initial waiver page", () => {
 });
 And("verify user is on new waiver renewal page", () => {
   OneMacSubmissionTypePage.verifyNewWaiverRenewalPage();
+});
+And("verify user is on new Appendix K page", () => {
+  OneMacSubmissionTypePage.verifyNewAppendixKPage();
 });
 And("verify user is on new waiver amendment page", () => {
   OneMacSubmissionTypePage.verifyNewWaiverAmendmentPage();
@@ -2726,4 +2739,10 @@ And("verify id number in the first row matches approved waiver number", () => {
       data.approvedInitialWaiverNum1
     );
   });
+});
+And("type Appendix K Submission 1 into Amendment Title field", () => {
+  OneMacAppendixKAmendmentPage.inputAmendmentTitle("Appendix K Submission 1");
+});
+And("verify id number in the first row matches Appendix K number", () => {
+  OneMacPackagePage.verifyIDNumberInFirstRowIs("MD-10330.R00.12");
 });

--- a/tests/cypress/support/pages/oneMacAppendixKAmendmentPage.js
+++ b/tests/cypress/support/pages/oneMacAppendixKAmendmentPage.js
@@ -1,6 +1,8 @@
 const waiverNumberInputBox = "#transmittal-number";
 const errorMessageForWaiverNumber = "#transmittal-number-status-msg";
 const firstUploadFileBtn = "#uploader-input-0";
+const ammendmentTitleField = "#title";
+const newWaiverNumberInputBox = "#componentId";
 
 export class oneMacAppendixKAmendmentPage {
   inputWaiverNumber(s) {
@@ -29,6 +31,12 @@ export class oneMacAppendixKAmendmentPage {
 
   verifyErrorMessageIsDisplayed() {
     cy.get(errorMessageForWaiverNumber).should("be.visible");
+  }
+  inputAmendmentTitle(s) {
+    cy.get(ammendmentTitleField).type(s);
+  }
+  inputWaiverNumberNewForms(s) {
+    cy.get(newWaiverNumberInputBox).type(s);
   }
 }
 export default oneMacAppendixKAmendmentPage;

--- a/tests/cypress/support/pages/oneMacSubmissionTypePage.js
+++ b/tests/cypress/support/pages/oneMacSubmissionTypePage.js
@@ -52,6 +52,9 @@ export class oneMacSubmissionTypePage {
   verifyNewWaiverAmendmentPage() {
     cy.url().should("include", "/waiver-amendment");
   }
+  verifyNewAppendixKPage() {
+    cy.url().should("include", "/appendix-k-amendment");
+  }
   clickwaiverAction() {
     cy.xpath(waiverAction).click();
   }


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-11589
Endpoint: See github-actions bot comment

### Test Plan

```
Feature: Appendix K Waiver Type Selection
    Background: Reoccurring steps
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        Then click on New Submission
        And Click on Waiver Action

    Scenario: Screen Enhance - Appendix K
        And verify Appendix K is a clickable option
        And Click on Appendix K Amendment
        And verify user is on new Appendix K page

    Scenario: create Appendix K from package dashboard and search it
        And Click on Appendix K Amendment
        And type Appendix K Submission 1 into Amendment Title field
        And type in Waiver Number with 5 characters on new Appendix K Amendment Page
        And select proposed effective date 3 months from today
        And Add file for 1915c Appendix K Amendment Waiver Template
        And Type Additonal Info Comments in new form
        And Click on Submit Button
        And verify submission successful message in the alert bar
        And verify the Waivers tab is selected
        And search for Appendix K number
        And verify id number in the first row matches Appendix K number
        And click the Waiver Number link in the first row
        And verify the package details page is visible
        And verify action card exists
        And verify the status on the card is "Submitted"
        And verify withdraw package action exists
        And verify package actions header is visible
        And verify the details section exists
        And verify the waiver authority header exists
        And verify there is a State header in the details section
        And verify a state exists for the State
        And verify there is an Amendment Title in the details section
        And verify the Amendment Title is "Appendix K Submission 1"
        And verify there is an Initial Submission Date header in the details section
        And verify a date exists for the Initial Submission Date
        And verify there is a Proposed Effective Date header in the details section
```
