### PR TITLE
Language change for 'Respond to Wavier RAI'

### DIFF
--- a/services/common/changeRequest.js
+++ b/services/common/changeRequest.js
@@ -405,8 +405,8 @@ export const CONFIG = {
   },
 
   [TYPE.WAIVER_RAI]: {
-    pageTitle: "Respond to 1915(b) Waiver RAI",
-    readOnlyPageTitle: "1915(b) Waiver RAI Response Details",
+    pageTitle: "Respond to Waiver RAI",
+    readOnlyPageTitle: "Waiver RAI Response Details",
     subheaderMessage: {
       __html: raiSubheaderMessage,
     },

--- a/services/ui-src/src/changeRequest/NewWaiver.js
+++ b/services/ui-src/src/changeRequest/NewWaiver.js
@@ -16,7 +16,7 @@ const choices = [
     linkTo: ROUTES.WAIVER_EXTENSION,
   },
   {
-    title: "Respond to 1915(b) Waiver RAI",
+    title: "Respond to Waiver RAI",
     description: "Submit additional information",
     linkTo: ROUTES.WAIVER_RAI,
   },


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-20556
Endpoint: See github-actions bot comment

### Details

As a OneMAC user, I need the description language to be accurate so that I know which documents must be submitted and my waiver workflow is streamlined.

### Changes

- Change back to “Respond to Waiver RAI” from “Respond to 1915(b) Waiver RAI”

### Implementation Notes

- Changed back on both the card and the title of the page
