### PR TITLE
OY2 20599: Update Waiver Authority for App K Amendment Details

### DIFF
--- a/services/app-api/form/defaultFormConfig.js
+++ b/services/app-api/form/defaultFormConfig.js
@@ -13,3 +13,5 @@ export const defaultProposedEffectiveDateSchema = [
 ];
 
 export const defaultTitleSchema = Joi.string().required();
+
+export const defaultWaiverAuthoritySchema = Joi.string().required();

--- a/services/app-api/form/submitInitialWaiver.js
+++ b/services/app-api/form/submitInitialWaiver.js
@@ -1,4 +1,3 @@
-import Joi from "joi";
 import { initialWaiver } from "cmscommonlib";
 
 import handler from "../libs/handler-lib";

--- a/services/app-api/form/submitInitialWaiver.js
+++ b/services/app-api/form/submitInitialWaiver.js
@@ -6,6 +6,7 @@ import { submitAny } from "./submitAny";
 import {
   defaultFormConfig,
   defaultProposedEffectiveDateSchema,
+  defaultWaiverAuthoritySchema,
 } from "./defaultFormConfig";
 
 /**
@@ -24,7 +25,7 @@ export const initialWaiverFormConfig = {
   ...defaultFormConfig,
   ...initialWaiver,
   appendToSchema: {
-    waiverAuthority: Joi.string().required(),
+    waiverAuthority: defaultWaiverAuthoritySchema,
     // Should look into a real validation with choices centrally located in cmscommonlib
     //      waiverAuthority: Joi.string().valid(WAIVER_AUTHORITY_CHOICES).required(),
     proposedEffectiveDate: defaultProposedEffectiveDateSchema,

--- a/services/app-api/form/submitWaiverAmendment.js
+++ b/services/app-api/form/submitWaiverAmendment.js
@@ -6,6 +6,7 @@ import { submitAny } from "./submitAny";
 import {
   defaultFormConfig,
   defaultProposedEffectiveDateSchema,
+  defaultWaiverAuthoritySchema,
 } from "./defaultFormConfig";
 
 export const waiverAmendmentFormConfig = {
@@ -13,7 +14,7 @@ export const waiverAmendmentFormConfig = {
   ...waiverAmendment,
   appendToSchema: {
     parentId: Joi.string().required(),
-    waiverAuthority: Joi.string().required(),
+    waiverAuthority: defaultWaiverAuthoritySchema,
     // Should look into a real validation with choices centrally located in cmscommonlib
     //      waiverAuthority: Joi.string().valid(WAIVER_AUTHORITY_CHOICES).required(),
     proposedEffectiveDate: defaultProposedEffectiveDateSchema,

--- a/services/app-api/form/submitWaiverAppendixK.js
+++ b/services/app-api/form/submitWaiverAppendixK.js
@@ -1,4 +1,3 @@
-import Joi from "joi";
 import { waiverAppendixK } from "cmscommonlib";
 
 import handler from "../libs/handler-lib";
@@ -7,13 +6,14 @@ import {
   defaultFormConfig,
   defaultProposedEffectiveDateSchema,
   defaultTitleSchema,
+  defaultWaiverAuthoritySchema,
 } from "./defaultFormConfig";
 
 export const waiverAppendixKFormConfig = {
   ...defaultFormConfig,
   ...waiverAppendixK,
   appendToSchema: {
-    waiverAuthority: Joi.string().required(),
+    waiverAuthority: defaultWaiverAuthoritySchema,
     proposedEffectiveDate: defaultProposedEffectiveDateSchema,
     title: defaultTitleSchema,
   },

--- a/services/app-api/form/submitWaiverAppendixK.js
+++ b/services/app-api/form/submitWaiverAppendixK.js
@@ -1,3 +1,4 @@
+import Joi from "joi";
 import { waiverAppendixK } from "cmscommonlib";
 
 import handler from "../libs/handler-lib";
@@ -12,6 +13,7 @@ export const waiverAppendixKFormConfig = {
   ...defaultFormConfig,
   ...waiverAppendixK,
   appendToSchema: {
+    waiverAuthority: Joi.string().required(),
     proposedEffectiveDate: defaultProposedEffectiveDateSchema,
     title: defaultTitleSchema,
   },

--- a/services/app-api/form/submitWaiverRenewal.js
+++ b/services/app-api/form/submitWaiverRenewal.js
@@ -6,13 +6,14 @@ import { submitAny } from "./submitAny";
 import {
   defaultFormConfig,
   defaultProposedEffectiveDateSchema,
+  defaultWaiverAuthoritySchema,
 } from "./defaultFormConfig";
 
 export const waiverRenewalFormConfig = {
   ...defaultFormConfig,
   ...waiverRenewal,
   appendToSchema: {
-    waiverAuthority: Joi.string().required(),
+    waiverAuthority: defaultWaiverAuthoritySchema,
     parentId: Joi.string().required(),
     // Should look into a real validation with choices centrally located in cmscommonlib
     //      waiverAuthority: Joi.string().valid(WAIVER_AUTHORITY_CHOICES).required(),

--- a/services/common/type/waiverAppendixK.js
+++ b/services/common/type/waiverAppendixK.js
@@ -10,6 +10,7 @@ export const waiverAppendixK = {
       errorLevel: "error",
     },
   ],
+  waiverAuthorities: [{ label: "1915(c) HCBS", value: "1915(c)" }],
   allowMultiplesWithSameId: false,
   requiredAttachments: ["1915(c) Appendix K Amendment Waiver Template"],
   optionalAttachments: ["Other"],

--- a/services/ui-src/src/page/DetailView.tsx
+++ b/services/ui-src/src/page/DetailView.tsx
@@ -27,7 +27,7 @@ import { AdditionalInfoSection } from "./section/AdditionalInfoSection";
 const AUTHORITY_LABELS = {
   "1915(b)": "All other 1915(b) Waivers",
   "1915(b)(4)": "1915(b)(4) FFS Selective Contracting waivers",
-  "1915(c)": "1915(c) Appendix K Amendment",
+  "1915(c)": "1915(c) HCBS",
 } as const;
 
 type PathParams = {

--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -79,12 +79,18 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
   const presetComponentId = location.state?.componentId ?? "";
   const presetParentId = location.state?.parentId ?? undefined;
 
+  // if only one waiver Authority choice, it is the default
+  const presetWaiverAuthority =
+    formConfig.waiverAuthorities && formConfig.waiverAuthorities.length === 1
+      ? formConfig.waiverAuthorities[0].value
+      : undefined;
+
   // The record we are using for the form.
   const [oneMacFormData, setOneMacFormData] = useState<OneMacFormData>({
     territory: getTerritoryFromComponentId(presetComponentId),
     additionalInformation: "",
     componentId: presetComponentId,
-    waiverAuthority: undefined,
+    waiverAuthority: presetWaiverAuthority,
     proposedEffectiveDate: undefined,
     parentId: presetParentId,
     parentType: location.state?.parentType,
@@ -195,17 +201,6 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
   useEffect(() => {
     window.scrollTo({ top: 0 });
   }, [alertCode]);
-
-  useEffect(() => {
-    if (
-      formConfig.waiverAuthorities &&
-      formConfig.waiverAuthorities.length === 1
-    ) {
-      let updatedRecord = { ...oneMacFormData } as OneMacFormData; // You need a new object to be able to update the state
-      updatedRecord.waiverAuthority = formConfig.waiverAuthorities[0].value;
-      setOneMacFormData(updatedRecord);
-    }
-  }, [formConfig]);
 
   useEffect(() => {
     const checkId = async () => {

--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -197,6 +197,17 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
   }, [alertCode]);
 
   useEffect(() => {
+    if (
+      formConfig.waiverAuthorities &&
+      formConfig.waiverAuthorities.length === 1
+    ) {
+      let updatedRecord = { ...oneMacFormData } as OneMacFormData; // You need a new object to be able to update the state
+      updatedRecord.waiverAuthority = formConfig.waiverAuthorities[0].value;
+      setOneMacFormData(updatedRecord);
+    }
+  }, [formConfig]);
+
+  useEffect(() => {
     const checkId = async () => {
       try {
         const parentStatusMessages: Message[] = [];
@@ -465,21 +476,22 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
               maxLength={config.MAX_PACKAGE_TITLE_LENGTH}
             ></TextField>
           )}
-          {formConfig.waiverAuthorities && (
-            <Dropdown
-              options={[
-                ...defaultWaiverAuthority,
-                ...formConfig.waiverAuthorities,
-              ]}
-              defaultValue={oneMacFormData.waiverAuthority}
-              label="Waiver Authority"
-              labelClassName="ds-u-margin-top--0 required"
-              fieldClassName="field"
-              name="waiverAuthority"
-              id="waiver-authority"
-              onChange={handleInputChange}
-            />
-          )}
+          {formConfig.waiverAuthorities &&
+            formConfig.waiverAuthorities.length > 1 && (
+              <Dropdown
+                options={[
+                  ...defaultWaiverAuthority,
+                  ...formConfig.waiverAuthorities,
+                ]}
+                defaultValue={oneMacFormData.waiverAuthority}
+                label="Waiver Authority"
+                labelClassName="ds-u-margin-top--0 required"
+                fieldClassName="field"
+                name="waiverAuthority"
+                id="waiver-authority"
+                onChange={handleInputChange}
+              />
+            )}
           {typeof formConfig.getParentInfo == "function" && (
             <Review heading={"Parent " + formConfig.idLabel}>
               {oneMacFormData.parentId ?? "Unknown"}

--- a/services/ui-src/src/page/waiver-appendix-k/WaiverAppendixKDetail.tsx
+++ b/services/ui-src/src/page/waiver-appendix-k/WaiverAppendixKDetail.tsx
@@ -12,6 +12,11 @@ import {
 } from "../../libs/detailLib";
 import { waiverAppendixK } from "cmscommonlib";
 
+const appendixKWaiverAuthority = {
+  ...waiverAuthorityDefault,
+  default: "1915(c) HCBS",
+};
+
 export const waiverAppendixKDetail: OneMACDetail = {
   ...defaultDetail,
   ...waiverAppendixK,
@@ -25,7 +30,7 @@ export const waiverAppendixKDetail: OneMACDetail = {
     },
   ],
   detailSection: [
-    waiverAuthorityDefault,
+    appendixKWaiverAuthority,
     territoryDefault,
     {
       heading: "Amendment Title",

--- a/tests/cypress/cypress/integration/Mini_Dashboard_Package_Details_Waivers.spec.feature
+++ b/tests/cypress/cypress/integration/Mini_Dashboard_Package_Details_Waivers.spec.feature
@@ -133,6 +133,7 @@ Feature: OY2-11585 Waiver Package Details View: Initial Waivers and Waiver Renew
         And verify package actions header is visible
         And verify the details section exists
         And verify the waiver authority header exists
+        And verify the waiver authority is 1915c HCBS
         And verify there is a State header in the details section
         And verify a state exists for the State
         And verify there is an Amendment Title in the details section
@@ -158,6 +159,7 @@ Feature: OY2-11585 Waiver Package Details View: Initial Waivers and Waiver Renew
         And verify Respond to RAI action exists
         And verify the details section exists
         And verify the waiver authority header exists
+        And verify the waiver authority is 1915c HCBS
         And verify there is a State header in the details section
         And verify a state exists for the State
         And verify there is an Amendment Title in the details section

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -2300,6 +2300,9 @@ And("verify the amendment title is NA", () => {
 And("verify the waiver authority header exists", () => {
   OneMacPackageDetailsPage.verifyWaiverAuthorityHeaderExists();
 });
+And("verify the waiver authority is 1915c HCBS", () => {
+  OneMacPackageDetailsPage.verifyWaiverAuthorityHeaderis1915cHCBS();
+});
 And("verify the supporting documentation section exists", () => {
   OneMacPackageDetailsPage.verifySupportingDocumentationSectionExists();
 });

--- a/tests/cypress/support/pages/oneMacPackageDetailsPage.js
+++ b/tests/cypress/support/pages/oneMacPackageDetailsPage.js
@@ -197,6 +197,9 @@ export class oneMacPackageDetailsPage {
   verifyWaiverAuthorityHeaderExists() {
     cy.xpath(waiverAuthorityHeader).should("be.visible");
   }
+  verifyWaiverAuthorityHeaderis1915cHCBS() {
+    cy.xpath(waiverAuthorityHeader).next().contains("1915(c) HCBS");
+  }
   verifySupportingDocumentationSectionExists() {
     cy.xpath(supportingDocumentationSection).should("be.visible");
   }


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-20599
Endpoint: See github-actions bot comment

### Details
Appendix K's have a different Waiver Authority from 1915(b) waivers and it is always 1915(c) HCBS

### Changes
- Updated the DetailView niceLabel to the new text
- set that value as the default for Waiver Authority being null (currently, the Appendix K form does not set a waiver authority, so app k  items in the database have no waiverAuthority (the seed data does, however))
- added the default 1915(c) value to the waiverAuthorities "choices" as the single choice
- modified the form to handle only one waiverAuthority choice as something to send straight through

### Test Plan
1. Login as a user who can view packages
2. Navigate to Package Dashboard, Waivers Tab
3. Locate an Appendix K Amendment in the table
4. Click the ID to view details
5. Verify the Waiver Authority follows the story AC
