### PR TITLE
Oy2 20404 - unique component id

### DIFF
--- a/services/ui-src/src/components/ComponentId.tsx
+++ b/services/ui-src/src/components/ComponentId.tsx
@@ -73,7 +73,7 @@ const ComponentId: React.FC<{
             name="componentId"
             aria-describedby={idFieldHint
               ?.map(function (idFieldHint, idx) {
-                return "fieldHint" + idx;
+                return idPrefix + "fieldHint" + idx;
               })
               .join(" ")}
             value={value}

--- a/services/ui-src/src/components/ComponentId.tsx
+++ b/services/ui-src/src/components/ComponentId.tsx
@@ -8,6 +8,7 @@ import { Message } from "../libs/formLib";
  * Returns the ID specific form element
  */
 const ComponentId: React.FC<{
+  idPrefix?: string;
   idLabel: string;
   idFieldHint: FieldHint[];
   idFAQLink?: string;
@@ -15,8 +16,8 @@ const ComponentId: React.FC<{
   value: string;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   disabled: boolean;
-  id?: string;
 }> = ({
+  idPrefix = "", //default prefix to empty string
   idLabel,
   idFieldHint,
   idFAQLink,
@@ -24,7 +25,6 @@ const ComponentId: React.FC<{
   value,
   onChange,
   disabled,
-  id = "componentId",
 }) => {
   return (
     <>
@@ -32,7 +32,7 @@ const ComponentId: React.FC<{
         <>
           <div className="label-container">
             <div>
-              <label htmlFor={id} className="required">
+              <label htmlFor={idPrefix + "componentId"} className="required">
                 {idLabel}
               </label>
             </div>
@@ -46,7 +46,7 @@ const ComponentId: React.FC<{
             {idFieldHint?.map(function (idFieldHint, idx) {
               return (
                 <p
-                  id={"fieldHint" + idx}
+                  id={idPrefix + "fieldHint" + idx}
                   key={"fieldHint" + idx}
                   className={idFieldHint.className || "field-hint"}
                 >
@@ -60,7 +60,7 @@ const ComponentId: React.FC<{
             statusMessages.map((message, i) => (
               <div
                 key={i}
-                id={"componentIdStatusMsg" + i}
+                id={idPrefix + "componentIdStatusMsg" + i}
                 className={"ds-u-color--" + message.statusLevel}
               >
                 {message.statusMessage}
@@ -69,7 +69,7 @@ const ComponentId: React.FC<{
           <input
             className="field"
             type="text"
-            id={id}
+            id={idPrefix + "componentId"}
             name="componentId"
             aria-describedby={idFieldHint
               ?.map(function (idFieldHint, idx) {

--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -483,7 +483,7 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
             )}
           {formConfig.parentLabel && (
             <ComponentId
-              idPrefix="parent"
+              idPrefix="parent-"
               idLabel={formConfig.parentLabel}
               idFieldHint={formConfig.parentFieldHint ?? [{ text: "" }]}
               statusMessages={parentIdStatusMessages}

--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -483,7 +483,7 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
             )}
           {formConfig.parentLabel && (
             <ComponentId
-              id="parentComponentId"
+              idPrefix="parent"
               idLabel={formConfig.parentLabel}
               idFieldHint={formConfig.parentFieldHint ?? [{ text: "" }]}
               statusMessages={parentIdStatusMessages}


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-20404
Endpoint: See github-actions bot comment

### Details

Add custom id attributes to componentId component when using multiple of same component on a page

### Changes

- Added optional `idPrefix` param to componentId
- updated componentId to use idPrefix if present for all ids
- updated OneMacForm.tsx to use idPrefix for parent component id

### Test Plan

1. Login as state submitter
2. Navigate to New Submission -> Waiver Action -> Renewal, Amendment, or Temp Extension
3. Verify the html id for the parent component id fields and the main component id fields are unique
4. Ensure id uniqueness for labels, fields, grey subtext, and any error text
