### PR TITLE
update css media queries for tables to adjust behavior based on viewport

### DIFF
--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -981,7 +981,6 @@ article.form-container {
 }
 
 .dashboard-container {
-  @extend .app-bar;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -999,24 +998,46 @@ article.form-container {
 }
 
 .table-wrapper {
-  display: block;
-  max-width: 1040px;
-  max-height: 520px;
   overflow: auto;
+  @media only screen and (max-width: 1023px) {
+    display: block;
+    max-height: 320px;
+  }
+
+  @media only screen and (min-width: 1024px) {
+    display: flex;
+    min-width: min(calc(100vw - 14.4rem), 1024px);
+  }
 }
 
 .submissions-table,
 .package-table {
   @include custom-table;
-  min-width: 1024px;
+
+  @media only screen and (max-width: 1199px) {
+    td .type-badge {
+      white-space: normal;
+    }
+    th,
+    td {
+      &:not(:last-child) {
+        padding-right: 8px;
+      }
+    }
+  }
+
+  @media only screen and (min-width: 1200px) {
+    th,
+    td {
+      &:not(:last-child) {
+        padding-right: $table-padding;
+      }
+    }
+  }
 
   th,
   td {
     white-space: nowrap;
-
-    &:not(:last-child) {
-      padding-right: 2ch;
-    }
   }
 
   th:first-child,
@@ -2319,6 +2340,8 @@ aside#faq-contact-info-box {
 }
 
 .search-and-filter {
+  margin-left: 7.2rem;
+  margin-right: 7.2rem;
   @extend .ds-u-margin-bottom--4;
   @extend .ds-u-display--flex;
   @extend .ds-u-justify-content--between;
@@ -2527,6 +2550,8 @@ aside#faq-contact-info-box {
 }
 
 .tab-bar {
+  margin-left: 7.2rem;
+  margin-right: 7.2rem;
   @extend .ds-u-margin-bottom--4;
   @extend .ds-u-display--flex;
   @extend .ds-u-align-items--start;


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-20623
Endpoint: See github-actions bot comment

### Details

Adjust package (and submission) pages so that they do not use scrollbars at 1024 and above resolutions.

### Changes

- Separated the table area from the tabs and search so that we only enforce max-width on those header elements and not on the table
- added media queries such that below 1024px width the table will behave as before with scrollbars and fixed size
- added media queries such that at 1024px and above width the table will dynamically size and calculate the minimum width based on current viewport size
- added media queries such that below 1200px width the spacing between elements is smaller and the type labels are able to wrap
- added media queries such that at 1200px and above width the spacing between elements is the default $table-padding

### Implementation Notes

- Im no CSS expert and played with many iterations before finding something that worked for all sizes (800px,1024px, 1280px, 1920px) so feel free to point out any errors or suggestions
- due to the sticky column i was unable to use a `justify-content: center;` style on the table flex box because as things grew they would get "lost" behind the sticky element; therefore i landed on the usage of calculating the minimum width based on current viewport minus 14.4rem since other page margins use 7.4rem on each side. This allowed content to be automatically lined in the center and the sticky column behaving as intended.

### Test Plan

1. Login as statesubmitter
2. navigate to package list
3. change screen size using browser tool or manual adjustment to see behavior at various sizes
