### PR TITLE
revert webacl name

### DIFF
--- a/services/app-api/resources/api-gateway.yml
+++ b/services/app-api/resources/api-gateway.yml
@@ -17,10 +17,10 @@ Resources:
       ResponseType: DEFAULT_5XX
       RestApiId:
         Ref: "ApiGatewayRestApi"
-  ApiGwWebAcl2:
+  ApiGwWebAcl:
     Type: AWS::WAFv2::WebACL
     Properties:
-      Name: ${self:custom.stage}-ApiGwWebAcl2
+      Name: ${self:custom.stage}-ApiGwWebAcl
       DefaultAction:
         Block: {}
       Rules:


### PR DESCRIPTION
We had to temporarily rename the webacl to get things back in sync after reverting the WAF changes. This is to also revert the name change to the webacl.