### PR TITLE
Oy2 20967 - temporary extension form updates

### DIFF
--- a/services/app-api/email/CMSSubmissionNotice.test.js
+++ b/services/app-api/email/CMSSubmissionNotice.test.js
@@ -19,5 +19,5 @@ it("builds the CMS Submission Notice Email", async () => {
 
   expect(response2.HTML.includes(testData.componentId)).toBe(true);
   expect(response2.HTML.includes(process.env.applicationEndpoint)).toBe(true);
-  expect(response2.HTML.length).toBe(1222);
+  expect(response2.HTML.length).toBe(1231);
 });

--- a/services/app-api/email/CMSWithdrawalNotice.test.js
+++ b/services/app-api/email/CMSWithdrawalNotice.test.js
@@ -14,5 +14,5 @@ it("builds the CMS Withdrawal Notice Email", async () => {
   };
 
   const response2 = CMSWithdrawalNotice(testData, testConfig);
-  expect(response2.HTML.length).toBe(393);
+  expect(response2.HTML.length).toBe(402);
 });

--- a/services/app-api/email/formatPackageDetails.js
+++ b/services/app-api/email/formatPackageDetails.js
@@ -23,6 +23,11 @@ export const formatPackageDetails = (data, config) => {
             : ""
         }
         ${
+          data.temporaryExtensionType
+            ? `<br><b>Temporary Extension Type</b>: ${data.temporaryExtensionType}`
+            : ""
+        }
+        ${
           data.proposedEffectiveDate
             ? `<br><b>Proposed Effective Date</b>: ${format(
                 parseISO(data.proposedEffectiveDate),

--- a/services/app-api/email/stateSubmissionReceipt.test.js
+++ b/services/app-api/email/stateSubmissionReceipt.test.js
@@ -12,5 +12,5 @@ it("builds the State Submission Receipt Email", async () => {
   };
 
   const response2 = stateSubmissionReceipt(testData, testConfig);
-  expect(response2.HTML.length).toBe(1086);
+  expect(response2.HTML.length).toBe(1095);
 });

--- a/services/app-api/email/stateWithdrawalReceipt.test.js
+++ b/services/app-api/email/stateWithdrawalReceipt.test.js
@@ -14,5 +14,5 @@ it("builds the State Withdrawal Receipt Email", async () => {
   };
   // TODO:  Get Test Data
   const response = stateWithdrawalReceipt(testData, testConfig);
-  expect(response.HTML.length).toBe(392);
+  expect(response.HTML.length).toBe(401);
 });

--- a/services/app-api/form/submitAny.test.js
+++ b/services/app-api/form/submitAny.test.js
@@ -56,6 +56,7 @@ const tempExtensionEventBody = {
   territory: "VA",
   submitterEmail: "statesubmitteractive@cms.hhs.local",
   submitterName: "Angie Active",
+  temporaryExtensionType: "1915(b)",
   attachments: [
     {
       contentType: "image/png",

--- a/services/app-api/form/submitWaiverExtension.js
+++ b/services/app-api/form/submitWaiverExtension.js
@@ -10,6 +10,7 @@ export const waiverTemporaryExtensionFormConfig = {
   appendToSchema: {
     parentId: Joi.string().required(),
     parentType: Joi.string().optional(),
+    temporaryExtensionType: Joi.string().required(),
   },
 };
 

--- a/services/app-api/resources/api-gateway.yml
+++ b/services/app-api/resources/api-gateway.yml
@@ -17,10 +17,10 @@ Resources:
       ResponseType: DEFAULT_5XX
       RestApiId:
         Ref: "ApiGatewayRestApi"
-  ApiGwWebAcl2:
+  ApiGwWebAcl:
     Type: AWS::WAFv2::WebACL
     Properties:
-      Name: ${self:custom.stage}-ApiGwWebAcl2
+      Name: ${self:custom.stage}-ApiGwWebAcl
       DefaultAction:
         Block: {}
       Rules:

--- a/services/app-api/utils/newSubmission.js
+++ b/services/app-api/utils/newSubmission.js
@@ -21,6 +21,7 @@ const topLevelAttributes = [
   "parentId",
   "parentType",
   "title",
+  "temporaryExtensionType",
 ];
 
 export default async function newSubmission(newData, config) {

--- a/services/common/type/waiverTemporaryExtension.js
+++ b/services/common/type/waiverTemporaryExtension.js
@@ -1,7 +1,7 @@
 export const waiverTemporaryExtension = {
   componentType: "waiverextension",
   typeLabel: "Waiver Extension",
-  idLabel: "Temporary Extension Number",
+  idLabel: "Temporary Extension Request Number",
   idRegex: "^[A-Z]{2}[-][0-9]{4,5}[.]R[0-9]{2}[.]TE[0-9]{2}$",
   idExistValidations: [
     {

--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -654,12 +654,11 @@ input[type="file"] {
   }
   .label-container {
     @extend .ds-l-row;
-    @extend .ds-u-measure--wide;
     margin-left: 0px;
     @extend .ds-u-align-items--end;
 
     .label-rcol {
-      @extend .ds-u-margin-left--auto;
+      @extend .ds-u-margin-left--2;
       text-align: right;
       font-weight: 400;
     }

--- a/services/ui-src/src/libs/formLib.tsx
+++ b/services/ui-src/src/libs/formLib.tsx
@@ -11,20 +11,25 @@ export type OneMACFormConfig = {
   idFieldHint: FieldHint[];
   idAdditionalErrorMessage?: string[];
   idFAQLink: string;
-  parentLabel?: string;
-  parentFieldHint?: FieldHint[];
-  parentNotFoundMessage?: string;
-  validateParentAPI?: string;
   pageTitle: string;
   addlIntroJSX?: JSX.Element;
   detailsHeader?: string;
   landingPage: string;
-  confirmSubmit?: boolean;
+  confirmSubmit: boolean;
   proposedEffectiveDate?: boolean;
   titleLabel?: string;
-  getParentInfo?: (id: string) => string[];
 } & PackageType &
-  Partial<WaiverPackageType>;
+  Partial<ParentPackageType> &
+  Partial<WaiverPackageType> &
+  Partial<TemporaryExtensionPackageType>;
+
+type ParentPackageType = {
+  parentLabel?: string;
+  parentFieldHint?: FieldHint[];
+  parentNotFoundMessage?: string;
+  validateParentAPI?: string;
+  getParentInfo?: (id: string) => string[];
+};
 
 export const defaultOneMACFormConfig = {
   idFormat: "",
@@ -55,6 +60,10 @@ export type WaiverPackageType = {
   waiverAuthorities: SelectOption[];
 };
 
+export type TemporaryExtensionPackageType = {
+  temporaryExtensionTypes: SelectOption[];
+};
+
 export type Message = {
   statusLevel: string;
   statusMessage: string;
@@ -66,6 +75,7 @@ export type OneMacFormData = {
   additionalInformation: string;
   componentId: string;
   waiverAuthority?: string;
+  temporaryExtensionType?: string;
   proposedEffectiveDate?: string;
   title?: string;
   parentId?: string;

--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -34,6 +34,7 @@ import PageTitleBar from "../components/PageTitleBar";
 import AlertBar from "../components/AlertBar";
 import { FormLocationState } from "../domain-types";
 import ComponentId from "../components/ComponentId";
+import TemporaryExtensionTypeInput from "./temporary-extension/TemporaryExtensionTypeInput";
 
 const leavePageConfirmMessage = "Changes you made will not be saved.";
 
@@ -91,6 +92,7 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
     additionalInformation: "",
     componentId: presetComponentId,
     waiverAuthority: presetWaiverAuthority,
+    temporaryExtensionType: undefined,
     proposedEffectiveDate: undefined,
     parentId: presetParentId,
     parentType: location.state?.parentType,
@@ -327,6 +329,10 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
     const isWaiverAuthorityReady: boolean = Boolean(
       !formConfig.waiverAuthorities || oneMacFormData.waiverAuthority
     );
+    const isTemporaryExtensionTypeReady: boolean = Boolean(
+      !formConfig.temporaryExtensionTypes ||
+        oneMacFormData.temporaryExtensionType
+    );
     const isProposedEffecitveDateReady: boolean = Boolean(
       !formConfig.proposedEffectiveDate || oneMacFormData.proposedEffectiveDate
     );
@@ -342,6 +348,7 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
     setIsSubmissionReady(
       isTitleReady &&
         isWaiverAuthorityReady &&
+        isTemporaryExtensionTypeReady &&
         isParentIdReady &&
         idHasNoErrors &&
         areUploadsReady &&
@@ -481,6 +488,12 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
                 onChange={handleInputChange}
               />
             )}
+          {formConfig.temporaryExtensionTypes && (
+            <TemporaryExtensionTypeInput
+              temporaryExtensionTypes={[...formConfig.temporaryExtensionTypes]}
+              handleOnChange={handleInputChange}
+            />
+          )}
           {formConfig.parentLabel && (
             <ComponentId
               idPrefix="parent-"

--- a/services/ui-src/src/page/temporary-extension/TemporaryExtensionForm.test.js
+++ b/services/ui-src/src/page/temporary-extension/TemporaryExtensionForm.test.js
@@ -66,7 +66,7 @@ describe("Temporary Extension Form", () => {
     expect(submitButtonEl).toBeDisabled();
 
     const transmittalNumberEl = screen.getByLabelText(
-      "Temporary Extension Number"
+      "Temporary Extension Request Number"
     );
 
     ChangeRequestDataApi.packageExists.mockResolvedValue(false);

--- a/services/ui-src/src/page/temporary-extension/TemporaryExtensionForm.tsx
+++ b/services/ui-src/src/page/temporary-extension/TemporaryExtensionForm.tsx
@@ -17,7 +17,7 @@ const TemporaryExtensionForm: FC = () => {
   const temporaryExtensionFormInfo: OneMACFormConfig = {
     ...waiverTemporaryExtension,
     ...defaultOneMACFormConfig,
-    pageTitle: "Request a Temporary Extension",
+    pageTitle: "Request 1915(b) or 1915(c) Temporary Extension",
     detailsHeader: "Temporary Extension Request",
     idFAQLink: ROUTES.FAQ_WAIVER_EXTENSION_ID,
     idFieldHint: [
@@ -42,6 +42,10 @@ const TemporaryExtensionForm: FC = () => {
     parentNotFoundMessage:
       "The waiver number entered does not appear to match our records. Please enter an approved initial or renewal waiver number, using a dash after the two character state abbreviation.",
     validateParentAPI: "validateParentOfTemporaryExtension",
+    temporaryExtensionTypes: [
+      { label: "1915(b) Temporary Extension", value: "1915(b)" },
+      { label: "1915(c) Temporary Extension", value: "1915(c)" },
+    ],
   };
 
   return <OneMACForm formConfig={temporaryExtensionFormInfo} />;

--- a/services/ui-src/src/page/temporary-extension/TemporaryExtensionTypeInput.tsx
+++ b/services/ui-src/src/page/temporary-extension/TemporaryExtensionTypeInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from "react";
+import React from "react";
 import { Dropdown } from "@cmsgov/design-system";
 import { SelectOption } from "cmscommonlib";
 

--- a/services/ui-src/src/page/temporary-extension/TemporaryExtensionTypeInput.tsx
+++ b/services/ui-src/src/page/temporary-extension/TemporaryExtensionTypeInput.tsx
@@ -1,0 +1,28 @@
+import React, { FC } from "react";
+import { Dropdown } from "@cmsgov/design-system";
+import { SelectOption } from "cmscommonlib";
+
+const TemporaryExtensionTypeInput: React.FC<{
+  temporaryExtensionTypes: SelectOption[];
+  handleOnChange: any;
+}> = ({ temporaryExtensionTypes, handleOnChange }) => {
+  const defaultType: SelectOption = {
+    label: "-- select a temporary extension type --",
+    value: "",
+  };
+
+  return (
+    <Dropdown
+      options={[defaultType, ...(temporaryExtensionTypes ?? [])]}
+      defaultValue={defaultType.value}
+      label="Temporary Extension Type"
+      labelClassName="ds-u-margin-top--0 required"
+      fieldClassName="field"
+      name="temporaryExtensionType"
+      id="temp-ext-type"
+      onChange={handleOnChange}
+    />
+  );
+};
+
+export default TemporaryExtensionTypeInput;

--- a/tests/cypress/cypress/integration/Package_Dashboard_Temporary_Extension_Form.spec.feature
+++ b/tests/cypress/cypress/integration/Package_Dashboard_Temporary_Extension_Form.spec.feature
@@ -1,86 +1,86 @@
-# Feature: Package Dashboard Temporary Extension
-#     Background: reoccurring steps
-#         Given I am on Login Page
-#         When Clicking on Development Login
-#         When Login with state submitter user
-#         And click on Packages
+Feature: Package Dashboard Temporary Extension
+    Background: reoccurring steps
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
 
-#     Scenario: Verify user can create a temporary extension and that it is in the temporary extensions list
-#         Then click on New Submission
-#         And Click on Waiver Action
-#         And Click on Request Temporary Extension in Package dashboard
-#         And type approved Initial Waiver number into Existing Waiver Number to Renew field
-#         And Type Temporary Extension Number 1 With 5 Characters
-#         And upload Waiver Extension Request
-#         And type "This is just a test" in additional info textarea
-#         And Click on Submit Button
-#         And verify submission successful message in the alert bar
-#         And search for approved Initial Waiver Number 1
-#         And click the Waiver Number link in the first row
-#         And click on the Temporary Extension nav button
-#         And verify the temporary extension exists
-#         And click on the link for temporary extension number 1
-#         And verify the details section exists
-#         And verify there is a Type header in the details section
-#         And verify the type is 1915b Temporary Extension
-#         And verify there is a Parent Waiver Number header in the details section
-#         And verify the Parent Waiver Number ID is the approved intial waiver number 1
-#         And verify there is an Initial Submission Date header in the details section
-#         And verify a date exists for the Initial Submission Date
+    Scenario: Verify user can create a temporary extension and that it is in the temporary extensions list
+    # Then click on New Submission
+    # And Click on Waiver Action
+    # And Click on Request Temporary Extension in Package dashboard
+    # And type approved Initial Waiver number into Existing Waiver Number to Renew field
+    # And Type Temporary Extension Number 1 With 5 Characters
+    # And upload Waiver Extension Request
+    # And type "This is just a test" in additional info textarea
+    # And Click on Submit Button
+    # And verify submission successful message in the alert bar
+    # And search for approved Initial Waiver Number 1
+    # And click the Waiver Number link in the first row
+    # And click on the Temporary Extension nav button
+    # And verify the temporary extension exists
+    # And click on the link for temporary extension number 1
+    # And verify the details section exists
+    # And verify there is a Type header in the details section
+    # And verify the type is 1915b Temporary Extension
+    # And verify there is a Parent Waiver Number header in the details section
+    # And verify the Parent Waiver Number ID is the approved intial waiver number 1
+    # And verify there is an Initial Submission Date header in the details section
+    # And verify a date exists for the Initial Submission Date
 
-#     Scenario: Verify user can withdraw temporary extension from mini-dashboard page
-#         Then click on New Submission
-#         And Click on Waiver Action
-#         And Click on Request Temporary Extension in Package dashboard
-#         And type approved Initial Waiver number into Existing Waiver Number to Renew field
-#         And Type Temporary Extension Number 2 With 5 Characters
-#         And upload Waiver Extension Request
-#         And type "This is just a test" in additional info textarea
-#         And Click on Submit Button
-#         And verify submission successful message in the alert bar
-#         And search for approved Initial Waiver Number 1
-#         And click the Waiver Number link in the first row
-#         And click on the Temporary Extension nav button
-#         And click the action button for temporary extension 2
-#         And click withdraw button on the temp extension page
-#         And click yes, withdraw package button
-#         And verify success message for Withdrawal
+    Scenario: Verify user can withdraw temporary extension from mini-dashboard page
+    # Then click on New Submission
+    # And Click on Waiver Action
+    # And Click on Request Temporary Extension in Package dashboard
+    # And type approved Initial Waiver number into Existing Waiver Number to Renew field
+    # And Type Temporary Extension Number 2 With 5 Characters
+    # And upload Waiver Extension Request
+    # And type "This is just a test" in additional info textarea
+    # And Click on Submit Button
+    # And verify submission successful message in the alert bar
+    # And search for approved Initial Waiver Number 1
+    # And click the Waiver Number link in the first row
+    # And click on the Temporary Extension nav button
+    # And click the action button for temporary extension 2
+    # And click withdraw button on the temp extension page
+    # And click yes, withdraw package button
+    # And verify success message for Withdrawal
 
-#     Scenario: Verify user can create a temporary extension from the Temp. Extension Mini-Dashboard
-#         And click on the Waivers tab
-#         And search for approved Initial Waiver Number 1
-#         And click the Waiver Number link in the first row
-#         And click on the Temporary Extension nav button
-#         And Click the Request Extension button
-#         And verify the parent ID is prefilled in the form
-#         And Type Temporary Extension Number 3 With 5 Characters
-#         And upload Waiver Extension Request
-#         And Type Additonal Info Comments in new form
-#         And Click on Submit Button
-#         And verify submission successful message in the alert bar
+    Scenario: Verify user can create a temporary extension from the Temp. Extension Mini-Dashboard
+        And click on the Waivers tab
+        And search for approved Initial Waiver Number 1
+        And click the Waiver Number link in the first row
+        And click on the Temporary Extension nav button
+        And Click the Request Extension button
+        And verify the parent ID is prefilled in the form
+        And Type Temporary Extension Number 3 With 5 Characters
+        And upload Waiver Extension Request
+        And Type Additonal Info Comments in new form
+        And Click on Submit Button
+        And verify submission successful message in the alert bar
 
-#     Scenario: Verify user can create a temporary extension from the package details Mini-Dashboard
-#         And click on the Waivers tab
-#         And search for approved Initial Waiver Number 1
-#         And click the Waiver Number link in the first row
-#         And verify Request a Temporary Extension package action exists
-#         And click Request a Temporary Extension package action
-#         And verify the parent ID is prefilled in the form
-#         And Type Temporary Extension Number 4
-#         And upload Waiver Extension Request
-#         And Type Additonal Info Comments in new form
-#         And Click on Submit Button
-#         And verify submission successful message in the alert bar
+    Scenario: Verify user can create a temporary extension from the package details Mini-Dashboard
+    # And click on the Waivers tab
+    # And search for approved Initial Waiver Number 1
+    # And click the Waiver Number link in the first row
+    # And verify Request a Temporary Extension package action exists
+    # And click Request a Temporary Extension package action
+    # And verify the parent ID is prefilled in the form
+    # And Type Temporary Extension Number 4
+    # And upload Waiver Extension Request
+    # And Type Additonal Info Comments in new form
+    # And Click on Submit Button
+    # And verify submission successful message in the alert bar
 
-#     Scenario: Verify user can create a temporary extension from the package dashboard waiver tab
-#         And click on the Waivers tab
-#         And search for approved Initial Waiver Number 1
-#         And click the actions button in row one
-#         And verify the Request Temporary Extension button is displayed
-#         And click the Request Temporary Extension button
-#         And verify the parent ID is prefilled in the form
-#         And Type Temporary Extension Number 5
-#         And upload Waiver Extension Request
-#         And Type Additonal Info Comments in new form
-#         And Click on Submit Button
-#         And verify submission successful message in the alert bar
+    Scenario: Verify user can create a temporary extension from the package dashboard waiver tab
+# And click on the Waivers tab
+# And search for approved Initial Waiver Number 1
+# And click the actions button in row one
+# And verify the Request Temporary Extension button is displayed
+# And click the Request Temporary Extension button
+# And verify the parent ID is prefilled in the form
+# And Type Temporary Extension Number 5
+# And upload Waiver Extension Request
+# And Type Additonal Info Comments in new form
+# And Click on Submit Button
+# And verify submission successful message in the alert bar

--- a/tests/cypress/cypress/integration/Package_Dashboard_Temporary_Extension_Form.spec.feature
+++ b/tests/cypress/cypress/integration/Package_Dashboard_Temporary_Extension_Form.spec.feature
@@ -1,86 +1,86 @@
-Feature: Package Dashboard Temporary Extension
-    Background: reoccurring steps
-        Given I am on Login Page
-        When Clicking on Development Login
-        When Login with state submitter user
-        And click on Packages
+# Feature: Package Dashboard Temporary Extension
+#     Background: reoccurring steps
+#         Given I am on Login Page
+#         When Clicking on Development Login
+#         When Login with state submitter user
+#         And click on Packages
 
-    Scenario: Verify user can create a temporary extension and that it is in the temporary extensions list
-        Then click on New Submission
-        And Click on Waiver Action
-        And Click on Request Temporary Extension in Package dashboard
-        And type approved Initial Waiver number into Existing Waiver Number to Renew field
-        And Type Temporary Extension Number 1 With 5 Characters
-        And upload Waiver Extension Request
-        And type "This is just a test" in additional info textarea
-        And Click on Submit Button
-        And verify submission successful message in the alert bar
-        And search for approved Initial Waiver Number 1
-        And click the Waiver Number link in the first row
-        And click on the Temporary Extension nav button
-        And verify the temporary extension exists
-        And click on the link for temporary extension number 1
-        And verify the details section exists
-        And verify there is a Type header in the details section
-        And verify the type is 1915b Temporary Extension
-        And verify there is a Parent Waiver Number header in the details section
-        And verify the Parent Waiver Number ID is the approved intial waiver number 1
-        And verify there is an Initial Submission Date header in the details section
-        And verify a date exists for the Initial Submission Date
+#     Scenario: Verify user can create a temporary extension and that it is in the temporary extensions list
+#         Then click on New Submission
+#         And Click on Waiver Action
+#         And Click on Request Temporary Extension in Package dashboard
+#         And type approved Initial Waiver number into Existing Waiver Number to Renew field
+#         And Type Temporary Extension Number 1 With 5 Characters
+#         And upload Waiver Extension Request
+#         And type "This is just a test" in additional info textarea
+#         And Click on Submit Button
+#         And verify submission successful message in the alert bar
+#         And search for approved Initial Waiver Number 1
+#         And click the Waiver Number link in the first row
+#         And click on the Temporary Extension nav button
+#         And verify the temporary extension exists
+#         And click on the link for temporary extension number 1
+#         And verify the details section exists
+#         And verify there is a Type header in the details section
+#         And verify the type is 1915b Temporary Extension
+#         And verify there is a Parent Waiver Number header in the details section
+#         And verify the Parent Waiver Number ID is the approved intial waiver number 1
+#         And verify there is an Initial Submission Date header in the details section
+#         And verify a date exists for the Initial Submission Date
 
-    Scenario: Verify user can withdraw temporary extension from mini-dashboard page
-        Then click on New Submission
-        And Click on Waiver Action
-        And Click on Request Temporary Extension in Package dashboard
-        And type approved Initial Waiver number into Existing Waiver Number to Renew field
-        And Type Temporary Extension Number 2 With 5 Characters
-        And upload Waiver Extension Request
-        And type "This is just a test" in additional info textarea
-        And Click on Submit Button
-        And verify submission successful message in the alert bar
-        And search for approved Initial Waiver Number 1
-        And click the Waiver Number link in the first row
-        And click on the Temporary Extension nav button
-        And click the action button for temporary extension 2
-        And click withdraw button on the temp extension page
-        And click yes, withdraw package button
-        And verify success message for Withdrawal
+#     Scenario: Verify user can withdraw temporary extension from mini-dashboard page
+#         Then click on New Submission
+#         And Click on Waiver Action
+#         And Click on Request Temporary Extension in Package dashboard
+#         And type approved Initial Waiver number into Existing Waiver Number to Renew field
+#         And Type Temporary Extension Number 2 With 5 Characters
+#         And upload Waiver Extension Request
+#         And type "This is just a test" in additional info textarea
+#         And Click on Submit Button
+#         And verify submission successful message in the alert bar
+#         And search for approved Initial Waiver Number 1
+#         And click the Waiver Number link in the first row
+#         And click on the Temporary Extension nav button
+#         And click the action button for temporary extension 2
+#         And click withdraw button on the temp extension page
+#         And click yes, withdraw package button
+#         And verify success message for Withdrawal
 
-    Scenario: Verify user can create a temporary extension from the Temp. Extension Mini-Dashboard
-        And click on the Waivers tab
-        And search for approved Initial Waiver Number 1
-        And click the Waiver Number link in the first row
-        And click on the Temporary Extension nav button
-        And Click the Request Extension button
-        And verify the parent ID is prefilled in the form
-        And Type Temporary Extension Number 3 With 5 Characters
-        And upload Waiver Extension Request
-        And Type Additonal Info Comments in new form
-        And Click on Submit Button
-        And verify submission successful message in the alert bar
+#     Scenario: Verify user can create a temporary extension from the Temp. Extension Mini-Dashboard
+#         And click on the Waivers tab
+#         And search for approved Initial Waiver Number 1
+#         And click the Waiver Number link in the first row
+#         And click on the Temporary Extension nav button
+#         And Click the Request Extension button
+#         And verify the parent ID is prefilled in the form
+#         And Type Temporary Extension Number 3 With 5 Characters
+#         And upload Waiver Extension Request
+#         And Type Additonal Info Comments in new form
+#         And Click on Submit Button
+#         And verify submission successful message in the alert bar
 
-    Scenario: Verify user can create a temporary extension from the package details Mini-Dashboard
-        And click on the Waivers tab
-        And search for approved Initial Waiver Number 1
-        And click the Waiver Number link in the first row
-        And verify Request a Temporary Extension package action exists
-        And click Request a Temporary Extension package action
-        And verify the parent ID is prefilled in the form
-        And Type Temporary Extension Number 4
-        And upload Waiver Extension Request
-        And Type Additonal Info Comments in new form
-        And Click on Submit Button
-        And verify submission successful message in the alert bar
+#     Scenario: Verify user can create a temporary extension from the package details Mini-Dashboard
+#         And click on the Waivers tab
+#         And search for approved Initial Waiver Number 1
+#         And click the Waiver Number link in the first row
+#         And verify Request a Temporary Extension package action exists
+#         And click Request a Temporary Extension package action
+#         And verify the parent ID is prefilled in the form
+#         And Type Temporary Extension Number 4
+#         And upload Waiver Extension Request
+#         And Type Additonal Info Comments in new form
+#         And Click on Submit Button
+#         And verify submission successful message in the alert bar
 
-    Scenario: Verify user can create a temporary extension from the package dashboard waiver tab
-        And click on the Waivers tab
-        And search for approved Initial Waiver Number 1
-        And click the actions button in row one
-        And verify the Request Temporary Extension button is displayed
-        And click the Request Temporary Extension button
-        And verify the parent ID is prefilled in the form
-        And Type Temporary Extension Number 5
-        And upload Waiver Extension Request
-        And Type Additonal Info Comments in new form
-        And Click on Submit Button
-        And verify submission successful message in the alert bar
+#     Scenario: Verify user can create a temporary extension from the package dashboard waiver tab
+#         And click on the Waivers tab
+#         And search for approved Initial Waiver Number 1
+#         And click the actions button in row one
+#         And verify the Request Temporary Extension button is displayed
+#         And click the Request Temporary Extension button
+#         And verify the parent ID is prefilled in the form
+#         And Type Temporary Extension Number 5
+#         And upload Waiver Extension Request
+#         And Type Additonal Info Comments in new form
+#         And Click on Submit Button
+#         And verify submission successful message in the alert bar

--- a/tests/cypress/cypress/integration/Package_View_Temproray_Extension_oy2_20967.spec.js
+++ b/tests/cypress/cypress/integration/Package_View_Temproray_Extension_oy2_20967.spec.js
@@ -1,0 +1,32 @@
+describe("Waiver Mini-Dashboard: Temporary Extension", () => {
+  beforeEach(() => {
+    cy.visit("/");
+    cy.get("#devloginBtn").click();
+    cy.get("#email").type("statesubmitter@nightwatch.test");
+    cy.get("#password").type("Passw0rd!");
+    cy.get("#loginDevUserBtn").click();
+  });
+
+  it("Screen Enhancement", () => {
+    cy.get("#packageListLink").click();
+    cy.get("#new-submission-button").click();
+    cy.get(":nth-child(2) > a > :nth-child(1) > p").click();
+    cy.get(":nth-child(5) > a > :nth-child(1) > .choice-title").click();
+    cy.get("h1").should(
+      "have.text",
+      "Request 1915(b) or 1915(c) Temporary Extension"
+    );
+    cy.get("#temp-ext-type").select("1915(b)");
+    cy.get("#temp-ext-type").should("be.visible");
+    cy.get("#temp-ext-type").select("1915(c)");
+    cy.get("#temp-ext-type").should("be.visible");
+    cy.get(":nth-child(7) > :nth-child(1) > .required").should(
+      "have.text",
+      "Temporary Extension Request Number"
+    );
+    cy.get(".MuiTypography-root").should(
+      "have.text",
+      "What is my Temporary Extension Request Number?"
+    );
+  });
+});


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-20967
Endpoint: See github-actions bot comment

### Details

Update lables and add temporary extension type form field

### Changes

- Updated form title
- updated id label and faq label
- added temporary extension type field
- - added new property to OneMacFormConifg and OneMacFormData
- - created component to wrap implementation and added component to form
- - added to joi schema for submitWaiverExtension

### Test Plan

1. Login as state submitter
2. Navigate to package view and click New Submission button
3. Select Waiver Action -> Request Temporary Extension
4. Verify on form the title and labels match ACs
5. Verify the new field "Temporary Extenstion Type" has the appropriate options and is required
6. Verify the form will not submit without selecting a Temporary Extension Type
7. Verify form will submit after entering all required fields (including the Temporary Extension Type)
