### PR TITLE
OY2 20983: Package Details Page Timestamp - All Details Pages

### DIFF
--- a/services/ui-src/package-lock.json
+++ b/services/ui-src/package-lock.json
@@ -23,6 +23,7 @@
         "cmscommonlib": "file:../common",
         "core-js": "^3.7.0",
         "date-fns": "^2.16.1",
+        "date-fns-tz": "^1.3.7",
         "file-saver": "^2.0.5",
         "isomorphic-fetch": "^3.0.0",
         "jszip": "^3.6.0",
@@ -14947,6 +14948,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.7.tgz",
+      "integrity": "sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==",
+      "peerDependencies": {
+        "date-fns": ">=2.0.0"
       }
     },
     "node_modules/dayjs": {
@@ -44849,6 +44858,12 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
       "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
+    },
+    "date-fns-tz": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.7.tgz",
+      "integrity": "sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==",
+      "requires": {}
     },
     "dayjs": {
       "version": "1.11.5",

--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -18,7 +18,6 @@
     "cmscommonlib": "file:../common",
     "core-js": "^3.7.0",
     "date-fns": "^2.16.1",
-    "date-fns-tz": "^1.3.7",
     "file-saver": "^2.0.5",
     "isomorphic-fetch": "^3.0.0",
     "jszip": "^3.6.0",

--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -18,6 +18,7 @@
     "cmscommonlib": "file:../common",
     "core-js": "^3.7.0",
     "date-fns": "^2.16.1",
+    "date-fns-tz": "^1.3.7",
     "file-saver": "^2.0.5",
     "isomorphic-fetch": "^3.0.0",
     "jszip": "^3.6.0",

--- a/services/ui-src/src/page/DetailView.tsx
+++ b/services/ui-src/src/page/DetailView.tsx
@@ -15,7 +15,7 @@ import {
 import { LocationState } from "../domain-types";
 import LoadingScreen from "../components/LoadingScreen";
 import PackageApi from "../utils/PackageApi";
-import { formatDetailViewDate } from "../utils/date-utils";
+import { showAsCmsTimestamp } from "../utils/date-utils";
 import PageTitleBar from "../components/PageTitleBar";
 import AlertBar from "../components/AlertBar";
 import { getTerritoryFromTransmittalNumber } from "../changeRequest/SubmissionForm";
@@ -100,7 +100,7 @@ const DetailView: React.FC<{ pageConfig: OneMACDetail }> = ({ pageConfig }) => {
             AUTHORITY_LABELS[fetchedDetail.waiverAuthority];
         }
         if (fetchedDetail.submissionTimestamp) {
-          fetchedDetail.submissionDateNice = formatDetailViewDate(
+          fetchedDetail.submissionDateNice = showAsCmsTimestamp(
             fetchedDetail.submissionTimestamp
           );
         }

--- a/services/ui-src/src/page/DetailView.tsx
+++ b/services/ui-src/src/page/DetailView.tsx
@@ -15,7 +15,7 @@ import {
 import { LocationState } from "../domain-types";
 import LoadingScreen from "../components/LoadingScreen";
 import PackageApi from "../utils/PackageApi";
-import { showAsCmsTimestamp } from "../utils/date-utils";
+import { formatDate } from "../utils/date-utils";
 import PageTitleBar from "../components/PageTitleBar";
 import AlertBar from "../components/AlertBar";
 import { getTerritoryFromTransmittalNumber } from "../changeRequest/SubmissionForm";
@@ -100,7 +100,7 @@ const DetailView: React.FC<{ pageConfig: OneMACDetail }> = ({ pageConfig }) => {
             AUTHORITY_LABELS[fetchedDetail.waiverAuthority];
         }
         if (fetchedDetail.submissionTimestamp) {
-          fetchedDetail.submissionDateNice = showAsCmsTimestamp(
+          fetchedDetail.submissionDateNice = formatDate(
             fetchedDetail.submissionTimestamp
           );
         }

--- a/services/ui-src/src/page/section/DetailSection.tsx
+++ b/services/ui-src/src/page/section/DetailSection.tsx
@@ -2,7 +2,7 @@ import { Accordion, AccordionItem, Review } from "@cmsgov/design-system";
 import { Workflow, getUserRoleObj } from "cmscommonlib";
 import React, { useCallback } from "react";
 import { useAppContext } from "../../libs/contextLib";
-import { formatDateOnly, formatDetailViewDate } from "../../utils/date-utils";
+import { formatDateOnly, formatDate } from "../../utils/date-utils";
 import { ComponentDetail } from "../DetailView";
 import { OneMACDetail } from "../../libs/detailLib";
 import FileList from "../../components/FileList";
@@ -129,7 +129,7 @@ export const DetailSection = ({
                     contentClassName="accordion-content"
                     heading={
                       "Submitted on " +
-                      formatDetailViewDate(raiResponse.submissionTimestamp)
+                      formatDate(raiResponse.submissionTimestamp)
                     }
                     headingLevel="6"
                     id={raiResponse.componentType + index + "_caret"}

--- a/services/ui-src/src/page/section/DetailSection.tsx
+++ b/services/ui-src/src/page/section/DetailSection.tsx
@@ -2,7 +2,7 @@ import { Accordion, AccordionItem, Review } from "@cmsgov/design-system";
 import { Workflow, getUserRoleObj } from "cmscommonlib";
 import React, { useCallback } from "react";
 import { useAppContext } from "../../libs/contextLib";
-import { formatDetailViewDate } from "../../utils/date-utils";
+import { formatDateOnly, formatDetailViewDate } from "../../utils/date-utils";
 import { ComponentDetail } from "../DetailView";
 import { OneMACDetail } from "../../libs/detailLib";
 import FileList from "../../components/FileList";
@@ -58,13 +58,13 @@ export const DetailSection = ({
             {pageConfig.show90thDayInfo && ninetyDayText !== "N/A" && (
               <Review heading="90th Day">
                 {Number(ninetyDayText)
-                  ? formatDetailViewDate(new Date(ninetyDayText))
+                  ? formatDateOnly(new Date(ninetyDayText))
                   : ninetyDayText ?? "N/A"}
               </Review>
             )}
             {pageConfig.showEffectiveDate && detail.effectiveDateTimestamp && (
               <Review heading="Effective Date">
-                {formatDetailViewDate(detail.effectiveDateTimestamp)}
+                {formatDateOnly(detail.effectiveDateTimestamp)}
               </Review>
             )}
           </section>

--- a/services/ui-src/src/utils/date-utils.js
+++ b/services/ui-src/src/utils/date-utils.js
@@ -8,6 +8,10 @@ import { format, parseISO } from "date-fns";
 export function formatDate(date) {
   let dateString = "";
 
+  if (typeof date === "string") {
+    date = parseISO(date);
+  }
+
   if (date) {
     dateString = format(date, "EEE, MMM d yyyy, h:mm:ss a");
   }
@@ -26,7 +30,7 @@ export function formatDetailViewDate(date) {
     if (typeof date === "string") {
       date = parseISO(date);
     }
-    dateString = format(date, "MMM d yyyy");
+    dateString = format(date, "EEE, MMM d yyyy, h:mm:ss a");
   }
   return dateString;
 }
@@ -38,6 +42,9 @@ export function formatDetailViewDate(date) {
  */
 export function formatDateOnly(date) {
   let dateString = "";
+  if (typeof date === "string") {
+    date = parseISO(date);
+  }
 
   if (date) {
     dateString = format(date, "EEE, MMM d yyyy");

--- a/services/ui-src/src/utils/date-utils.js
+++ b/services/ui-src/src/utils/date-utils.js
@@ -1,4 +1,4 @@
-import { format, parseISO, utcToZonedTime } from "date-fns-tz";
+import { format, parseISO } from "date-fns-tz";
 
 /**
  * Format a date to a string.

--- a/services/ui-src/src/utils/date-utils.js
+++ b/services/ui-src/src/utils/date-utils.js
@@ -1,4 +1,4 @@
-import { format, parseISO } from "date-fns-tz";
+import { format, parseISO } from "date-fns";
 
 /**
  * Format a date to a string.
@@ -19,23 +19,6 @@ export function formatDate(date) {
 }
 
 /**
- * Format a date to a string per the Figma for the Details View
- * @param {Date} date
- * @returns a string with the date
- */
-export function formatDetailViewDate(date) {
-  let dateString = "";
-
-  if (date) {
-    if (typeof date === "string") {
-      date = parseISO(date);
-    }
-    dateString = format(date, "EEE, MMM d yyyy, h:mm:ss a");
-  }
-  return dateString;
-}
-
-/**
  * Format a date to a string.
  * @param {Date} date
  * @returns a string with the date without time
@@ -50,12 +33,4 @@ export function formatDateOnly(date) {
     dateString = format(date, "EEE, MMM d yyyy");
   }
   return dateString;
-}
-
-export function showAsCmsTimestamp(date) {
-  return (
-    format(date, "EEE, MMM d yyyy, h:mm:ss a", {
-      timeZone: "America/New York",
-    }) + " EST"
-  );
 }

--- a/services/ui-src/src/utils/date-utils.js
+++ b/services/ui-src/src/utils/date-utils.js
@@ -1,4 +1,4 @@
-import { format, parseISO } from "date-fns";
+import { format, parseISO, utcToZonedTime } from "date-fns-tz";
 
 /**
  * Format a date to a string.
@@ -50,4 +50,12 @@ export function formatDateOnly(date) {
     dateString = format(date, "EEE, MMM d yyyy");
   }
   return dateString;
+}
+
+export function showAsCmsTimestamp(date) {
+  return (
+    format(date, "EEE, MMM d yyyy, h:mm:ss a", {
+      timeZone: "America/New York",
+    }) + " EST"
+  );
 }

--- a/services/ui-src/src/utils/date-utils.test.js
+++ b/services/ui-src/src/utils/date-utils.test.js
@@ -4,6 +4,12 @@ it("formats correctly", () => {
   const response = formatDate(1638462874431);
   expect(response).toMatch(/Thu, Dec 2 2021, \d{1,2}:34:34 [AP]M/);
 
+  const responseISO = formatDate("20211202T013434");
+  expect(responseISO).toMatch(/Thu, Dec 2 2021, \d{1,2}:34:34 [AP]M/);
+
   const response2 = formatDateOnly(1638462874431);
   expect(response2).toBe("Thu, Dec 2 2021");
+
+  const responseISO2 = formatDateOnly("20211202");
+  expect(responseISO2).toBe("Thu, Dec 2 2021");
 });


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-20983
Endpoint: See github-actions bot comment

### Details
Date Submitted on the packages needs to have the time as well as the date shown.

### Changes
- Updated Initial Submission Date format to include the time
- updated the RAI header to also include the time, since it is a Submission Date
- left the "date picker" dates without times, since we don't have those

### Test Plan
1. Log in as a submitting user
2. Navigate to Package Dashboard
3. Find a package of each type, verify that the package details page uses the correct date/time format
