### PR TITLE
OY2-21003 - change withdraw to withdraw package

### DIFF
--- a/services/common/index.d.ts
+++ b/services/common/index.d.ts
@@ -102,7 +102,7 @@ export namespace ChangeRequest {
 
   export enum PACKAGE_ACTION {
     RESPOND_TO_RAI = "Respond to RAI",
-    WITHDRAW = "Withdraw",
+    WITHDRAW = "Withdraw Package",
     REQUEST_TEMPORARY_EXTENSION = "Request a Temporary Extension",
     ADD_AMENDMENT = "Add Amendment",
   }
@@ -128,7 +128,7 @@ export namespace ChangeRequest {
 export namespace Workflow {
   export enum PACKAGE_ACTION {
     RESPOND_TO_RAI = "Respond to RAI",
-    WITHDRAW = "Withdraw",
+    WITHDRAW = "Withdraw Package",
     REQUEST_TEMPORARY_EXTENSION = "Request a Temporary Extension",
     ADD_AMENDMENT = "Add Amendment",
   }

--- a/services/common/workflow.js
+++ b/services/common/workflow.js
@@ -39,7 +39,7 @@ export const ONEMAC_STATUS = {
 
 export const PACKAGE_ACTION = {
   RESPOND_TO_RAI: "Respond to RAI",
-  WITHDRAW: "Withdraw",
+  WITHDRAW: "Withdraw Package",
   REQUEST_TEMPORARY_EXTENSION: "Request a Temporary Extension",
   ADD_AMENDMENT: "Add Amendment",
 };

--- a/services/ui-src/src/components/PopupMenu.js
+++ b/services/ui-src/src/components/PopupMenu.js
@@ -28,8 +28,8 @@ const VARIATION_PROPS = {
     width: "wide",
   },
   PackageList: {
-    acceptText: "Yes, withdraw",
-    dialogTitle: "Withdraw?",
+    acceptText: "Yes, withdraw package",
+    dialogTitle: "Withdraw Package?",
   },
 };
 

--- a/services/ui-src/src/page/action/Withdraw.js
+++ b/services/ui-src/src/page/action/Withdraw.js
@@ -30,8 +30,8 @@ export default function Withdraw({ theComponent, alertCallback }) {
       onClick={() => {
         confirmAction &&
           confirmAction(
-            "Withdraw?",
-            "Yes, withdraw",
+            "Withdraw Package?",
+            "Yes, withdraw package",
             "Cancel",
             `You are about to withdraw ${theComponent.componentId}. Once complete, you will not be able to resubmit this package. CMS will be notified.`,
             onPopupActionWithdraw
@@ -39,7 +39,7 @@ export default function Withdraw({ theComponent, alertCallback }) {
       }}
       id={"withdraw-action-" + theComponent.componentId}
     >
-      Withdraw
+      Withdraw Package
     </Link>
   );
 }

--- a/services/ui-src/src/page/action/Withdraw.test.js
+++ b/services/ui-src/src/page/action/Withdraw.test.js
@@ -31,5 +31,7 @@ it("renders", async () => {
       </Router>
     </AppContext.Provider>
   );
-  expect(screen.getByRole("link", { name: "Withdraw" })).toBeInTheDocument();
+  expect(
+    screen.getByRole("link", { name: "Withdraw Package" })
+  ).toBeInTheDocument();
 });

--- a/services/ui-src/src/page/chip-spa/CHIPSPADetail.test.js
+++ b/services/ui-src/src/page/chip-spa/CHIPSPADetail.test.js
@@ -154,7 +154,7 @@ describe("Detail View Tests", () => {
     // wait for loading screen to disappear so package table displays
     await waitForElementToBeRemoved(() => screen.getByTestId(LOADER_TEST_ID));
 
-    fireEvent.click(screen.getByText("Withdraw"));
+    fireEvent.click(screen.getByText("Withdraw Package"));
   });
 
   it("allows respond to RAI action", async () => {

--- a/services/ui-src/src/page/initial-waiver/InitialWaiverDetail.test.js
+++ b/services/ui-src/src/page/initial-waiver/InitialWaiverDetail.test.js
@@ -116,9 +116,11 @@ describe("Detail View Tests", () => {
           name: "Actions for MD.83420.R00.TE01",
         })
       );
-      await userEvent.click(screen.getByRole("menuitem", { name: "Withdraw" }));
       await userEvent.click(
-        screen.getByRole("button", { name: "Yes, withdraw" })
+        screen.getByRole("menuitem", { name: "Withdraw Package" })
+      );
+      await userEvent.click(
+        screen.getByRole("button", { name: "Yes, withdraw package" })
       );
     });
 

--- a/services/ui-src/src/page/medicaid-spa/MedicaidSPADetail.test.js
+++ b/services/ui-src/src/page/medicaid-spa/MedicaidSPADetail.test.js
@@ -154,7 +154,7 @@ describe("Detail View Tests", () => {
     // wait for loading screen to disappear so package table displays
     await waitForElementToBeRemoved(() => screen.getByTestId(LOADER_TEST_ID));
 
-    fireEvent.click(screen.getByText("Withdraw"));
+    fireEvent.click(screen.getByText("Withdraw Package"));
   });
 
   it("allows respond to RAI action", async () => {


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-21003
Endpoint: See github-actions bot comment

### Details

Update actions from "Withdraw" to "Withdraw Package" and also update confirmation dialog with the same.

### Changes

- Updated Withdraw component to show desired language
- Also updated popup component since TE still uses that from the mini dash (couldnt consolidate easily)
- Updated tests to reflect language changes

### Implementation Notes

- I tried to make TE use the same ActionPopup component that Package list uses however it messed too much with the tests since I dont believe we still found a way to hit buttons in the popup since it is outside the context of the test. Furthermore it is my understanding the mini dash will be going away in favor of moving all items to top level items on the package list. So its a moot point anyway and we can retire the older popup component at that time.

### Test Plan

1. Login as statesubmitter
2. navigate to package dashboard and verify actions for types: Initial Waiver, Renewal, Amendment, and Temporary Extensions that are in a withdrawable status (such as submitted or in review) have the action listed as "Withdraw Package"
3. navigate to the details page and verify the action is also "Withdraw Package"
4. click the withdraw package link on the details page (could also be from the kebab on the package list) and verify the popup is named Withdraw Package.
