### PR TITLE
OY2 20217: Consolidate a list of all messages and correlating forms for Submission and Package View

### DIFF
--- a/services/common/index.d.ts
+++ b/services/common/index.d.ts
@@ -32,6 +32,7 @@ export class UserRole {
   canAccessMetrics: boolean;
   canAccessUserManagement: boolean;
   canDownloadCsv: boolean;
+  canAccessAdminTools: boolean;
 }
 
 export type RoleEntry = {

--- a/services/common/index.js
+++ b/services/common/index.js
@@ -149,6 +149,7 @@ export class Role {
     this.canAccessUserManagement = false;
     this.canAccessMetrics = false;
     this.canManageUsers = false;
+    this.canAccessAdminTools = false;
   }
 
   getAccesses() {
@@ -237,6 +238,7 @@ class SystemAdmin extends Role {
     this.canAccessUserManagement = true;
     this.canAccessMetrics = true;
     this.canManageUsers = true;
+    this.canAccessAdminTools = true;
   }
 }
 

--- a/services/common/routes.js
+++ b/services/common/routes.js
@@ -64,6 +64,7 @@ export const ONEMAC_ROUTES = {
   APPENDIX_K_AMENDMENT: "/appendix-k-amendment",
   TEMPORARY_EXTENSION: "/temporary-extension",
   TEMPORARY_EXTENSION_DETAIL: "/detail/temporary-extension",
+  FORMS_DESCRIBE: "/forms-describe",
 };
 
 export const TYPE_TO_DETAIL_ROUTE = {

--- a/services/common/type/chipSPA.js
+++ b/services/common/type/chipSPA.js
@@ -6,12 +6,6 @@ export const chipSPA = {
   idRegex:
     "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{1,4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
   idMustExist: false,
-  idExistValidations: [
-    {
-      idMustExist: false,
-      errorLevel: "error",
-    },
-  ],
   allowMultiplesWithSameId: false,
   requiredAttachments: [
     "Current State Plan",

--- a/services/common/type/chipSPA.js
+++ b/services/common/type/chipSPA.js
@@ -5,6 +5,7 @@ export const chipSPA = {
   idLabel: "SPA ID",
   idRegex:
     "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{1,4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
+  idMustExist: false,
   idExistValidations: [
     {
       idMustExist: false,

--- a/services/common/type/chipSPARAIResponse.js
+++ b/services/common/type/chipSPARAIResponse.js
@@ -4,6 +4,7 @@ export const chipSPARAIResponse = {
   idLabel: "SPA ID",
   idRegex:
     "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{1,4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
+  idMustExist: true,
   idExistValidations: [
     {
       idMustExist: true,

--- a/services/common/type/chipSPARAIResponse.js
+++ b/services/common/type/chipSPARAIResponse.js
@@ -5,12 +5,6 @@ export const chipSPARAIResponse = {
   idRegex:
     "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{1,4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
   idMustExist: true,
-  idExistValidations: [
-    {
-      idMustExist: true,
-      errorLevel: "error",
-    },
-  ],
   allowMultiplesWithSameId: true,
   requiredAttachments: [
     "Revised Amended State Plan Language",

--- a/services/common/type/initialWaiver.js
+++ b/services/common/type/initialWaiver.js
@@ -5,12 +5,6 @@ export const initialWaiver = {
   idLabel: "Initial Waiver Number",
   idRegex: "^[A-Z]{2}[-][0-9]{4,5}[.]R00[.]00$",
   idMustExist: false,
-  idExistValidations: [
-    {
-      idMustExist: false,
-      errorLevel: "error",
-    },
-  ],
   allowMultiplesWithSameId: false,
   allowWaiverExtension: true,
   requiredAttachments: [],

--- a/services/common/type/initialWaiver.js
+++ b/services/common/type/initialWaiver.js
@@ -4,6 +4,7 @@ export const initialWaiver = {
   typeLabel: "1915(b) Initial Waiver",
   idLabel: "Initial Waiver Number",
   idRegex: "^[A-Z]{2}[-][0-9]{4,5}[.]R00[.]00$",
+  idMustExist: false,
   idExistValidations: [
     {
       idMustExist: false,

--- a/services/common/type/medicaidSPA.js
+++ b/services/common/type/medicaidSPA.js
@@ -5,6 +5,7 @@ export const medicaidSPA = {
   idLabel: "SPA ID",
   idRegex:
     "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{1,4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
+  idMustExist: false,
   idExistValidations: [
     {
       idMustExist: false,

--- a/services/common/type/medicaidSPA.js
+++ b/services/common/type/medicaidSPA.js
@@ -6,12 +6,6 @@ export const medicaidSPA = {
   idRegex:
     "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{1,4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
   idMustExist: false,
-  idExistValidations: [
-    {
-      idMustExist: false,
-      errorLevel: "error",
-    },
-  ],
   allowMultiplesWithSameId: false,
   requiredAttachments: [
     { title: "CMS Form 179", allowMultiple: false },

--- a/services/common/type/medicaidSPARAIResponse.js
+++ b/services/common/type/medicaidSPARAIResponse.js
@@ -4,6 +4,7 @@ export const medicaidSPARAIResponse = {
   idLabel: "SPA ID",
   idRegex:
     "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{1,4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
+  idMustExist: true,
   idExistValidations: [
     {
       idMustExist: true,

--- a/services/common/type/medicaidSPARAIResponse.js
+++ b/services/common/type/medicaidSPARAIResponse.js
@@ -5,12 +5,6 @@ export const medicaidSPARAIResponse = {
   idRegex:
     "(^[A-Z]{2}-[0-9]{2}-[0-9]{4}-[a-zA-Z0-9]{1,4}$)|(^[A-Z]{2}-[0-9]{2}-[0-9]{4}$)",
   idMustExist: true,
-  idExistValidations: [
-    {
-      idMustExist: true,
-      errorLevel: "error",
-    },
-  ],
   allowMultiplesWithSameId: true, // Medicaid SPA RAI can only have one but until business decides how to handle we will allow multiple
   requiredAttachments: ["RAI Response"],
   optionalAttachments: ["Other"],

--- a/services/common/type/waiverAmendment.js
+++ b/services/common/type/waiverAmendment.js
@@ -4,13 +4,6 @@ export const waiverAmendment = {
   idLabel: "1915(b) Waiver Amendment Number",
   idRegex: "^[A-Z]{2}[-][0-9]{4,5}.R[0-9]{2}.(0[1-9]|[1-9][0-9])$",
   idMustExist: false,
-  idExistValidations: [
-    // DON'T want the entire Waiver amendment number to exist
-    {
-      idMustExist: false,
-      errorLevel: "error",
-    },
-  ],
   allowMultiplesWithSameId: false,
   requiredAttachments: [],
   optionalAttachments: [

--- a/services/common/type/waiverAmendment.js
+++ b/services/common/type/waiverAmendment.js
@@ -3,6 +3,7 @@ export const waiverAmendment = {
   typeLabel: "1915(b) Waiver Amendment",
   idLabel: "1915(b) Waiver Amendment Number",
   idRegex: "^[A-Z]{2}[-][0-9]{4,5}.R[0-9]{2}.(0[1-9]|[1-9][0-9])$",
+  idMustExist: false,
   idExistValidations: [
     // DON'T want the entire Waiver amendment number to exist
     {

--- a/services/common/type/waiverAppendixK.js
+++ b/services/common/type/waiverAppendixK.js
@@ -5,12 +5,6 @@ export const waiverAppendixK = {
   idLabel: "Waiver Amendment Number",
   idRegex: "^[A-Z]{2}[-][0-9]{4,5}.R[0-9]{2}.(0[1-9]|[1-9][0-9])$",
   idMustExist: false,
-  idExistValidations: [
-    {
-      idMustExist: false,
-      errorLevel: "error",
-    },
-  ],
   waiverAuthorities: [{ label: "1915(c) HCBS", value: "1915(c)" }],
   allowMultiplesWithSameId: false,
   requiredAttachments: ["1915(c) Appendix K Amendment Waiver Template"],

--- a/services/common/type/waiverAppendixK.js
+++ b/services/common/type/waiverAppendixK.js
@@ -4,6 +4,7 @@ export const waiverAppendixK = {
   typeLabel: "1915(c) Appendix K Amendment",
   idLabel: "Waiver Amendment Number",
   idRegex: "^[A-Z]{2}[-][0-9]{4,5}.R[0-9]{2}.(0[1-9]|[1-9][0-9])$",
+  idMustExist: false,
   idExistValidations: [
     {
       idMustExist: false,

--- a/services/common/type/waiverAppendixKRAIResponse.js
+++ b/services/common/type/waiverAppendixKRAIResponse.js
@@ -4,12 +4,6 @@ export const waiverAppendixKRAIResponse = {
   idLabel: "Waiver Amendment Number",
   idRegex: "^[A-Z]{2}[-][0-9]{4,5}.R[0-9]{2}.(0[1-9]|[1-9][0-9])$",
   idMustExist: true,
-  idExistValidations: [
-    {
-      idMustExist: true,
-      errorLevel: "error",
-    },
-  ],
   allowMultiplesWithSameId: true,
   requiredAttachments: ["1915(c) Appendix K RAI Response"],
   optionalAttachments: ["Other"],

--- a/services/common/type/waiverAppendixKRAIResponse.js
+++ b/services/common/type/waiverAppendixKRAIResponse.js
@@ -3,6 +3,7 @@ export const waiverAppendixKRAIResponse = {
   typeLabel: "1915(c) Appendix K RAI Response",
   idLabel: "Waiver Amendment Number",
   idRegex: "^[A-Z]{2}[-][0-9]{4,5}.R[0-9]{2}.(0[1-9]|[1-9][0-9])$",
+  idMustExist: true,
   idExistValidations: [
     {
       idMustExist: true,

--- a/services/common/type/waiverRAIResponse.js
+++ b/services/common/type/waiverRAIResponse.js
@@ -5,12 +5,6 @@ export const waiverRAIResponse = {
   idRegex:
     "(^[A-Z]{2}[.-][0-9]{4,5}$)|(^[A-Z]{2}[.-][0-9]{4,5}[.]R[0-9]{2}$)|(^[A-Z]{2}[.-][0-9]{4,5}[.]R[0-9]{2}[.]M?[0-9]{2}$)",
   idMustExist: true,
-  idExistValidations: [
-    {
-      idMustExist: true,
-      errorLevel: "error",
-    },
-  ],
   allowMultiplesWithSameId: true,
   requiredAttachments: ["Waiver RAI Response"],
   optionalAttachments: ["Other"],

--- a/services/common/type/waiverRAIResponse.js
+++ b/services/common/type/waiverRAIResponse.js
@@ -4,6 +4,7 @@ export const waiverRAIResponse = {
   idLabel: "Waiver Number",
   idRegex:
     "(^[A-Z]{2}[.-][0-9]{4,5}$)|(^[A-Z]{2}[.-][0-9]{4,5}[.]R[0-9]{2}$)|(^[A-Z]{2}[.-][0-9]{4,5}[.]R[0-9]{2}[.]M?[0-9]{2}$)",
+  idMustExist: true,
   idExistValidations: [
     {
       idMustExist: true,

--- a/services/common/type/waiverRenewal.js
+++ b/services/common/type/waiverRenewal.js
@@ -5,12 +5,6 @@ export const waiverRenewal = {
   idLabel: "1915(b) Waiver Renewal Number",
   idRegex: "^[A-Z]{2}[.-][0-9]{4,5}.R(0[1-9]|[1-9][0-9]).00$",
   idMustExist: false,
-  idExistValidations: [
-    {
-      idMustExist: false,
-      errorLevel: "error",
-    },
-  ],
   allowMultiplesWithSameId: false,
   requiredAttachments: [],
   optionalAttachments: [
@@ -28,7 +22,6 @@ export const waiverRenewal = {
     },
     { label: "All other 1915(b) Waivers", value: "1915(b)" },
   ],
-  parentMustExist: true,
   allowedParentTypes: ["waivernew", "waiverrenewal"],
   allowedParentStatuses: ["Approved"],
 };

--- a/services/common/type/waiverRenewal.js
+++ b/services/common/type/waiverRenewal.js
@@ -4,6 +4,7 @@ export const waiverRenewal = {
   typeLabel: "1915(b) Waiver Renewal",
   idLabel: "1915(b) Waiver Renewal Number",
   idRegex: "^[A-Z]{2}[.-][0-9]{4,5}.R(0[1-9]|[1-9][0-9]).00$",
+  idMustExist: false,
   idExistValidations: [
     {
       idMustExist: false,

--- a/services/common/type/waiverTemporaryExtension.js
+++ b/services/common/type/waiverTemporaryExtension.js
@@ -4,13 +4,6 @@ export const waiverTemporaryExtension = {
   idLabel: "Temporary Extension Request Number",
   idRegex: "^[A-Z]{2}[-][0-9]{4,5}[.]R[0-9]{2}[.]TE[0-9]{2}$",
   idMustExist: false,
-  idMustExistErrorLevel: "error",
-  idExistValidations: [
-    {
-      idMustExist: false,
-      errorLevel: "error",
-    },
-  ],
   allowMultiplesWithSameId: false,
   requiredAttachments: ["Waiver Extension Request"],
   optionalAttachments: ["Other"],

--- a/services/common/type/waiverTemporaryExtension.js
+++ b/services/common/type/waiverTemporaryExtension.js
@@ -3,6 +3,8 @@ export const waiverTemporaryExtension = {
   typeLabel: "Waiver Extension",
   idLabel: "Temporary Extension Number",
   idRegex: "^[A-Z]{2}[-][0-9]{4,5}[.]R[0-9]{2}[.]TE[0-9]{2}$",
+  idMustExist: false,
+  idMustExistErrorLevel: "error",
   idExistValidations: [
     {
       idMustExist: false,

--- a/services/ui-src/src/Routes.tsx
+++ b/services/ui-src/src/Routes.tsx
@@ -52,6 +52,7 @@ import WaiverRAIForm from "./page/waiver-rai/WaiverRAIForm";
 import WaiverAmendmentForm from "./page/waiver-amendment/WaiverAmendmentForm";
 import WaiverAppendixKForm from "./page/waiver-appendix-k/WaiverAppendixKForm";
 import WaiverAppendixKRAIForm from "./page/waiver-appendix-k/WaiverAppendixKRAIForm";
+import DescribeForms from "./page/DescribeForms";
 
 // this is legacy and should not be touched!
 const FORM_TYPES = {
@@ -229,6 +230,10 @@ const ROUTE_LIST: RouteSpec[] = [
     {
       path: ONEMAC_ROUTES.TEMPORARY_EXTENSION,
       component: TemporaryExtensionForm,
+    },
+    {
+      path: "/forms-describe",
+      component: DescribeForms,
     },
   ].map(({ path, ...rest }) => ({
     path,

--- a/services/ui-src/src/Routes.tsx
+++ b/services/ui-src/src/Routes.tsx
@@ -231,10 +231,6 @@ const ROUTE_LIST: RouteSpec[] = [
       path: ONEMAC_ROUTES.TEMPORARY_EXTENSION,
       component: TemporaryExtensionForm,
     },
-    {
-      path: "/forms-describe",
-      component: DescribeForms,
-    },
   ].map(({ path, ...rest }) => ({
     path,
     component: AuthenticatedRouteListRenderer,
@@ -368,6 +364,17 @@ const ROUTE_LIST: RouteSpec[] = [
     path: ROUTES.ATTACHMENT_LANDING,
     exact: true,
     component: AttachmentLanding,
+  },
+  {
+    path: ONEMAC_ROUTES.FORMS_DESCRIBE,
+    component: accessGuardRouteListRenderer("canAccessAdminTools"),
+    routes: [
+      {
+        path: ONEMAC_ROUTES.FORMS_DESCRIBE,
+        exact: true,
+        component: DescribeForms,
+      },
+    ],
   },
 ];
 

--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -2676,3 +2676,18 @@ aside#faq-contact-info-box {
 .ds-u-color--warn {
   @extend .ds-u-color--primary;
 }
+
+.form-describe {
+  th {
+    background-color: $color-gray-lightest;
+    text-align: center;
+    border: solid 1px;
+    margin: 2px;
+    padding: 2px;
+  }
+  td {
+    border: solid 1px;
+    margin: 2px;
+    padding: 2px;
+  }
+}

--- a/services/ui-src/src/libs/formLib.tsx
+++ b/services/ui-src/src/libs/formLib.tsx
@@ -1,6 +1,5 @@
 import {
   FieldHint,
-  IdValidation,
   SelectOption,
   FileUploadProps,
   ONEMAC_ROUTES,

--- a/services/ui-src/src/libs/formLib.tsx
+++ b/services/ui-src/src/libs/formLib.tsx
@@ -45,6 +45,8 @@ export type PackageType = {
   typeLabel: string;
   idLabel: string;
   idRegex: string;
+  idMustExist: boolean;
+  idMustExistErrorLevel?: string;
   idExistValidations: IdValidation[];
   allowMultiplesWithSameId: boolean;
   requiredAttachments: (string | FileUploadProps)[];

--- a/services/ui-src/src/libs/formLib.tsx
+++ b/services/ui-src/src/libs/formLib.tsx
@@ -51,8 +51,6 @@ export type PackageType = {
   idLabel: string;
   idRegex: string;
   idMustExist: boolean;
-  idMustExistErrorLevel?: string;
-  idExistValidations: IdValidation[];
   allowMultiplesWithSameId: boolean;
   requiredAttachments: (string | FileUploadProps)[];
   optionalAttachments: (string | FileUploadProps)[];

--- a/services/ui-src/src/libs/formLib.tsx
+++ b/services/ui-src/src/libs/formLib.tsx
@@ -73,3 +73,21 @@ export type OneMacFormData = {
   parentId?: string;
   parentType?: string;
 };
+
+export const stateAccessMessage: Message = {
+  statusLevel: "error",
+  statusMessage: `You can only submit for a state you have access to. If you need to add another state, visit your user profile to request access.`,
+};
+export const buildWrongFormatMessage = (formConfig: OneMACFormConfig) => ({
+  statusLevel: "error",
+  statusMessage: `The ${formConfig.idLabel} must be in the format of ${formConfig.idFormat}`,
+});
+
+export const buildMustExistMessage = (formConfig: OneMACFormConfig) => ({
+  statusLevel: "error",
+  statusMessage: `According to our records, this ${formConfig.idLabel} does not exist. Please check the ${formConfig.idLabel} and try entering it again.`,
+});
+export const buildMustNotExistMessage = (formConfig: OneMACFormConfig) => ({
+  statusLevel: "error",
+  statusMessage: `According to our records, this ${formConfig.idLabel} already exists. Please check the ${formConfig.idLabel} and try entering it again.`,
+});

--- a/services/ui-src/src/page/DescribeForms.tsx
+++ b/services/ui-src/src/page/DescribeForms.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Review } from "@cmsgov/design-system";
 
+import { approvedBlueWarningMessage } from "cmscommonlib";
 import {
   OneMACFormConfig,
   stateAccessMessage,
@@ -88,7 +89,7 @@ const DescribeField: React.FC<{
       <table className="form-describe">
         <thead>
           <tr>
-            <th>Form</th>
+            <th>Package Form</th>
             <th>{fieldLabel} Value</th>
           </tr>
         </thead>
@@ -108,7 +109,7 @@ const DescribeField: React.FC<{
                 displayValue = JSON.stringify(oneConfig[fieldName]);
               return (
                 <tr key={index}>
-                  <td>{oneConfig.typeLabel}</td>
+                  <td>{oneConfig.pageTitle}</td>
                   <td>{displayValue}</td>
                 </tr>
               );
@@ -126,23 +127,22 @@ const DescribeField: React.FC<{
 const DescribeForms: React.FC = () => {
   return (
     <>
-      <PageTitleBar heading={"Describe Package View Forms"} enableBackNav />
+      <PageTitleBar heading={"Describe Forms"} enableBackNav />
       <div className="onemac-form">
-        {/* <section className="detail-section">
-          <h3>Medicaid SPA Form</h3>
-          <h4>ID Label: {medicaidSpaFormInfo.idLabel}</h4>
-          <p></p>
-        </section>
-        <hr/> */}
+        <h2>Package View</h2>
+        <p>
+          NOTE: These are generated from application, so reflect the true
+          values.
+        </p>
         <section className="detail-section">
-          <DescribeField fieldLabel="Page Title" fieldName="pageTitle" />
+          {/* <DescribeField fieldLabel="Page Title" fieldName="pageTitle" />
           <DescribeField
             fieldLabel="Form Title"
             fieldName="detailsHeader"
             appendText=" Details"
           />
           <DescribeField fieldLabel="ID Label" fieldName="idLabel" />
-          <DescribeField fieldLabel="ID Format Text" fieldName="idFormat" />
+          <DescribeField fieldLabel="ID Format Text" fieldName="idFormat" /> */}
           <DescribeField
             fieldLabel="ID Gray Text"
             fieldName="idFieldHint"
@@ -154,7 +154,7 @@ const DescribeForms: React.FC = () => {
             fieldName="idExistValidations"
             customFunc={describeErrors}
           />
-          <DescribeField fieldLabel="FAQ Link" fieldName="idFAQLink" />
+          {/* <DescribeField fieldLabel="FAQ Link" fieldName="idFAQLink" />
           <DescribeField
             fieldLabel="Form contains Proposed Effective Date field"
             fieldName="proposedEffectiveDate"
@@ -162,7 +162,351 @@ const DescribeForms: React.FC = () => {
           <DescribeField
             fieldLabel="Form Requires Confirmation"
             fieldName="confirmSubmit"
-          />
+          /> */}
+        </section>
+        <h2>Submission View</h2>
+        <p>
+          NOTE: These are hand-entered and therefore may be out of date with the
+          application.
+        </p>
+        <section className="detail-section">
+          <Review heading="ID Gray Text Values">
+            <table className="form-describe">
+              <thead>
+                <tr>
+                  <th>Submission Form</th>
+                  <th>ID Gray Text Values</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Submit New Medicaid SPA</td>
+                  <td>
+                    Must follow the format SS-YY-NNNN-xxxx
+                    <br />
+                    Reminder - CMS recommends that all SPA numbers start with
+                    the year in which the package is submitted.
+                  </td>
+                </tr>
+                <tr>
+                  <td>Respond to Formal Medicaid SPA RAI</td>
+                  <td>
+                    Please use the exact Medicaid SPA ID sent with the RAI
+                  </td>
+                </tr>
+                <tr>
+                  <td>Submit New CHIP SPA</td>
+                  <td>Must follow the format SS-YY-NNNN-xxxx</td>
+                </tr>
+                <tr>
+                  <td>Respond to Formal CHIP SPA RAI</td>
+                  <td>Please use the exact CHIP SPA ID sent with the RAI</td>
+                </tr>
+                <tr>
+                  <td>Submit New 1915(b) Waiver Action</td>
+                  <td>
+                    Changes depending on selected Action Type
+                    <br />
+                    Default: Must follow the format required by the Action Type
+                    <br />
+                    New Waiver: Must be a new initial number with the format
+                    SS-####.R00.00 or SS-#####.R00.00
+                    <br />
+                    Waiver Amendment: Must follow the format SS-####.R##.## or
+                    SS-#####.R##.##
+                    <br />
+                    Request for waiver renewal: Must follow the format
+                    SS-####.R##.00 or SS-#####.R##.00
+                  </td>
+                </tr>
+                <tr>
+                  <td>Request 1915(b) and 1915(c) Temporary Extension</td>
+                  <td>
+                    Must follow the format SS-####.R##.TE## or SS-#####.R##.TE##
+                    (use R00 for waivers without renewals)
+                  </td>
+                </tr>
+                <tr>
+                  <td>Respond to Waiver RAI</td>
+                  <td>
+                    Please enter the waiver number for the RAI you are
+                    responding to. Use a dash after the two character state
+                    abbreviation.
+                  </td>
+                </tr>
+                <tr>
+                  <td>Submit 1915(c) Appendix K Amendment</td>
+                  <td>
+                    Must follow the format SS-####.R##.## or SS-#####.R##.##
+                    (use R00 for waivers without renewals)
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </Review>
+          <Review heading="ID Blue Text Values">
+            <table className="form-describe">
+              <thead>
+                <tr>
+                  <th>Submission Form</th>
+                  <th>ID Blue Text Values</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Submit New Medicaid SPA</td>
+                  <td>None</td>
+                </tr>
+                <tr>
+                  <td>Respond to Formal Medicaid SPA RAI</td>
+                  <td>
+                    Medicaid SPA ID should exist warning:
+                    <br />
+                    {approvedBlueWarningMessage}
+                  </td>
+                </tr>
+                <tr>
+                  <td>Submit New CHIP SPA</td>
+                  <td>None</td>
+                </tr>
+                <tr>
+                  <td>Respond to Formal CHIP SPA RAI</td>
+                  <td>
+                    CHIP SPA ID should exist warning:
+                    <br />
+                    {approvedBlueWarningMessage}
+                  </td>
+                </tr>
+                <tr>
+                  <td>Submit New 1915(b) Waiver Action</td>
+                  <td>
+                    Changes depending on selected Action Type
+                    <br />
+                    Default: None
+                    <br />
+                    New Waiver: None
+                    <br />
+                    Waiver Amendment: If the "parent ID" (the first three
+                    sections of the entered ID) is not found:
+                    <br />
+                    {approvedBlueWarningMessage}
+                    <br />
+                    Request for waiver renewal: If the "parent ID" (the first
+                    two sections of the entered ID) is not found:
+                    <br />
+                    {approvedBlueWarningMessage}
+                    <br />
+                  </td>
+                </tr>
+                <tr>
+                  <td>Request 1915(b) and 1915(c) Temporary Extension</td>
+                  <td>None</td>
+                </tr>
+                <tr>
+                  <td>Respond to Waiver RAI</td>
+                  <td>None</td>
+                </tr>
+                <tr>
+                  <td>Submit 1915(c) Appendix K Amendment</td>
+                  <td>
+                    If the "parent ID" (the first two sections of the entered
+                    ID) is not found:
+                    <br />
+                    {approvedBlueWarningMessage}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </Review>
+          <Review heading="ID Red Text Values">
+            <table className="form-describe">
+              <thead>
+                <tr>
+                  <th>Submission Form</th>
+                  <th>ID Red Text Values</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Submit New Medicaid SPA</td>
+                  <td>
+                    State Access Error:
+                    <br />
+                    You can only submit for a state you have access to. If you
+                    need to add another state, visit your user profile to
+                    request access.
+                    <br />
+                    <br />
+                    ID format error:
+                    <br />
+                    The SPA ID must be in the format of SS-YY-NNNN or
+                    SS-YY-NNNN-xxxx
+                    <br />
+                    <br />
+                    ID must not exist:
+                    <br />
+                    According to our records, this SPA ID already exists. Please
+                    check the SPA ID and try entering it again.
+                  </td>
+                </tr>
+                <tr>
+                  <td>Respond to Formal Medicaid SPA RAI</td>
+                  <td>
+                    State Access Error:
+                    <br />
+                    You can only submit for a state you have access to. If you
+                    need to add another state, visit your user profile to
+                    request access.
+                    <br />
+                    <br />
+                  </td>
+                </tr>
+                <tr>
+                  <td>Submit New CHIP SPA</td>
+                  <td>
+                    State Access Error:
+                    <br />
+                    You can only submit for a state you have access to. If you
+                    need to add another state, visit your user profile to
+                    request access.
+                    <br />
+                    <br />
+                    ID format error:
+                    <br />
+                    The SPA ID must be in the format of SS-YY-NNNN or
+                    SS-YY-NNNN-xxxx
+                    <br />
+                    <br />
+                    ID must not exist:
+                    <br />
+                    According to our records, this SPA ID already exists. Please
+                    check the SPA ID and try entering it again.
+                  </td>
+                </tr>
+                <tr>
+                  <td>Respond to Formal CHIP SPA RAI</td>
+                  <td>
+                    State Access Error:
+                    <br />
+                    You can only submit for a state you have access to. If you
+                    need to add another state, visit your user profile to
+                    request access.
+                    <br />
+                    <br />
+                  </td>
+                </tr>
+                <tr>
+                  <td>Submit New 1915(b) Waiver Action</td>
+                  <td>
+                    State Access Error:
+                    <br />
+                    You can only submit for a state you have access to. If you
+                    need to add another state, visit your user profile to
+                    request access.
+                    <br />
+                    <br />
+                    ID format error:
+                    <br />
+                    Changes depending on selected Action Type
+                    <br />
+                    Default: The Waiver Number must be in the format of the
+                    Action Type. Please select an Action Type first.
+                    <br />
+                    New Waiver: The Waiver Number must be in the format of
+                    SS-####.R00.00 or SS-#####.R00.00
+                    <br />
+                    Waiver Amendment: The Waiver Number must be in the format of
+                    SS-####.R##.## or SS-#####.R##.##
+                    <br />
+                    For amendments, the last two digits start with “01” and
+                    ascends.
+                    <br />
+                    Request for waiver renewal: The Waiver Number must be in the
+                    format of SS-####.R##.00 or SS-#####.R##.00
+                    <br />
+                    <br />
+                    ID existence errors:
+                    <br />
+                    Changes depending on selected Action Type
+                    <br />
+                    Default: None
+                    <br />
+                    New Waiver: ID must NOT exist error: According to our
+                    records, this Waiver Number already exists. Please check the
+                    Waiver Number and try entering it again.
+                    <br />
+                    Waiver Amendment: ID must NOT exist error: According to our
+                    records, this Waiver Number already exists. Please check the
+                    Waiver Number and try entering it again.
+                    <br />
+                    Request for waiver renewal: ID must NOT exist error:
+                    According to our records, this Waiver Number already exists.
+                    Please check the Waiver Number and try entering it again.
+                    <br />
+                  </td>
+                </tr>
+                <tr>
+                  <td>Request 1915(b) and 1915(c) Temporary Extension</td>
+                  <td>
+                    State Access Error:
+                    <br />
+                    You can only submit for a state you have access to. If you
+                    need to add another state, visit your user profile to
+                    request access.
+                    <br />
+                    <br />
+                    ID format error:
+                    <br />
+                    The Temporary Extension Request Number must be in the format
+                    of SS-####.R##.TE## or SS-#####.R##.TE##
+                    <br />
+                    <br />
+                    ID must not exist:
+                    <br />
+                    According to our records, this Temporary Extension Request
+                    Number already exists. Please check the Temporary Extension
+                    Request Number and try entering it again.
+                  </td>
+                </tr>
+                <tr>
+                  <td>Respond to Waiver RAI</td>
+                  <td>
+                    State Access Error:
+                    <br />
+                    You can only submit for a state you have access to. If you
+                    need to add another state, visit your user profile to
+                    request access.
+                    <br />
+                    <br />
+                    ID must exist:
+                    <br />
+                    The waiver number entered does not appear to match our
+                    records. Please enter the waiver number sent with the RAI,
+                    using a dash after the two character state abbreviation.
+                  </td>
+                </tr>
+                <tr>
+                  <td>Submit 1915(c) Appendix K Amendment</td>
+                  <td>
+                    State Access Error:
+                    <br />
+                    You can only submit for a state you have access to. If you
+                    need to add another state, visit your user profile to
+                    request access.
+                    <br />
+                    <br />
+                    ID format error:
+                    <br />
+                    The Waiver Number must be in the format of SS-####.R##.## or
+                    SS-#####.R##.##
+                    <br />
+                    For amendments, the last two digits start with “01” and
+                    ascends.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </Review>
         </section>
       </div>
     </>

--- a/services/ui-src/src/page/DescribeForms.tsx
+++ b/services/ui-src/src/page/DescribeForms.tsx
@@ -1,16 +1,14 @@
 import React from "react";
 import { Review } from "@cmsgov/design-system";
 
-import { FieldHint, IdValidation } from "cmscommonlib";
-
-import { OneMACFormConfig } from "../libs/formLib";
-import PageTitleBar from "../components/PageTitleBar";
-
 import {
+  OneMACFormConfig,
   stateAccessMessage,
-  //  buildMustExistMessage,
-  //   buildMustNotExistMessage
-} from "./OneMACForm";
+  buildWrongFormatMessage,
+  buildMustExistMessage,
+  buildMustNotExistMessage,
+} from "../libs/formLib";
+import PageTitleBar from "../components/PageTitleBar";
 
 import { medicaidSpaFormInfo } from "./medicaid-spa/MedicaidSpaForm";
 import { medicaidSPARAIFormInfo } from "./medicaid-spa/MedicaidSPARAIForm";
@@ -38,32 +36,44 @@ const configList: OneMACFormConfig[] | any = [
   { ...temporaryExtensionFormInfo },
 ];
 
-const describeFieldHint = (inFieldHintArray: FieldHint[]) => {
+const describeFieldHint = (formConfig: OneMACFormConfig) => {
   return (
     <>
-      {inFieldHintArray.map((oneHint, index) => (
+      {formConfig.idFieldHint.map((oneHint, index) => (
         <p key={index}>{oneHint.text}</p>
       ))}
     </>
   );
 };
 
-const describeErrors = (
-  validationList: IdValidation[],
-  idLabel: string | undefined
-) => {
-  const newLabel = idLabel ?? "ID";
-  return (
+const describeErrors = (formConfig: OneMACFormConfig) => {
+  return formConfig.idFormat ? (
     <>
-      <p>
-        State Access Error:
-        <br />
-        {stateAccessMessage.statusMessage}
-      </p>
-      {/* <p>ID Format Error:
-    <br/>{stateAccessMessage.statusMessage}</p>
-    {validationList.map((oneCheck, index) => oneCheck.errorLevel === "error" && <><p key={index}>ID must {(!oneCheck.idMustExist ? "not ": "")}exist Error:<br/>{(!oneCheck.idMustExist ? buildMustNotExistMessage(newLabel): buildMustExistMessage(newLabel))}</p></>)} */}
+      State Access Error:
+      <br />
+      {stateAccessMessage.statusMessage}
+      <br />
+      <br />
+      ID Format Error:
+      <br />
+      {buildWrongFormatMessage(formConfig).statusMessage}
+      {formConfig.idAdditionalErrorMessage &&
+        formConfig.idAdditionalErrorMessage.map((message, index) => (
+          <span key={index}>
+            <br />
+            {message}
+          </span>
+        ))}
+      <br />
+      <br />
+      ID must {formConfig.idMustExist === false ? "not " : ""}exist Error:
+      <br />
+      {formConfig.idMustExist === false
+        ? buildMustNotExistMessage(formConfig).statusMessage
+        : buildMustExistMessage(formConfig).statusMessage}
     </>
+  ) : (
+    <>ID not editable.</>
   );
 };
 
@@ -71,7 +81,7 @@ const DescribeField: React.FC<{
   fieldLabel: string;
   fieldName: string;
   appendText?: string;
-  customFunc?: (inVar: FieldHint[] | any, varTwo?: string) => JSX.Element;
+  customFunc?: (formConfig: OneMACFormConfig) => JSX.Element;
 }> = ({ fieldLabel, fieldName, appendText, customFunc }) => {
   return (
     <Review heading={fieldLabel + "s"}>
@@ -87,11 +97,7 @@ const DescribeField: React.FC<{
             (oneConfig: OneMACFormConfig | any, index: number) => {
               let displayValue: string | JSX.Element = "None";
 
-              if (customFunc)
-                displayValue = customFunc(
-                  oneConfig[fieldName],
-                  oneConfig.idLabel
-                );
+              if (customFunc) displayValue = customFunc(oneConfig);
               else if (
                 typeof oneConfig[fieldName] === "string" ||
                 typeof oneConfig[fieldName] === "boolean"

--- a/services/ui-src/src/page/DescribeForms.tsx
+++ b/services/ui-src/src/page/DescribeForms.tsx
@@ -154,6 +154,16 @@ const DescribeForms: React.FC = () => {
             fieldName="idExistValidations"
             customFunc={describeErrors}
           />
+          <DescribeField
+            fieldLabel="Parent ID Gray Text"
+            fieldName="parentFieldHint"
+            customFunc={describeFieldHint}
+          />
+          <DescribeField
+            fieldLabel="Red Parent Not Found Message"
+            fieldName="parentNotFoundMessage"
+          />
+
           {/* <DescribeField fieldLabel="FAQ Link" fieldName="idFAQLink" />
           <DescribeField
             fieldLabel="Form contains Proposed Effective Date field"
@@ -503,6 +513,68 @@ const DescribeForms: React.FC = () => {
                     For amendments, the last two digits start with “01” and
                     ascends.
                   </td>
+                </tr>
+              </tbody>
+            </table>
+          </Review>
+          <Review heading="Parent ID Messaging">
+            <table className="form-describe">
+              <thead>
+                <tr>
+                  <th>Submission Form</th>
+                  <th>Parent ID Messaging Values</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Submit New Medicaid SPA</td>
+                  <td>No Parent ID on form.</td>
+                </tr>
+                <tr>
+                  <td>Respond to Formal Medicaid SPA RAI</td>
+                  <td>No Parent ID on form.</td>
+                </tr>
+                <tr>
+                  <td>Submit New CHIP SPA</td>
+                  <td>No Parent ID on form.</td>
+                </tr>
+                <tr>
+                  <td>Respond to Formal CHIP SPA RAI</td>
+                  <td>No Parent ID on form.</td>
+                </tr>
+                <tr>
+                  <td>Submit New 1915(b) Waiver Action</td>
+                  <td>No Parent ID on form.</td>
+                </tr>
+                <tr>
+                  <td>Request 1915(b) and 1915(c) Temporary Extension</td>
+                  <td>
+                    Gray text:
+                    <br />
+                    Please enter the initial or renewal waiver number you are
+                    requesting a Temporary Extension for
+                    <br />
+                    <br />
+                    Blue text: None
+                    <br />
+                    <br />
+                    Red text:
+                    <br />
+                    ID must exist:
+                    <br />
+                    The waiver number entered does not appear to match our
+                    records. Please enter an approved initial or renewal waiver
+                    number, using a dash after the two character state
+                    abbreviation.
+                  </td>
+                </tr>
+                <tr>
+                  <td>Respond to Waiver RAI</td>
+                  <td>No Parent ID on form.</td>
+                </tr>
+                <tr>
+                  <td>Submit 1915(c) Appendix K Amendment</td>
+                  <td>No Parent ID on form.</td>
                 </tr>
               </tbody>
             </table>

--- a/services/ui-src/src/page/DescribeForms.tsx
+++ b/services/ui-src/src/page/DescribeForms.tsx
@@ -7,9 +7,9 @@ import { OneMACFormConfig } from "../libs/formLib";
 import PageTitleBar from "../components/PageTitleBar";
 
 import {
-  stateAccessError,
-  buildMustExistMessage,
-  buildMustNotExistMessage,
+  stateAccessMessage,
+  //  buildMustExistMessage,
+  //   buildMustNotExistMessage
 } from "./OneMACForm";
 
 import { medicaidSpaFormInfo } from "./medicaid-spa/MedicaidSpaForm";
@@ -58,22 +58,11 @@ const describeErrors = (
       <p>
         State Access Error:
         <br />
-        {stateAccessError.statusMessage}
+        {stateAccessMessage.statusMessage}
       </p>
-      {validationList.map(
-        (oneCheck, index) =>
-          oneCheck.errorLevel === "error" && (
-            <>
-              <p key={index}>
-                ID must {!oneCheck.idMustExist ? "not " : ""}exist Error:
-                <br />
-                {!oneCheck.idMustExist
-                  ? buildMustNotExistMessage(newLabel)
-                  : buildMustExistMessage(newLabel)}
-              </p>
-            </>
-          )
-      )}
+      {/* <p>ID Format Error:
+    <br/>{stateAccessMessage.statusMessage}</p>
+    {validationList.map((oneCheck, index) => oneCheck.errorLevel === "error" && <><p key={index}>ID must {(!oneCheck.idMustExist ? "not ": "")}exist Error:<br/>{(!oneCheck.idMustExist ? buildMustNotExistMessage(newLabel): buildMustExistMessage(newLabel))}</p></>)} */}
     </>
   );
 };

--- a/services/ui-src/src/page/DescribeForms.tsx
+++ b/services/ui-src/src/page/DescribeForms.tsx
@@ -151,7 +151,7 @@ const DescribeForms: React.FC = () => {
           <DescribeField fieldLabel="ID Blue Text" fieldName="junk" />
           <DescribeField
             fieldLabel="ID Red Text"
-            fieldName="idExistValidations"
+            fieldName="idMustExist"
             customFunc={describeErrors}
           />
           <DescribeField

--- a/services/ui-src/src/page/DescribeForms.tsx
+++ b/services/ui-src/src/page/DescribeForms.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { Review } from "@cmsgov/design-system";
+
+import { OneMACFormConfig } from "../libs/formLib";
+import PageTitleBar from "../components/PageTitleBar";
+
+import { medicaidSpaFormInfo } from "./medicaid-spa/MedicaidSpaForm";
+import { medicaidSPARAIFormInfo } from "./medicaid-spa/MedicaidSPARAIForm";
+import { chipSpaFormInfo } from "./chip-spa/ChipSpaForm";
+import { chipSPARAIFormInfo } from "./chip-spa/CHIPSPARAIForm";
+import { initialWaiverFormInfo } from "./initial-waiver/InitialWaiverForm";
+import { waiverRenewalFormInfo } from "./waiver-renewal/WaiverRenewalForm";
+import { waiverAmendmentFormInfo } from "./waiver-amendment/WaiverAmendmentForm";
+import { waiverRAIFormInfo } from "./waiver-rai/WaiverRAIForm";
+import { waiverAppendixKFormInfo } from "./waiver-appendix-k/WaiverAppendixKForm";
+import { waiverAppendixKRAIFormInfo } from "./waiver-appendix-k/WaiverAppendixKRAIForm";
+import { temporaryExtensionFormInfo } from "./temporary-extension/TemporaryExtensionForm";
+
+const DescribeField: React.FC<{ fieldLabel: string; fieldName: string }> = ({
+  fieldLabel,
+  fieldName,
+}) => {
+  const configList: OneMACFormConfig[] | any = [
+    { ...medicaidSpaFormInfo },
+    { ...medicaidSPARAIFormInfo },
+    { ...chipSpaFormInfo },
+    { ...chipSPARAIFormInfo },
+    { ...initialWaiverFormInfo },
+    { ...waiverRenewalFormInfo },
+    { ...waiverAmendmentFormInfo },
+    { ...waiverRAIFormInfo },
+    { ...waiverAppendixKFormInfo },
+    { ...waiverAppendixKRAIFormInfo },
+    { ...temporaryExtensionFormInfo },
+  ];
+  return (
+    <Review heading={fieldLabel + "s"}>
+      <table className="form-describe">
+        <th>Form</th>
+        <th>{fieldLabel} Value</th>
+        {configList.map((oneConfig: OneMACFormConfig | any, index: number) => {
+          // const fieldValue = oneConfig[fieldName] || "None"
+          return (
+            <tr key={index}>
+              <td>{oneConfig.typeLabel}</td>
+              <td>{oneConfig[fieldName] || "None"}</td>
+            </tr>
+          );
+        })}
+      </table>
+    </Review>
+  );
+};
+
+/**
+ * For easy viewing of the Form configuration values
+ */
+const DescribeForms: React.FC = () => {
+  const formConfig = medicaidSpaFormInfo;
+  return (
+    <>
+      <PageTitleBar heading={"Describe Package View Forms"} enableBackNav />
+      <div className="onemac-form">
+        <section className="detail-section">
+          <DescribeField fieldLabel="ID Label" fieldName="idLabel" />
+          <DescribeField fieldLabel="ID Format Text" fieldName="idFormat" />
+          {/* <DescribeField fieldLabel="ID FieldHint" fieldName="idFieldHint" /> */}
+          <DescribeField fieldLabel="FAQ Link" fieldName="idFAQLink" />
+          <DescribeField
+            fieldLabel="Form Requires Confirmation"
+            fieldName="confirmSubmit"
+          />
+          <hr />
+          <p>{JSON.stringify(formConfig)}</p>
+        </section>
+      </div>
+    </>
+  );
+};
+
+export default DescribeForms;

--- a/services/ui-src/src/page/DescribeForms.tsx
+++ b/services/ui-src/src/page/DescribeForms.tsx
@@ -128,7 +128,7 @@ const DescribeForms: React.FC = () => {
   return (
     <>
       <PageTitleBar heading={"Describe Forms"} enableBackNav />
-      <div className="onemac-form">
+      <div className="form-container">
         <h2>Package View</h2>
         <p>
           NOTE: These are generated from application, so reflect the true
@@ -174,6 +174,7 @@ const DescribeForms: React.FC = () => {
             fieldName="confirmSubmit"
           /> */}
         </section>
+        <hr />
         <h2>Submission View</h2>
         <p>
           NOTE: These are hand-entered and therefore may be out of date with the

--- a/services/ui-src/src/page/DescribeForms.tsx
+++ b/services/ui-src/src/page/DescribeForms.tsx
@@ -1,8 +1,16 @@
 import React from "react";
 import { Review } from "@cmsgov/design-system";
 
+import { FieldHint, IdValidation } from "cmscommonlib";
+
 import { OneMACFormConfig } from "../libs/formLib";
 import PageTitleBar from "../components/PageTitleBar";
+
+import {
+  stateAccessError,
+  buildMustExistMessage,
+  buildMustNotExistMessage,
+} from "./OneMACForm";
 
 import { medicaidSpaFormInfo } from "./medicaid-spa/MedicaidSpaForm";
 import { medicaidSPARAIFormInfo } from "./medicaid-spa/MedicaidSPARAIForm";
@@ -16,37 +24,102 @@ import { waiverAppendixKFormInfo } from "./waiver-appendix-k/WaiverAppendixKForm
 import { waiverAppendixKRAIFormInfo } from "./waiver-appendix-k/WaiverAppendixKRAIForm";
 import { temporaryExtensionFormInfo } from "./temporary-extension/TemporaryExtensionForm";
 
-const DescribeField: React.FC<{ fieldLabel: string; fieldName: string }> = ({
-  fieldLabel,
-  fieldName,
-}) => {
-  const configList: OneMACFormConfig[] | any = [
-    { ...medicaidSpaFormInfo },
-    { ...medicaidSPARAIFormInfo },
-    { ...chipSpaFormInfo },
-    { ...chipSPARAIFormInfo },
-    { ...initialWaiverFormInfo },
-    { ...waiverRenewalFormInfo },
-    { ...waiverAmendmentFormInfo },
-    { ...waiverRAIFormInfo },
-    { ...waiverAppendixKFormInfo },
-    { ...waiverAppendixKRAIFormInfo },
-    { ...temporaryExtensionFormInfo },
-  ];
+const configList: OneMACFormConfig[] | any = [
+  { ...medicaidSpaFormInfo },
+  { ...medicaidSPARAIFormInfo },
+  { ...chipSpaFormInfo },
+  { ...chipSPARAIFormInfo },
+  { ...initialWaiverFormInfo },
+  { ...waiverRenewalFormInfo },
+  { ...waiverAmendmentFormInfo },
+  { ...waiverRAIFormInfo },
+  { ...waiverAppendixKFormInfo },
+  { ...waiverAppendixKRAIFormInfo },
+  { ...temporaryExtensionFormInfo },
+];
+
+const describeFieldHint = (inFieldHintArray: FieldHint[]) => {
+  return (
+    <>
+      {inFieldHintArray.map((oneHint, index) => (
+        <p key={index}>{oneHint.text}</p>
+      ))}
+    </>
+  );
+};
+
+const describeErrors = (
+  validationList: IdValidation[],
+  idLabel: string | undefined
+) => {
+  const newLabel = idLabel ?? "ID";
+  return (
+    <>
+      <p>
+        State Access Error:
+        <br />
+        {stateAccessError.statusMessage}
+      </p>
+      {validationList.map(
+        (oneCheck, index) =>
+          oneCheck.errorLevel === "error" && (
+            <>
+              <p key={index}>
+                ID must {!oneCheck.idMustExist ? "not " : ""}exist Error:
+                <br />
+                {!oneCheck.idMustExist
+                  ? buildMustNotExistMessage(newLabel)
+                  : buildMustExistMessage(newLabel)}
+              </p>
+            </>
+          )
+      )}
+    </>
+  );
+};
+
+const DescribeField: React.FC<{
+  fieldLabel: string;
+  fieldName: string;
+  appendText?: string;
+  customFunc?: (inVar: FieldHint[] | any, varTwo?: string) => JSX.Element;
+}> = ({ fieldLabel, fieldName, appendText, customFunc }) => {
   return (
     <Review heading={fieldLabel + "s"}>
       <table className="form-describe">
-        <th>Form</th>
-        <th>{fieldLabel} Value</th>
-        {configList.map((oneConfig: OneMACFormConfig | any, index: number) => {
-          // const fieldValue = oneConfig[fieldName] || "None"
-          return (
-            <tr key={index}>
-              <td>{oneConfig.typeLabel}</td>
-              <td>{oneConfig[fieldName] || "None"}</td>
-            </tr>
-          );
-        })}
+        <thead>
+          <tr>
+            <th>Form</th>
+            <th>{fieldLabel} Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          {configList.map(
+            (oneConfig: OneMACFormConfig | any, index: number) => {
+              let displayValue: string | JSX.Element = "None";
+
+              if (customFunc)
+                displayValue = customFunc(
+                  oneConfig[fieldName],
+                  oneConfig.idLabel
+                );
+              else if (
+                typeof oneConfig[fieldName] === "string" ||
+                typeof oneConfig[fieldName] === "boolean"
+              )
+                displayValue =
+                  oneConfig[fieldName] + (appendText ? appendText : "");
+              else if (Array.isArray(oneConfig[fieldName]))
+                displayValue = JSON.stringify(oneConfig[fieldName]);
+              return (
+                <tr key={index}>
+                  <td>{oneConfig.typeLabel}</td>
+                  <td>{displayValue}</td>
+                </tr>
+              );
+            }
+          )}
+        </tbody>
       </table>
     </Review>
   );
@@ -56,22 +129,45 @@ const DescribeField: React.FC<{ fieldLabel: string; fieldName: string }> = ({
  * For easy viewing of the Form configuration values
  */
 const DescribeForms: React.FC = () => {
-  const formConfig = medicaidSpaFormInfo;
   return (
     <>
       <PageTitleBar heading={"Describe Package View Forms"} enableBackNav />
       <div className="onemac-form">
+        {/* <section className="detail-section">
+          <h3>Medicaid SPA Form</h3>
+          <h4>ID Label: {medicaidSpaFormInfo.idLabel}</h4>
+          <p></p>
+        </section>
+        <hr/> */}
         <section className="detail-section">
+          <DescribeField fieldLabel="Page Title" fieldName="pageTitle" />
+          <DescribeField
+            fieldLabel="Form Title"
+            fieldName="detailsHeader"
+            appendText=" Details"
+          />
           <DescribeField fieldLabel="ID Label" fieldName="idLabel" />
           <DescribeField fieldLabel="ID Format Text" fieldName="idFormat" />
-          {/* <DescribeField fieldLabel="ID FieldHint" fieldName="idFieldHint" /> */}
+          <DescribeField
+            fieldLabel="ID Gray Text"
+            fieldName="idFieldHint"
+            customFunc={describeFieldHint}
+          />
+          <DescribeField fieldLabel="ID Blue Text" fieldName="junk" />
+          <DescribeField
+            fieldLabel="ID Red Text"
+            fieldName="idExistValidations"
+            customFunc={describeErrors}
+          />
           <DescribeField fieldLabel="FAQ Link" fieldName="idFAQLink" />
+          <DescribeField
+            fieldLabel="Form contains Proposed Effective Date field"
+            fieldName="proposedEffectiveDate"
+          />
           <DescribeField
             fieldLabel="Form Requires Confirmation"
             fieldName="confirmSubmit"
           />
-          <hr />
-          <p>{JSON.stringify(formConfig)}</p>
         </section>
       </div>
     </>

--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -143,13 +143,7 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
 
       return errorMessages;
     },
-    [
-      activeTerritories,
-      formConfig.idAdditionalErrorMessage,
-      formConfig.idFormat,
-      formConfig.idLabel,
-      formConfig.idRegex,
-    ]
+    [activeTerritories, formConfig]
   );
 
   async function handleComponentIdChange(componentId: string) {

--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -37,6 +37,15 @@ import ComponentId from "../components/ComponentId";
 
 const leavePageConfirmMessage = "Changes you made will not be saved.";
 
+export const stateAccessError = {
+  statusLevel: "error",
+  statusMessage: `You can only submit for a state you have access to. If you need to add another state, visit your user profile to request access.`,
+};
+
+export const buildMustExistMessage = (idLabel: string) =>
+  `According to our records, this ${idLabel} does not exist. Please check the ${idLabel} and try entering it again.`;
+export const buildMustNotExistMessage = (idLabel: string) =>
+  `According to our records, this ${idLabel} already exists. Please check the ${idLabel} and try entering it again.`;
 /**
  * Parses out the two character state/territory at the beginning of the component id.
  * @param componentId the component id
@@ -123,10 +132,7 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
         (activeTerritories &&
           !activeTerritories.includes(getTerritoryFromComponentId(componentId)))
       ) {
-        errorMessages.push({
-          statusLevel: "error",
-          statusMessage: `You can only submit for a state you have access to. If you need to add another state, visit your user profile to request access.`,
-        });
+        errorMessages.push(stateAccessError);
       }
       // must match the associated Regex string for format
       else if (
@@ -251,10 +257,6 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
                 oneMacFormData.componentId
               );
             }
-            // if (idExistValidation.existenceRegex !== undefined) {
-            //   checkingNumber = checkingNumber.match(idExistValidation.existenceRegex
-            //   )![0];
-            // }
             try {
               result = await ChangeRequestDataApi.packageExists(checkingNumber);
             } catch (e) {
@@ -275,19 +277,17 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
               // ID does not exist but it should exist
               if (!dupID && correspondingValidation.idMustExist) {
                 if (correspondingValidation.errorLevel === "error") {
-                  tempMessage = `According to our records, this ${formConfig.idLabel} does not exist. Please check the ${formConfig.idLabel} and try entering it again.`;
+                  tempMessage = buildMustExistMessage(formConfig.idLabel);
                 } else {
-                  // tempMessage = `${formConfig.idLabel} not found. Please ensure you have the correct ${formConfig.idLabel} before submitting. Contact the MACPro Help Desk (code: ${RESPONSE_CODE.SUBMISSION_ID_NOT_FOUND_WARNING}) if you need support.`;
                   tempMessage = approvedBlueWarningMessage;
                   tempCode = RESPONSE_CODE.SUBMISSION_ID_NOT_FOUND_WARNING;
                 }
                 // ID exists but it should NOT exist
               } else if (dupID && !correspondingValidation.idMustExist) {
                 if (correspondingValidation.errorLevel === "error") {
-                  tempMessage = `According to our records, this ${formConfig.idLabel} already exists. Please check the ${formConfig.idLabel} and try entering it again.`;
+                  tempMessage = buildMustNotExistMessage(formConfig.idLabel);
                   tempCode = RESPONSE_CODE.SUBMISSION_ID_EXIST_WARNING;
                 } else {
-                  // tempMessage = `According to our records, this ${formConfig.idLabel} already exists. Please ensure you have the correct ${formConfig.idLabel} before submitting. Contact the MACPro Help Desk (code: ${RESPONSE_CODE.SUBMISSION_ID_EXIST_WARNING}) if you need support.`;
                   tempMessage = approvedBlueWarningMessage;
                   tempCode = RESPONSE_CODE.SUBMISSION_ID_EXIST_WARNING;
                 }

--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -37,15 +37,23 @@ import ComponentId from "../components/ComponentId";
 
 const leavePageConfirmMessage = "Changes you made will not be saved.";
 
-export const stateAccessError = {
+export const stateAccessMessage = {
   statusLevel: "error",
   statusMessage: `You can only submit for a state you have access to. If you need to add another state, visit your user profile to request access.`,
 };
+export const buildWrongFormatMessage = (formConfig: OneMACFormConfig) => ({
+  statusLevel: "error",
+  statusMessage: `The ${formConfig.idLabel} must be in the format of ${formConfig.idFormat}`,
+});
 
-export const buildMustExistMessage = (idLabel: string) =>
-  `According to our records, this ${idLabel} does not exist. Please check the ${idLabel} and try entering it again.`;
-export const buildMustNotExistMessage = (idLabel: string) =>
-  `According to our records, this ${idLabel} already exists. Please check the ${idLabel} and try entering it again.`;
+export const buildMustExistMessage = (formConfig: OneMACFormConfig) => ({
+  statusLevel: "error",
+  statusMessage: `According to our records, this ${formConfig.idLabel} does not exist. Please check the ${formConfig.idLabel} and try entering it again.`,
+});
+export const buildMustNotExistMessage = (formConfig: OneMACFormConfig) => ({
+  statusLevel: "error",
+  statusMessage: `According to our records, this ${formConfig.idLabel} already exists. Please check the ${formConfig.idLabel} and try entering it again.`,
+});
 /**
  * Parses out the two character state/territory at the beginning of the component id.
  * @param componentId the component id
@@ -132,17 +140,14 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
         (activeTerritories &&
           !activeTerritories.includes(getTerritoryFromComponentId(componentId)))
       ) {
-        errorMessages.push(stateAccessError);
+        errorMessages.push(stateAccessMessage);
       }
       // must match the associated Regex string for format
       else if (
         formConfig.idRegex &&
         !matchesRegex(componentId, formConfig.idRegex)
       ) {
-        errorMessages.push({
-          statusLevel: "error",
-          statusMessage: `The ${formConfig.idLabel} must be in the format of ${formConfig.idFormat}`,
-        });
+        errorMessages.push(buildWrongFormatMessage(formConfig));
         if (formConfig.idAdditionalErrorMessage) {
           formConfig.idAdditionalErrorMessage.forEach((message) =>
             errorMessages.push({
@@ -234,84 +239,89 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
 
   useEffect(() => {
     // default display message settings with empty message
-    let formatMessages: Message[] = validateComponentId(
+    let validationMessages: Message[] = validateComponentId(
       oneMacFormData.componentId
     );
 
-    let existMessages: Message[] = [];
-    let result = false;
-    try {
-      if (
-        formatMessages.length === 0 &&
-        oneMacFormData.componentId &&
-        formConfig.idExistValidations
-      ) {
-        const promises = formConfig.idExistValidations.map(
-          async (idExistValidation) => {
-            let checkingNumber = oneMacFormData.componentId;
-            if (
-              idExistValidation.validateParentId &&
-              typeof formConfig.getParentInfo == "function"
-            ) {
-              [checkingNumber] = formConfig.getParentInfo(
-                oneMacFormData.componentId
-              );
-            }
-            try {
-              result = await ChangeRequestDataApi.packageExists(checkingNumber);
-            } catch (e) {
-              console.log("error message is: ", (e as Error).message);
-              setAlertCode(RESPONSE_CODE[(e as Error).message]);
-            }
-            return result;
-          }
-        );
+    const checkPackage = async (checkingNumber: string) => {
+      return await ChangeRequestDataApi.packageExists(checkingNumber);
+    };
 
-        Promise.all(promises)
-          .then((results) => {
-            results.forEach((dupID, key) => {
-              const correspondingValidation =
-                formConfig.idExistValidations[key];
-              let tempMessage, tempCode;
+    if (validationMessages.length === 0 && oneMacFormData.componentId) {
+      try {
+        const isADup = checkPackage(oneMacFormData.componentId);
+        console.log("isADup", isADup);
 
-              // ID does not exist but it should exist
-              if (!dupID && correspondingValidation.idMustExist) {
-                if (correspondingValidation.errorLevel === "error") {
-                  tempMessage = buildMustExistMessage(formConfig.idLabel);
-                } else {
-                  tempMessage = approvedBlueWarningMessage;
-                  tempCode = RESPONSE_CODE.SUBMISSION_ID_NOT_FOUND_WARNING;
-                }
-                // ID exists but it should NOT exist
-              } else if (dupID && !correspondingValidation.idMustExist) {
-                if (correspondingValidation.errorLevel === "error") {
-                  tempMessage = buildMustNotExistMessage(formConfig.idLabel);
-                  tempCode = RESPONSE_CODE.SUBMISSION_ID_EXIST_WARNING;
-                } else {
-                  tempMessage = approvedBlueWarningMessage;
-                  tempCode = RESPONSE_CODE.SUBMISSION_ID_EXIST_WARNING;
-                }
-              }
-
-              // if we got a message through checking, then we should add it to the existMessages array
-              const messageToAdd: Message = {
-                statusLevel: correspondingValidation.errorLevel,
-                statusMessage: tempMessage as string,
-                warningMessageCode: tempCode,
-              };
-              tempMessage && existMessages.push(messageToAdd);
-            });
-          })
-          .then(() => {
-            setComponentIdStatusMessages(existMessages);
-          });
-      } else {
-        setComponentIdStatusMessages(formatMessages);
+        if (!isADup && formConfig.idMustExist) {
+          validationMessages.push(buildMustExistMessage(formConfig));
+          // ID exists but it should NOT exist
+        } //else if (isADup && !formConfig.idMustExist) {
+        //   validationMessages.push(buildMustNotExistMessage(formConfig));
+        // }
+      } catch (e) {
+        console.log("error message is: ", (e as Error).message);
+        setAlertCode(RESPONSE_CODE[(e as Error).message]);
       }
-    } catch (err) {
-      console.log("error is: ", err);
-      setAlertCode(RESPONSE_CODE[(err as Error).message]);
     }
+
+    // if (!isADup && formConfig.idMustExist) {
+    //       if (formConfig.idMustExistErrorLevel === "error") {
+    //         tempMessage = buildMustExistMessage(formConfig.idLabel);
+    //       } else {
+    //         tempMessage = approvedBlueWarningMessage;
+    //         tempCode = RESPONSE_CODE.SUBMISSION_ID_NOT_FOUND_WARNING;
+    //       }
+    //       // ID exists but it should NOT exist
+    //     } else if (dupID && !correspondingValidation.idMustExist) {
+    //       if (correspondingValidation.errorLevel === "error") {
+    //         tempMessage = buildMustNotExistMessage(formConfig.idLabel);
+    //         tempCode = RESPONSE_CODE.SUBMISSION_ID_EXIST_WARNING;
+    //       } else {
+    //         tempMessage = approvedBlueWarningMessage;
+    //         tempCode = RESPONSE_CODE.SUBMISSION_ID_EXIST_WARNING;
+    //       }
+    //     }
+
+    // Promise.all(promises)
+    //   .then((results) => {
+    //     results.forEach((dupID, key) => {
+    //       const correspondingValidation =
+    //         formConfig.idExistValidations[key];
+    //       let tempMessage, tempCode;
+
+    //       // ID does not exist but it should exist
+    //       if (!dupID && correspondingValidation.idMustExist) {
+    //         if (correspondingValidation.errorLevel === "error") {
+    //           tempMessage = buildMustExistMessage(formConfig.idLabel);
+    //         } else {
+    //           tempMessage = approvedBlueWarningMessage;
+    //           tempCode = RESPONSE_CODE.SUBMISSION_ID_NOT_FOUND_WARNING;
+    //         }
+    //         // ID exists but it should NOT exist
+    //       } else if (dupID && !correspondingValidation.idMustExist) {
+    //         if (correspondingValidation.errorLevel === "error") {
+    //           tempMessage = buildMustNotExistMessage(formConfig.idLabel);
+    //           tempCode = RESPONSE_CODE.SUBMISSION_ID_EXIST_WARNING;
+    //         } else {
+    //           tempMessage = approvedBlueWarningMessage;
+    //           tempCode = RESPONSE_CODE.SUBMISSION_ID_EXIST_WARNING;
+    //         }
+    //       }
+
+    //       // if we got a message through checking, then we should add it to the existMessages array
+    //       const messageToAdd: Message = {
+    //         statusLevel: correspondingValidation.errorLevel,
+    //         statusMessage: tempMessage as string,
+    //         warningMessageCode: tempCode,
+    //       };
+    //       tempMessage && existMessages.push(messageToAdd);
+    //     });
+    //   })
+    //   .then(() => {
+    //     setComponentIdStatusMessages(existMessages);
+    //   });
+
+    setComponentIdStatusMessages(validationMessages);
   }, [
     areUploadsReady,
     formConfig,

--- a/services/ui-src/src/page/chip-spa/CHIPSPARAIForm.tsx
+++ b/services/ui-src/src/page/chip-spa/CHIPSPARAIForm.tsx
@@ -5,17 +5,18 @@ import { ONEMAC_ROUTES, chipSPARAIResponse } from "cmscommonlib";
 import { FormLocationState } from "../../domain-types";
 import { useLocation } from "react-router-dom";
 
+export const chipSPARAIFormInfo: OneMACFormConfig = {
+  ...defaultOneMACFormConfig,
+  ...chipSPARAIResponse,
+  pageTitle: "Formal Request for Additional Information Response",
+  detailsHeader: "Formal CHIP SPA RAI",
+  landingPage: ONEMAC_ROUTES.CHIP_SPA_DETAIL,
+  confirmSubmit: true,
+};
+
 const CHIPSPARAIForm: FC = () => {
   const location = useLocation<FormLocationState>();
-  const chipSPARAIFormInfo: OneMACFormConfig = {
-    ...defaultOneMACFormConfig,
-    ...chipSPARAIResponse,
-    pageTitle: "Formal Request for Additional Information Response",
-    detailsHeader: "Formal CHIP SPA RAI",
-    landingPage:
-      ONEMAC_ROUTES.CHIP_SPA_DETAIL + `/${location.state?.componentId}`,
-    confirmSubmit: true,
-  };
+  chipSPARAIFormInfo.landingPage += `/${location.state?.componentId}`;
 
   return <OneMACForm formConfig={chipSPARAIFormInfo} />;
 };

--- a/services/ui-src/src/page/chip-spa/ChipSpaForm.tsx
+++ b/services/ui-src/src/page/chip-spa/ChipSpaForm.tsx
@@ -5,7 +5,7 @@ import { ROUTES, ONEMAC_ROUTES, chipSPA } from "cmscommonlib";
 
 const idFormat: string = "SS-YY-NNNN-xxxx";
 
-const chipSpaFormInfo: OneMACFormConfig = {
+export const chipSpaFormInfo: OneMACFormConfig = {
   ...defaultOneMACFormConfig,
   ...chipSPA,
   pageTitle: "Submit New CHIP SPA",

--- a/services/ui-src/src/page/medicaid-spa/MedicaidSPARAIForm.tsx
+++ b/services/ui-src/src/page/medicaid-spa/MedicaidSPARAIForm.tsx
@@ -5,18 +5,18 @@ import { ONEMAC_ROUTES, medicaidSPARAIResponse } from "cmscommonlib";
 import { FormLocationState } from "../../domain-types";
 import { useLocation } from "react-router-dom";
 
+export const medicaidSPARAIFormInfo: OneMACFormConfig = {
+  ...defaultOneMACFormConfig,
+  ...medicaidSPARAIResponse,
+  pageTitle: "Formal Request for Additional Information Response",
+  detailsHeader: "Medicaid SPA RAI",
+  landingPage: ONEMAC_ROUTES.MEDICAID_SPA_DETAIL,
+  confirmSubmit: true,
+};
+
 const MedicaidSPARAIForm: FC = () => {
   const location = useLocation<FormLocationState>();
-  const medicaidSPARAIFormInfo: OneMACFormConfig = {
-    ...defaultOneMACFormConfig,
-    ...medicaidSPARAIResponse,
-    pageTitle: "Formal Request for Additional Information Response",
-    detailsHeader: "Medicaid SPA RAI",
-    landingPage:
-      ONEMAC_ROUTES.MEDICAID_SPA_DETAIL + `/${location.state?.componentId}`,
-    confirmSubmit: true,
-  };
-
+  medicaidSPARAIFormInfo.landingPage += `/${location.state?.componentId}`;
   return <OneMACForm formConfig={medicaidSPARAIFormInfo} />;
 };
 

--- a/services/ui-src/src/page/medicaid-spa/MedicaidSpaForm.tsx
+++ b/services/ui-src/src/page/medicaid-spa/MedicaidSpaForm.tsx
@@ -5,7 +5,7 @@ import { ROUTES, ONEMAC_ROUTES, medicaidSPA } from "cmscommonlib";
 
 const medicaidSpaIdFormat: string = "SS-YY-NNNN or SS-YY-NNNN-xxxx";
 
-const medicaidSpaFormInfo: OneMACFormConfig = {
+export const medicaidSpaFormInfo: OneMACFormConfig = {
   ...defaultOneMACFormConfig,
   ...medicaidSPA,
   pageTitle: "Submit New Medicaid SPA",

--- a/services/ui-src/src/page/temporary-extension/TemporaryExtensionForm.tsx
+++ b/services/ui-src/src/page/temporary-extension/TemporaryExtensionForm.tsx
@@ -11,38 +11,38 @@ import { FormLocationState } from "../../domain-types";
 import { useLocation } from "react-router-dom";
 import { DetailViewTab } from "../../libs/detailLib";
 
+const idFormat: string = "SS-####.R##.TE## or SS-#####.R##.TE##";
+export const temporaryExtensionFormInfo: OneMACFormConfig = {
+  ...waiverTemporaryExtension,
+  ...defaultOneMACFormConfig,
+  pageTitle: "Request a Temporary Extension",
+  detailsHeader: "Temporary Extension Request",
+  idFAQLink: ROUTES.FAQ_WAIVER_EXTENSION_ID,
+  idFieldHint: [
+    {
+      text:
+        "Must be a waiver extension request number with the format " + idFormat,
+    },
+  ],
+  idFormat: idFormat,
+  landingPage: ONEMAC_ROUTES.PACKAGE_LIST_WAIVER,
+  parentLabel: "Approved Initial or Renewal Waiver Number",
+  parentFieldHint: [
+    {
+      text: "Please enter the initial or renewal waiver number for which you are requesting a Temporary Extension.",
+    },
+  ],
+  parentNotFoundMessage:
+    "The waiver number entered does not appear to match our records. Please enter an approved initial or renewal waiver number, using a dash after the two character state abbreviation.",
+  validateParentAPI: "validateParentOfTemporaryExtension",
+};
+
 const TemporaryExtensionForm: FC = () => {
   const location = useLocation<FormLocationState>();
-  const idFormat: string = "SS-####.R##.TE## or SS-#####.R##.TE##";
-  const temporaryExtensionFormInfo: OneMACFormConfig = {
-    ...waiverTemporaryExtension,
-    ...defaultOneMACFormConfig,
-    pageTitle: "Request a Temporary Extension",
-    detailsHeader: "Temporary Extension Request",
-    idFAQLink: ROUTES.FAQ_WAIVER_EXTENSION_ID,
-    idFieldHint: [
-      {
-        text:
-          "Must be a waiver extension request number with the format " +
-          idFormat,
-      },
-    ],
-    idFormat: idFormat,
-    landingPage:
-      location.state?.parentType && location.state?.parentId
-        ? TYPE_TO_DETAIL_ROUTE[location.state?.parentType] +
-          `/${location.state?.parentId}#${DetailViewTab.EXTENSION}`
-        : ONEMAC_ROUTES.PACKAGE_LIST_WAIVER,
-    parentLabel: "Approved Initial or Renewal Waiver Number",
-    parentFieldHint: [
-      {
-        text: "Please enter the initial or renewal waiver number for which you are requesting a Temporary Extension.",
-      },
-    ],
-    parentNotFoundMessage:
-      "The waiver number entered does not appear to match our records. Please enter an approved initial or renewal waiver number, using a dash after the two character state abbreviation.",
-    validateParentAPI: "validateParentOfTemporaryExtension",
-  };
+  if (location.state?.parentType && location.state?.parentId)
+    temporaryExtensionFormInfo.landingPage =
+      TYPE_TO_DETAIL_ROUTE[location.state?.parentType] +
+      `/${location.state?.parentId}#${DetailViewTab.EXTENSION}`;
 
   return <OneMACForm formConfig={temporaryExtensionFormInfo} />;
 };


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-20217
Endpoint: See github-actions bot comment

### Details
A list of the messages and form messages, etc will be obsolete pretty much the moment it is created.... devise an automagic form describer instead - at least for the Package View, which can change more.

### Changes
- cleaned up SOME of the error messaging in the forms 
- created "forms-describe" - a hidden page which describes package view forms
- removed all the complicated ID existence checking carried over from Submission View - Package View will have a better concept of "parentage" so should not need the ability to perform extra checks on ID existence based on format alone.

### Implementation Notes
- it would be super great if this did not exist in the application, if it could be some sort of admin tool that references the config files and supporting messaging, instead...

### Test Plan
1. Login to the Application as a System Admin User
2. Navigate to forms-describe using the URL address
3. see all the goodies!
