### PR TITLE
Oy2 20996 - remove 90th day

### DIFF
--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -229,33 +229,6 @@ const PackageList = () => {
           Filter: CustomFilterUi.MultiCheckbox,
         },
         {
-          Header: "90th Day",
-          accessor: ({ currentStatus, clockEndTimestamp }) => {
-            return Workflow.get90thDayText(currentStatus, clockEndTimestamp);
-          },
-          id: "ninetiethDay",
-          Cell: renderDate,
-          disableFilters: false,
-          filter: CustomFilterTypes.DateRangeAndMultiCheckbox,
-          Filter: CustomFilterUi.DateRangeAndMultiCheckbox,
-        },
-        tab === Workflow.PACKAGE_GROUP.WAIVER && {
-          Header: "Expiration Date",
-          accessor: ({ expirationTimestamp, componentType }) => {
-            if (!filterArray.componentType.includes(componentType)) {
-              if (expirationTimestamp) return expirationTimestamp;
-            } else {
-              return "N/A";
-            }
-            return "Pending";
-          },
-          id: "expirationTimestamp",
-          Cell: renderDate,
-          disableFilters: false,
-          filter: CustomFilterTypes.DateRange,
-          Filter: CustomFilterUi.DateRange,
-        },
-        {
           Header: "Date Submitted",
           accessor: "submissionTimestamp",
           Cell: renderDate,

--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -36,10 +36,6 @@ import { useAppContext } from "../libs/contextLib";
 import { pendingMessage, deniedOrRevokedMessage } from "../libs/userLib";
 import { tableListExportToCSV } from "../utils/tableListExportToCSV";
 
-const filterArray = {
-  componentType: [Workflow.ONEMAC_TYPE.SPA, Workflow.ONEMAC_TYPE.CHIP_SPA],
-};
-
 const renderDate = ({ value }) =>
   typeof value === "number" ? format(value, "MMM d, yyyy") : value ?? "N/A";
 

--- a/services/ui-src/src/containers/PackageList.test.js
+++ b/services/ui-src/src/containers/PackageList.test.js
@@ -3,13 +3,12 @@ import React from "react";
 import {
   render,
   screen,
-  within,
   waitForElementToBeRemoved,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 
-import { ONEMAC_ROUTES, Workflow } from "cmscommonlib";
+import { ONEMAC_ROUTES } from "cmscommonlib";
 import { AppContext } from "../libs/contextLib";
 import {
   stateSubmitterInitialAuthState,
@@ -104,7 +103,6 @@ it("renders table with spa columns", async () => {
   screen.getByText("SPA ID");
   screen.getByText("Type");
   screen.getByText("State");
-  screen.getByText("90th Day");
   screen.getByText("Date Submitted");
   screen.getByText("Submitted By");
   screen.getByText("Actions");
@@ -152,34 +150,34 @@ it("does not display waiver rais", async () => {
   ).toBeDisabled();
 });
 
-it.each`
-  filterFieldType    | filterFieldValue                      | inName                 | inValue          | textShown
-  ${"currentStatus"} | ${Workflow.ONEMAC_STATUS.WITHDRAWN}   | ${"clockEndTimestamp"} | ${null}          | ${"N/A"}
-  ${"currentStatus"} | ${Workflow.ONEMAC_STATUS.TERMINATED}  | ${"clockEndTimestamp"} | ${null}          | ${"N/A"}
-  ${"currentStatus"} | ${Workflow.ONEMAC_STATUS.UNSUBMITTED} | ${"clockEndTimestamp"} | ${null}          | ${"Pending"}
-  ${"currentStatus"} | ${Workflow.ONEMAC_STATUS.IN_REVIEW}   | ${"clockEndTimestamp"} | ${null}          | ${"Pending"}
-  ${"currentStatus"} | ${Workflow.ONEMAC_STATUS.SUBMITTED}   | ${"clockEndTimestamp"} | ${1570378876000} | ${"Pending"}
-  ${"currentStatus"} | ${Workflow.ONEMAC_STATUS.RAI_ISSUED}  | ${"clockEndTimestamp"} | ${null}          | ${"Clock Stopped"}
-`(
-  "shows $textShown in $inName when $filterFieldType is $filterFieldValue and value is $inValue",
-  async ({ filterFieldType, filterFieldValue, inName, inValue, textShown }) => {
-    const testPackage = packageList[0];
-    testPackage[filterFieldType] = filterFieldValue;
-    testPackage[inName] = inValue;
-    PackageApi.getMyPackages.mockResolvedValue([testPackage]);
+// it.each`
+//   filterFieldType    | filterFieldValue                      | inName                 | inValue          | textShown
+//   ${"currentStatus"} | ${Workflow.ONEMAC_STATUS.WITHDRAWN}   | ${"clockEndTimestamp"} | ${null}          | ${"N/A"}
+//   ${"currentStatus"} | ${Workflow.ONEMAC_STATUS.TERMINATED}  | ${"clockEndTimestamp"} | ${null}          | ${"N/A"}
+//   ${"currentStatus"} | ${Workflow.ONEMAC_STATUS.UNSUBMITTED} | ${"clockEndTimestamp"} | ${null}          | ${"Pending"}
+//   ${"currentStatus"} | ${Workflow.ONEMAC_STATUS.IN_REVIEW}   | ${"clockEndTimestamp"} | ${null}          | ${"Pending"}
+//   ${"currentStatus"} | ${Workflow.ONEMAC_STATUS.SUBMITTED}   | ${"clockEndTimestamp"} | ${1570378876000} | ${"Pending"}
+//   ${"currentStatus"} | ${Workflow.ONEMAC_STATUS.RAI_ISSUED}  | ${"clockEndTimestamp"} | ${null}          | ${"Clock Stopped"}
+// `(
+//   "shows $textShown in $inName when $filterFieldType is $filterFieldValue and value is $inValue",
+//   async ({ filterFieldType, filterFieldValue, inName, inValue, textShown }) => {
+//     const testPackage = packageList[0];
+//     testPackage[filterFieldType] = filterFieldValue;
+//     testPackage[inName] = inValue;
+//     PackageApi.getMyPackages.mockResolvedValue([testPackage]);
 
-    render(<PackageList />, { wrapper: ContextWrapper });
+//     render(<PackageList />, { wrapper: ContextWrapper });
 
-    // wait for loading screen to disappear so package table displays
-    await waitForElementToBeRemoved(() => screen.getByTestId(LOADER_TEST_ID));
+//     // wait for loading screen to disappear so package table displays
+//     await waitForElementToBeRemoved(() => screen.getByTestId(LOADER_TEST_ID));
 
-    // get the row for the status
-    const packageRow = within(
-      screen.getAllByText(filterFieldValue)[0].closest("tr")
-    );
-    expect(packageRow.getAllByText(textShown)[0]).toBeInTheDocument();
-  }
-);
+//     // get the row for the status
+//     const packageRow = within(
+//       screen.getAllByText(filterFieldValue)[0].closest("tr")
+//     );
+//     expect(packageRow.getAllByText(textShown)[0]).toBeInTheDocument();
+//   }
+// );
 /*
 it("provides option to withdraw packages", async () => {
   PackageApi.getMyPackages.mockResolvedValue(packageList);

--- a/services/ui-src/src/domain-types.ts
+++ b/services/ui-src/src/domain-types.ts
@@ -51,8 +51,6 @@ export type AppContextValue = {
 export type PackageRowValue = {
   componentId: string;
   componentType: string;
-  expirationTimestamp?: number;
-  ninetiethDay?: number;
   packageStatus: string;
   submissionTimestamp: number;
   submitter: string;

--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -1005,6 +1005,7 @@ article.form-container {
 
   @media only screen and (min-width: 1024px) {
     display: flex;
+    flex-wrap: wrap;
     min-width: min(calc(100vw - 14.4rem), 1024px);
   }
 }

--- a/services/ui-src/src/libs/detailLib.ts
+++ b/services/ui-src/src/libs/detailLib.ts
@@ -101,7 +101,7 @@ export const defaultDetail: OneMACDetail = {
     },
   ],
   actionsByStatus: Workflow.defaultActionsByStatus,
-  show90thDayInfo: true,
+  show90thDayInfo: false,
   showEffectiveDate: false,
   detailHeader: "Package",
   defaultTitle: null,


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-20996
Endpoint: See github-actions bot comment

### Details

Remove 90th day from details page
Remove 90th day and expiration date from package list

### Changes

- Removed column definitions from package list
- configured default detail config to `show90thDayInfo: false,` (if you prefer we just yank everything out altogether that is easy as well)

### Test Plan

1. Login as a statesubmitter
2. Navigate to package view and verify columns are no longer present in the grid/filter/show hide options
3. Navigate to details pages for a package in every status (since that is what used to drive the display) and verify 90th day no longer exists in the card
