### PR TITLE
OY2 21051: [Package Dashboard] Error sending submission confirmation email

### DIFF
--- a/services/app-api/email/stateSubmissionReceipt.js
+++ b/services/app-api/email/stateSubmissionReceipt.js
@@ -14,7 +14,7 @@ export const stateSubmissionReceipt = (data, config) => {
   data.attachments = {};
 
   return {
-    ToAddresses: `${data.submitterName} <${data.submitterEmail}>`,
+    ToAddresses: [`${data.submitterName} <${data.submitterEmail}>`],
     CcAddresses: [],
     Subject: `Your ${config.typeLabel} ${data.componentId} has been submitted to CMS`,
     HTML: `

--- a/services/app-api/email/stateWithdrawalReceipt.js
+++ b/services/app-api/email/stateWithdrawalReceipt.js
@@ -7,7 +7,7 @@ import { formatPackageDetails } from "./formatPackageDetails.js";
  * @returns {Object} email parameters in generic format.
  */
 export const stateWithdrawalReceipt = (data, config) => ({
-  ToAddresses: `${data.submitterName} <${data.submitterEmail}>`,
+  ToAddresses: [`${data.submitterName} <${data.submitterEmail}>`],
   Subject: `${config.typeLabel} Package ${data.componentId} Withdraw Request`,
   HTML: `
       <p>This is confirmation that you have requested to withdraw the package below. The package will no longer be considered for CMS review:</p>

--- a/services/ui-src/src/components/ComponentId.tsx
+++ b/services/ui-src/src/components/ComponentId.tsx
@@ -31,11 +31,9 @@ const ComponentId: React.FC<{
       {!disabled && (
         <>
           <div className="label-container">
-            <div>
-              <label htmlFor={idPrefix + "componentId"} className="required">
-                {idLabel}
-              </label>
-            </div>
+            <label htmlFor={idPrefix + "componentId"} className="required">
+              {idLabel}
+            </label>
             {idFAQLink && (
               <div className="label-rcol">
                 <Link target="new" href={idFAQLink}>
@@ -43,18 +41,18 @@ const ComponentId: React.FC<{
                 </Link>
               </div>
             )}
-            {idFieldHint?.map(function (idFieldHint, idx) {
-              return (
-                <p
-                  id={idPrefix + "fieldHint" + idx}
-                  key={"fieldHint" + idx}
-                  className={idFieldHint.className || "field-hint"}
-                >
-                  {idFieldHint.text}
-                </p>
-              );
-            })}
           </div>
+          {idFieldHint?.map(function (idFieldHint, idx) {
+            return (
+              <p
+                id={idPrefix + "fieldHint" + idx}
+                key={"fieldHint" + idx}
+                className={idFieldHint.className || "field-hint"}
+              >
+                {idFieldHint.text}
+              </p>
+            );
+          })}
           {statusMessages &&
             statusMessages.length > 0 &&
             statusMessages.map((message, i) => (

--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -657,6 +657,10 @@ input[type="file"] {
     margin-left: 0px;
     @extend .ds-u-align-items--end;
 
+    label {
+      min-width: 300px;
+    }
+
     .label-rcol {
       @extend .ds-u-margin-left--2;
       text-align: right;


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-21051
Endpoint: See github-actions bot comment

### Details
The state submitter receipt emails were not getting sent from Package form submissions.  The error in AWS suggested that SES was expecting an array of To Addresses and we sent a string.

### Changes
- converted the ToAddress field to an array
- tweaked the Component ID styles because Temporary Extension Number is long and SPA ID is short and they need to both look appropriate.

### Test Plan
1.Login with a submitting user who has a real email that you can access. (I have some gmail accounts expressly for this purpose, let me know if you have one you would like added to the Test Users list)
2. Navigate to Package View
3. Submit a form
4. Verify you receive the state submitter receipt for your form submission.
