### PR TITLE
OY2 21395: Incorrect title displayed on Request Waiver Temporary Extension page on Package view

### DIFF
--- a/services/ui-src/src/page/temporary-extension/TemporaryExtensionForm.tsx
+++ b/services/ui-src/src/page/temporary-extension/TemporaryExtensionForm.tsx
@@ -21,7 +21,7 @@ const idFormat: string = "SS-####.R##.TE## or SS-#####.R##.TE##";
 export const temporaryExtensionFormInfo: OneMACFormConfig = {
   ...waiverTemporaryExtension,
   ...defaultOneMACFormConfig,
-  pageTitle: "Request a Temporary Extension",
+  pageTitle: "Request 1915(b) or 1915(c) Temporary Extension",
   detailsHeader: "Temporary Extension Request",
   idFAQLink: ROUTES.FAQ_WAIVER_EXTENSION_ID,
   idFieldHint: [


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-21395
Endpoint: See github-actions bot comment

### Details
An update got lost as a result of a merge conflict that didn't completely merge.

### Changes
- Updated the page title of the Temporary Extension Form to the correct language.

### Test Plan
1. Login as a submitting user
2. Navigate to Package view, Waivers tab.
3. Click on the kebab menu of an approved waiver
4. Select Request Temporary Extension.
5. Verify title on Temp Extension form is “Request 1915(b) or 1915(c) Temporary Extension."
