### PR TITLE
send user back to correct package list tab after navigating back from…

### DIFF
--- a/services/common/type/chipSPA.js
+++ b/services/common/type/chipSPA.js
@@ -1,5 +1,6 @@
 export const chipSPA = {
   packageGroup: "spa",
+  whichTab: "spa",
   componentType: "chipspa",
   typeLabel: "CHIP SPA",
   idLabel: "SPA ID",

--- a/services/common/type/initialWaiver.js
+++ b/services/common/type/initialWaiver.js
@@ -1,5 +1,6 @@
 export const initialWaiver = {
   packageGroup: "waiver",
+  whichTab: "waiver",
   componentType: "waivernew",
   typeLabel: "1915(b) Initial Waiver",
   idLabel: "Initial Waiver Number",

--- a/services/common/type/medicaidSPA.js
+++ b/services/common/type/medicaidSPA.js
@@ -1,5 +1,6 @@
 export const medicaidSPA = {
   packageGroup: "spa",
+  whichTab: "spa",
   componentType: "medicaidspa",
   typeLabel: "Medicaid SPA",
   idLabel: "SPA ID",

--- a/services/common/type/waiverAmendment.js
+++ b/services/common/type/waiverAmendment.js
@@ -1,4 +1,5 @@
 export const waiverAmendment = {
+  whichTab: "waiver",
   componentType: "waiveramendment",
   typeLabel: "1915(b) Waiver Amendment",
   idLabel: "1915(b) Waiver Amendment Number",

--- a/services/common/type/waiverAppendixK.js
+++ b/services/common/type/waiverAppendixK.js
@@ -1,5 +1,6 @@
 export const waiverAppendixK = {
   packageGroup: "waiver",
+  whichTab: "waiver",
   componentType: "waiverappk",
   typeLabel: "1915(c) Appendix K Amendment",
   idLabel: "Waiver Amendment Number",

--- a/services/common/type/waiverRenewal.js
+++ b/services/common/type/waiverRenewal.js
@@ -1,6 +1,7 @@
 export const waiverRenewal = {
   componentType: "waiverrenewal",
   packageGroup: "waiver",
+  whichTab: "waiver",
   typeLabel: "1915(b) Waiver Renewal",
   idLabel: "1915(b) Waiver Renewal Number",
   idRegex: "^[A-Z]{2}[.-][0-9]{4,5}.R(0[1-9]|[1-9][0-9]).00$",

--- a/services/common/type/waiverTemporaryExtension.js
+++ b/services/common/type/waiverTemporaryExtension.js
@@ -1,4 +1,5 @@
 export const waiverTemporaryExtension = {
+  whichTab: "waiver",
   componentType: "waiverextension",
   typeLabel: "Waiver Extension",
   idLabel: "Temporary Extension Request Number",

--- a/services/ui-src/src/libs/detailLib.ts
+++ b/services/ui-src/src/libs/detailLib.ts
@@ -1,4 +1,5 @@
 import { Workflow } from "cmscommonlib";
+import { PackageType } from "./formLib";
 
 export type AttributeDetail = {
   heading: string;
@@ -19,7 +20,7 @@ export type OneMACDetail = {
   detailSection: AttributeDetail[];
   allowWaiverExtension: boolean;
   attachmentsHeading: string;
-};
+} & Partial<PackageType>;
 
 export const submissionDateDefault: AttributeDetail = {
   heading: "Date Submitted",

--- a/services/ui-src/src/libs/formLib.tsx
+++ b/services/ui-src/src/libs/formLib.tsx
@@ -45,6 +45,7 @@ export const defaultWaiverAuthority = [
 
 export type PackageType = {
   packageGroup?: string;
+  whichTab?: string;
   componentType: string;
   typeLabel: string;
   idLabel: string;

--- a/services/ui-src/src/page/DetailView.tsx
+++ b/services/ui-src/src/page/DetailView.tsx
@@ -75,6 +75,11 @@ const DetailView: React.FC<{ pageConfig: OneMACDetail }> = ({ pageConfig }) => {
   // The record we are using for the form.
   const [detail, setDetail] = useState<ComponentDetail>();
 
+  const goBackLink =
+    pageConfig.whichTab === "waiver"
+      ? ONEMAC_ROUTES.PACKAGE_LIST_WAIVER
+      : ONEMAC_ROUTES.PACKAGE_LIST_SPA;
+
   function closedAlert() {
     setAlertCode(RESPONSE_CODE.NONE);
   }
@@ -155,7 +160,7 @@ const DetailView: React.FC<{ pageConfig: OneMACDetail }> = ({ pageConfig }) => {
   return (
     <LoadingScreen isLoading={isLoading}>
       <PageTitleBar
-        backTo={ONEMAC_ROUTES.PACKAGE_LIST}
+        backTo={goBackLink}
         heading={detail && detail.componentId}
         enableBackNav
       />


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-21299
Endpoint: See github-actions bot comment

### Details

On package view details page, ensure the back arrow from title bar navigates back to the proper package tab on the package dashboard.

### Changes

- integrated new config var whichTab per discussion with @kristin-at-theta 
- added logic to detail page to 

### Test Plan

1. Login as a state submitter
2. Navigate to the package list dashboard spa tab 
3. Click on a spa id to go to the details page
4. Click the back arrow in the title bar of the page (not the browser back button)
5. You should be navigated back to the package dashboard on the spa tab
6. click the Waiver tab
7. Click on a waiver id to go to the details page
8. Click the back arrow in the title bar of the page (not the browser back button)
9. You should be navigated back to the package dashboard on the waiver tab
10. Repeat 7-9 for all waiver types
