### PR TITLE
oy2-21253 - update hint text for amendment, renewal, temp ext

### DIFF
--- a/services/ui-src/src/page/temporary-extension/TemporaryExtensionForm.tsx
+++ b/services/ui-src/src/page/temporary-extension/TemporaryExtensionForm.tsx
@@ -35,7 +35,7 @@ export const temporaryExtensionFormInfo: OneMACFormConfig = {
   parentLabel: "Approved Initial or Renewal Waiver Number",
   parentFieldHint: [
     {
-      text: "Please enter the initial or renewal waiver number for which you are requesting a Temporary Extension.",
+      text: "Enter the existing waiver number in the format it was approved, using a dash after the two character state abbreviation.",
     },
   ],
   parentNotFoundMessage:

--- a/services/ui-src/src/page/waiver-amendment/WaiverAmendmentForm.tsx
+++ b/services/ui-src/src/page/waiver-amendment/WaiverAmendmentForm.tsx
@@ -31,7 +31,7 @@ export const waiverAmendmentFormInfo: OneMACFormConfig = {
   parentLabel: "Existing Waiver Number to Amend",
   parentFieldHint: [
     {
-      text: "Enter the currently approved waiver number to amend.",
+      text: "Enter the existing waiver number you are seeking to amend in the format it was approved, using a dash after the two character state abbreviation.",
     },
   ],
   parentNotFoundMessage:

--- a/services/ui-src/src/page/waiver-renewal/WaiverRenewalForm.tsx
+++ b/services/ui-src/src/page/waiver-renewal/WaiverRenewalForm.tsx
@@ -25,7 +25,7 @@ export const waiverRenewalFormInfo: OneMACFormConfig = {
   parentLabel: "Existing Waiver Number to Renew",
   parentFieldHint: [
     {
-      text: "Enter the currently approved waiver number to renew.",
+      text: "Enter the existing waiver number in the format it was approved, using a dash after the two character state abbreviation.",
     },
   ],
   parentNotFoundMessage:

--- a/tests/cypress/cypress/integration/Package_Dashboard_Waiver_Renewal.spec.feature
+++ b/tests/cypress/cypress/integration/Package_Dashboard_Waiver_Renewal.spec.feature
@@ -15,6 +15,7 @@ Feature: Waiver Renewal in Package Dashboard
     Scenario: Existing Waiver Number Input Field format
         And click on Waiver Renewal
         And Click on 1915 b 4 FFS Selective Contracting waivers under Waiver Authority
+        And verify help text under Existing Waiver Number to Renew field
         And type bad format into Existing Waiver Number to Renew field
         And type new waiver renewal number 2 in 1915b Waiver Renewal Number field
         And select proposed effective date 3 months from today

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -2883,3 +2883,7 @@ And("type Appendix K Submission 1 into Amendment Title field", () => {
 And("verify id number in the first row matches Appendix K number", () => {
   OneMacPackagePage.verifyIDNumberInFirstRowIs("MD-10330.R00.12");
 });
+
+And("verify help text under Existing Waiver Number to Renew field", () => {
+  OneMacSubmitNewWaiverActionPage.verifyParentFieldHelpText();
+});

--- a/tests/cypress/support/pages/oneMacSubmitNewWaiverActionPage.js
+++ b/tests/cypress/support/pages/oneMacSubmitNewWaiverActionPage.js
@@ -17,6 +17,7 @@ const parentIDInputBox = "#parent-componentId";
 const parentErrMsgForWaiverNumber = "#parent-componentIdStatusMsg0";
 const parentIDLabel =
   "//h3[text()='Approved Initial or Renewal Waiver Number']";
+const parentIDHelpText = "#parent-fieldHint0";
 
 export class oneMacSubmitNewWaiverActionPage {
   inputWaiverNumberNewForms(s) {
@@ -125,6 +126,11 @@ export class oneMacSubmitNewWaiverActionPage {
   }
   clearWaiverParentNumber() {
     cy.get(parentIDInputBox).clear();
+  }
+  verifyParentFieldHelpText() {
+    cy.get(parentIDHelpText).contains(
+      "Enter the existing waiver number in the format it was approved, using a dash after the two character state abbreviation"
+    );
   }
 }
 export default oneMacSubmitNewWaiverActionPage;


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-21253
Endpoint: See github-actions bot comment

### Details

Update the hint text on the parent entry id for Waivers (Amendment, Renewal, Temporary Extensions)

### Changes

- updated hint text values in respective form configs

### Test Plan

1. Login as state submitter
2. Navigate to package view and click New Submission
3. Select Waiver Action -> select one of "1915(b) Waiver Renewal", "1915(b) Waiver Amendment", or "Request Temporary Extension"
4. Enter random characters into the parent id field and verify the text matches the AC
