### PR TITLE
Oy2 21563

### DIFF
--- a/services/app-api/action/changeStatusAny.js
+++ b/services/app-api/action/changeStatusAny.js
@@ -14,8 +14,9 @@ export const changeStatusAny = async (event, config) => {
     throw error;
   }
 
+  let user;
   try {
-    const user = await getUser(body.changedByEmail);
+    user = await getUser(body.changedByEmail);
     if (!validateUserSubmitting(user, body.componentId.substring(0, 2))) {
       return RESPONSE_CODE.USER_NOT_AUTHORIZED;
     }
@@ -43,7 +44,7 @@ export const changeStatusAny = async (event, config) => {
   try {
     const theEmails = await Promise.all(
       config.emailFunctions.map(
-        async (f) => await f(updatedPackageData, config)
+        async (f) => await f(updatedPackageData, config, user)
       )
     );
     console.log("the Emails: ", theEmails);

--- a/services/app-api/email/CMSWithdrawalNotice.js
+++ b/services/app-api/email/CMSWithdrawalNotice.js
@@ -15,9 +15,8 @@ export const CMSWithdrawalNotice = (data, config, user) => ({
   HTML: `
       <p>The OneMAC submission portal received a request to withdraw a package. You are receiving this email notification as ${
         data.componentId
-      } was withdrawn by ${user.fullName} and ${
-    user.email
-  }. The package will no longer be considered for CMS review.</p>
+      } was withdrawn by ${user.fullName} (${user.email}). 
+      The package will no longer be considered for CMS review.</p>
       ${formatPackageDetails(data, config)}
       <p>Thank you!</p>
     `,

--- a/services/app-api/email/CMSWithdrawalNotice.js
+++ b/services/app-api/email/CMSWithdrawalNotice.js
@@ -5,7 +5,7 @@ import { formatPackageDetails } from "./formatPackageDetails.js";
  * @param {Object} data from the package.
  * @returns {Object} email parameters in generic format.
  */
-export const CMSWithdrawalNotice = (data, config) => ({
+export const CMSWithdrawalNotice = (data, config, user) => ({
   ToAddresses: [process.env.reviewerEmail],
   CcAddresses:
     data.componentType === "chipspa" || data.componentType === "chipsparai"
@@ -13,7 +13,11 @@ export const CMSWithdrawalNotice = (data, config) => ({
       : [],
   Subject: `${config.typeLabel} Package ${data.componentId} Withdraw Request`,
   HTML: `
-      <p>The OneMAC Submission Portal received a request to withdraw the package below. The package will no longer be considered for CMS review:</p>
+      <p>The OneMAC submission portal received a request to withdraw a package. You are receiving this email notification as ${
+        data.componentId
+      } was withdrawn by ${user.fullName} and ${
+    user.email
+  }. The package will no longer be considered for CMS review.</p>
       ${formatPackageDetails(data, config)}
       <p>Thank you!</p>
     `,

--- a/services/app-api/email/CMSWithdrawalNotice.test.js
+++ b/services/app-api/email/CMSWithdrawalNotice.test.js
@@ -13,6 +13,11 @@ it("builds the CMS Withdrawal Notice Email", async () => {
     typeLabel: "Test Type",
   };
 
-  const response2 = CMSWithdrawalNotice(testData, testConfig);
+  const user = {
+    fullName: "Tester",
+    email: "tester@test.test",
+  };
+
+  const response2 = CMSWithdrawalNotice(testData, testConfig, user);
   expect(response2.HTML.length).toBe(402);
 });

--- a/services/app-api/email/CMSWithdrawalNotice.test.js
+++ b/services/app-api/email/CMSWithdrawalNotice.test.js
@@ -19,5 +19,5 @@ it("builds the CMS Withdrawal Notice Email", async () => {
   };
 
   const response2 = CMSWithdrawalNotice(testData, testConfig, user);
-  expect(response2.HTML.length).toBe(499);
+  expect(response2.HTML.length).toBe(504);
 });

--- a/services/app-api/email/CMSWithdrawalNotice.test.js
+++ b/services/app-api/email/CMSWithdrawalNotice.test.js
@@ -19,5 +19,5 @@ it("builds the CMS Withdrawal Notice Email", async () => {
   };
 
   const response2 = CMSWithdrawalNotice(testData, testConfig, user);
-  expect(response2.HTML.length).toBe(402);
+  expect(response2.HTML.length).toBe(499);
 });

--- a/services/app-api/email/stateWithdrawalReceipt.js
+++ b/services/app-api/email/stateWithdrawalReceipt.js
@@ -54,9 +54,9 @@ export const stateWithdrawalReceipt = async (data, config, user) => {
     HTML: `
         <p>The OneMAC submission portal received a request to withdraw a package. You are receiving this email notification as ${
           data.componentId
-        } was withdrawn by ${user.fullName} and ${
+        } was withdrawn by ${user.fullName} (${
       user.email
-    }. The package will no longer be considered for CMS review.</p>
+    }). The package will no longer be considered for CMS review.</p>
         ${formatPackageDetails(data, config)}
         <p>Thank you!</p>
         `,

--- a/services/app-api/email/stateWithdrawalReceipt.js
+++ b/services/app-api/email/stateWithdrawalReceipt.js
@@ -46,13 +46,17 @@ export const getAllActiveStateUserEmailAddresses = async (territory) => {
  * @param {Object} config for the package.
  * @returns {Object} email parameters in generic format.
  */
-export const stateWithdrawalReceipt = async (data, config) => {
+export const stateWithdrawalReceipt = async (data, config, user) => {
   const stateReceipt = {
     ToAddresses: [],
     CcAddresses: [],
     Subject: `${config.typeLabel} Package ${data.componentId} Withdraw Request`,
     HTML: `
-        <p>This is confirmation that you have requested to withdraw the package below. The package will no longer be considered for CMS review:</p>
+        <p>The OneMAC submission portal received a request to withdraw a package. You are receiving this email notification as ${
+          data.componentId
+        } was withdrawn by ${user.fullName} and ${
+      user.email
+    }. The package will no longer be considered for CMS review.</p>
         ${formatPackageDetails(data, config)}
         <p>Thank you!</p>
         `,

--- a/services/app-api/email/stateWithdrawalReceipt.test.js
+++ b/services/app-api/email/stateWithdrawalReceipt.test.js
@@ -24,10 +24,14 @@ const testData = {
 const testConfig = {
   typeLabel: "Test Type",
 };
+const user = {
+  fullName: "Tester",
+  email: "tester@test.test",
+};
 
 it("builds the State Withdrawal Receipt Email", async () => {
   try {
-    const response = await stateWithdrawalReceipt(testData, testConfig);
+    const response = await stateWithdrawalReceipt(testData, testConfig, user);
     expect(response.HTML.length).toBe(409);
   } catch (e) {
     console.log("reeived error: ", e);
@@ -42,7 +46,7 @@ it("handles a query exception", async () => {
     expect(await getAllActiveStateUserEmailAddresses("TT")).toThrow(
       "this is an error"
     );
-    const response = await stateWithdrawalReceipt(testData, testConfig);
+    const response = await stateWithdrawalReceipt(testData, testConfig, user);
     expect(response.ToAddresses.length).toBe(0);
   } catch (e) {
     console.log("reeived error: ", e);

--- a/services/app-api/email/stateWithdrawalReceipt.test.js
+++ b/services/app-api/email/stateWithdrawalReceipt.test.js
@@ -32,7 +32,7 @@ const user = {
 it("builds the State Withdrawal Receipt Email", async () => {
   try {
     const response = await stateWithdrawalReceipt(testData, testConfig, user);
-    expect(response.HTML.length).toBe(409);
+    expect(response.HTML.length).toBe(418);
   } catch (e) {
     console.log("reeived error: ", e);
   }

--- a/services/app-api/utils/changeUserStatus.js
+++ b/services/app-api/utils/changeUserStatus.js
@@ -64,7 +64,7 @@ export const changeUserStatus = async ({
         ":date": date,
         ":GSI1pk": "USER",
         ":GSI1sk": buildSK(role, territory),
-        ":GSI2pk": buildSK(role, territory),
+        ":GSI2pk": `${role}#${territory}`,
         ":GSI2sk": status,
         ":defaultval": 0,
         ":incrval": 1,


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-21563
Endpoint: See github-actions bot comment

### Details

Add user who did withdrawl to emails.

### Changes

- Pass in user already retrieved for security into the email functions.

### Test Plan

1. Login as a statesubmitter
2. Navigate to package view and find a package which the current user did not submit
3. Withdraw the package (from the three dots action bar)
4. Verify the logged in user appears in the email for both state and CMS
