### PR TITLE
BUG FIX: RAI response forms need to Validate Parents

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -251,6 +251,46 @@ functions:
           cors: true
           authorizer: aws_iam
 
+  validateParentOfMedicaidSpaRaiResponse:
+    handler: validation/validateParentOfMedicaidSpaRaiResponse.main
+    role: LambdaApiRole
+    events:
+      - http:
+          path: validateParentOfMedicaidSpaRaiResponse/{parentId}
+          method: get
+          cors: true
+          authorizer: aws_iam
+
+  validateParentOfChipSpaRaiResponse:
+    handler: validation/validateParentOfChipSpaRaiResponse.main
+    role: LambdaApiRole
+    events:
+      - http:
+          path: validateParentOfChipSpaRaiResponse/{parentId}
+          method: get
+          cors: true
+          authorizer: aws_iam
+
+  validateParentOfWaiverRaiResponse:
+    handler: validation/validateParentOfWaiverRaiResponse.main
+    role: LambdaApiRole
+    events:
+      - http:
+          path: validateParentOfWaiverRaiResponse/{parentId}
+          method: get
+          cors: true
+          authorizer: aws_iam
+
+  validateParentOfWaiverAppendixKRaiResponse:
+    handler: validation/validateParentOfWaiverAppendixKRaiResponse.main
+    role: LambdaApiRole
+    events:
+      - http:
+          path: validateParentOfWaiverAppendixKRaiResponse/{parentId}
+          method: get
+          cors: true
+          authorizer: aws_iam
+
   withdrawInitialWaiver:
     handler: action/withdrawInitialWaiver.main
     role: LambdaApiRole

--- a/services/app-api/validation/validateParentOfChipSpaRaiResponse.js
+++ b/services/app-api/validation/validateParentOfChipSpaRaiResponse.js
@@ -1,0 +1,12 @@
+import handler from "../libs/handler-lib";
+import { validateParentOfAny } from "./validateParentOfAny";
+import { chipSPARAIResponse } from "cmscommonlib";
+
+export const main = handler(async (event) => {
+  try {
+    return validateParentOfAny(event, chipSPARAIResponse);
+  } catch (error) {
+    console.log("Exception: ", error);
+    throw error;
+  }
+});

--- a/services/app-api/validation/validateParentOfMedicaidSpaRaiResponse.js
+++ b/services/app-api/validation/validateParentOfMedicaidSpaRaiResponse.js
@@ -1,0 +1,12 @@
+import handler from "../libs/handler-lib";
+import { validateParentOfAny } from "./validateParentOfAny";
+import { medicaidSPARAIResponse } from "cmscommonlib";
+
+export const main = handler(async (event) => {
+  try {
+    return validateParentOfAny(event, medicaidSPARAIResponse);
+  } catch (error) {
+    console.log("Exception: ", error);
+    throw error;
+  }
+});

--- a/services/app-api/validation/validateParentOfWaiverAppendixKRaiResponse.js
+++ b/services/app-api/validation/validateParentOfWaiverAppendixKRaiResponse.js
@@ -1,0 +1,12 @@
+import handler from "../libs/handler-lib";
+import { validateParentOfAny } from "./validateParentOfAny";
+import { waiverAppendixKRAIResponse } from "cmscommonlib";
+
+export const main = handler(async (event) => {
+  try {
+    return validateParentOfAny(event, waiverAppendixKRAIResponse);
+  } catch (error) {
+    console.log("Exception: ", error);
+    throw error;
+  }
+});

--- a/services/app-api/validation/validateParentOfWaiverRaiResponse.js
+++ b/services/app-api/validation/validateParentOfWaiverRaiResponse.js
@@ -1,0 +1,12 @@
+import handler from "../libs/handler-lib";
+import { validateParentOfAny } from "./validateParentOfAny";
+import { waiverRAIResponse } from "cmscommonlib";
+
+export const main = handler(async (event) => {
+  try {
+    return validateParentOfAny(event, waiverRAIResponse);
+  } catch (error) {
+    console.log("Exception: ", error);
+    throw error;
+  }
+});

--- a/services/common/type/chipSPARAIResponse.js
+++ b/services/common/type/chipSPARAIResponse.js
@@ -16,4 +16,6 @@ export const chipSPARAIResponse = {
     "Tribal Consultation",
     "Other",
   ],
+  allowedParentTypes: ["chipspa"],
+  allowedParentStatuses: ["RAI Issued"],
 };

--- a/services/common/type/medicaidSPARAIResponse.js
+++ b/services/common/type/medicaidSPARAIResponse.js
@@ -8,4 +8,6 @@ export const medicaidSPARAIResponse = {
   allowMultiplesWithSameId: true, // Medicaid SPA RAI can only have one but until business decides how to handle we will allow multiple
   requiredAttachments: ["RAI Response"],
   optionalAttachments: ["Other"],
+  allowedParentTypes: ["medicaidspa"],
+  allowedParentStatuses: ["RAI Issued"],
 };

--- a/services/common/type/waiverRAIResponse.js
+++ b/services/common/type/waiverRAIResponse.js
@@ -8,4 +8,6 @@ export const waiverRAIResponse = {
   allowMultiplesWithSameId: true,
   requiredAttachments: ["Waiver RAI Response"],
   optionalAttachments: ["Other"],
+  allowedParentTypes: ["waivernew", "waiverrenewal", "waiveramendment"],
+  allowedParentStatuses: ["RAI Issued"],
 };

--- a/services/ui-src/src/page/OneMACForm.tsx
+++ b/services/ui-src/src/page/OneMACForm.tsx
@@ -190,6 +190,7 @@ const OneMACForm: React.FC<{ formConfig: OneMACFormConfig }> = ({
     const checkId = async () => {
       try {
         const parentStatusMessages: Message[] = [];
+        console.log("validateParentAPI is: %s", formConfig.validateParentAPI);
         if (!!oneMacFormData.parentId) {
           const isParentIdValid = await PackageApi.validateParent(
             oneMacFormData.parentId,

--- a/services/ui-src/src/page/chip-spa/CHIPSPARAIForm.tsx
+++ b/services/ui-src/src/page/chip-spa/CHIPSPARAIForm.tsx
@@ -25,6 +25,7 @@ export const chipSPARAIFormInfo: OneMACFormConfig = {
       </p>
     ),
   },
+  validateParentAPI: "validateParentOfChipSpaRaiResponse",
 };
 
 const CHIPSPARAIForm: FC = () => {

--- a/services/ui-src/src/page/medicaid-spa/MedicaidSPARAIForm.tsx
+++ b/services/ui-src/src/page/medicaid-spa/MedicaidSPARAIForm.tsx
@@ -16,6 +16,7 @@ export const medicaidSPARAIFormInfo: OneMACFormConfig = {
   detailsHeader: "Medicaid SPA RAI",
   landingPage: ONEMAC_ROUTES.MEDICAID_SPA_DETAIL,
   confirmSubmit: defaultConfirmSubmitRAI,
+  validateParentAPI: "validateParentOfMedicaidSpaRaiResponse",
 };
 
 const MedicaidSPARAIForm: FC = () => {

--- a/services/ui-src/src/page/waiver-appendix-k/WaiverAppendixKRAIForm.tsx
+++ b/services/ui-src/src/page/waiver-appendix-k/WaiverAppendixKRAIForm.tsx
@@ -14,6 +14,7 @@ export const waiverAppendixKRAIFormInfo: OneMACFormConfig = {
   detailsHeader: "1915(c) Appendix K RAI Response",
   landingPage: ONEMAC_ROUTES.PACKAGE_LIST_WAIVER,
   confirmSubmit: defaultConfirmSubmitRAI,
+  validateParentAPI: "validateParentOfWaiverAppendixKRaiResponse",
 };
 
 const WaiverAppendixKRAIForm: FC = () => {

--- a/services/ui-src/src/page/waiver-rai/WaiverRAIForm.tsx
+++ b/services/ui-src/src/page/waiver-rai/WaiverRAIForm.tsx
@@ -14,6 +14,7 @@ export const waiverRAIFormInfo: OneMACFormConfig = {
   detailsHeader: "1915(b) Waiver RAI Response",
   landingPage: ONEMAC_ROUTES.PACKAGE_LIST_WAIVER,
   confirmSubmit: defaultConfirmSubmitRAI,
+  validateParentAPI: "validateParentOfWaiverRaiResponse",
 };
 
 const WaiverRAIForm: FC = () => {


### PR DESCRIPTION
Story: no story, discovered while migrating data
Endpoint: See github-actions bot comment

### Details
The RAI Response forms have parent IDs, but there was no parent validation.  This was causing an error to be reported to the console (though it isn't really all that big of a deal) In any case... For concurrency sake, we should actually check that the parent ID remains in the RAI Issued status.

### Changes
- added parent ID validation to all RAI Response forms
- Required status is "RAI Issued"

### Test Plan
1. Log in as a submitting user
2. Submit one of each RAI Responses while "inspecting" the console
3. Verify the RAI Responses can be submitted and there are no errors in the console
