### PR TITLE
amendment details test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -210,6 +210,7 @@ jobs:
             Package_Dashboard_Medicaid_SPA_Form.spec.feature,
             CMS_Read_Only_View.spec.feature,
             Package_Dashboard_Appendix_K.spec.feature,
+            Package_Dashboard_Amendment_Details.spec.feature,
             Package_Dashboard_Waiver_Amendment.spec.feature,
             Package_Dashboard_Waiver_Renewal.spec.feature,
             Package_Dashboard_CHIP_SPA_RAI_Response.spec.feature,

--- a/tests/cypress/cypress/integration/Package_Dashboard_Amendment_Details.spec.feature
+++ b/tests/cypress/cypress/integration/Package_Dashboard_Amendment_Details.spec.feature
@@ -9,7 +9,7 @@ Feature: Amendment details
         And click on Type
         And uncheck all of the type checkboxes
 
-    Scenario: Screen Enhance: Initial Waiver Details View - Submitted
+    Scenario: Screen Enhance: 1915 b Waiver Amendment Details View - Submitted
         And click 1915b Waiver Amendment check box
         And click on Type
         And click on Status

--- a/tests/cypress/cypress/integration/Package_Dashboard_Amendment_Details.spec.feature
+++ b/tests/cypress/cypress/integration/Package_Dashboard_Amendment_Details.spec.feature
@@ -1,174 +1,34 @@
-# Feature: OY2-15971 Updated Waiver read-only form: Amendment details
-#     Background: Reoccuring Steps
-#         Given I am on Login Page
-#         When Clicking on Development Login
-#         When Login with state submitter user
-#         And click on Packages
-#         Then click on New Submission
-#         And Click on Waiver Action
-#         And click on Initial Waiver
-#         And Click on 1915 b 4 FFS Selective Contracting waivers under Waiver Authority
-#         And Type Unique Valid Initial Waiver Number With SS-#####.R00.00 format
-#         And select proposed effective date 3 months from today
-#         And Upload 1915 b 4 file
-#         And Type "This is just a test" in Summary Box
-#         And Click on Submit Button
-#         And verify submission Successful message
-#         And Return to dashboard Page
-#         # do previous step until new Waiver Amendment form is done
-#         And click on New Submission
-#         And Click on Waiver Action
+Feature: Amendment details
+    Background: Reoccuring Steps
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And click on the Waivers tab
+        And Click on Filter Button
+        And click on Type
+        And uncheck all of the type checkboxes
 
-#     Scenario: Verify Amendment Details page - submitted
-#         And Click on Waiver Action under Waiver Type
-#         And Click on Waiver Amendment under Action type
-#         And Click on 1915 b 4 FFS Selective Contracting waivers under Waiver Authority
-#         And Type Unique Valid Waiver Amendment Number With 5 Characters
-#         And Upload 1915 b 4 file
-#         And Type "This is just another test" in Summary Box
-#         And Click on Submit Button
-#         And verify submission Successful message
-#         And click on Packages
-#         And click on the Waivers tab
-#         And search for Initial Waiver Number 1 with 12 Characters
-#         And wait for parent row expander to be enabled
-#         And click parent row expander
-#         And click the Waiver Number link for the Amendment
-#         And verify the package details page is visible
-#         And verify action card exists
-#         And verify the status on the card is "Submitted"
-#         And verify package actions header is visible
-#         And verify withdraw package action exists
-#         And verify 90th day header exists
-#         And verify 90th day header is NA
-#         And verify the amendment details section exists
-#         And verify the Amendment Number header exists
-#         And verify the amendment number matches
-#         And verify the amendment title header exists
-#         And verify the amendment title is NA
-#         And verify the waiver authority header exists
-#         And verify the supporting documentation section exists
-#         And verify the download all button exists
-#         And verify the additional information section exists
-
-#     Scenario: Verify Amendment Details page - withdrawn
-#         And Click on Waiver Action under Waiver Type
-#         And Click on Waiver Amendment under Action type
-#         And Click on 1915 b 4 FFS Selective Contracting waivers under Waiver Authority
-#         And Type Unique Valid Waiver Amendment Number With 5 Characters
-#         And Upload 1915 b 4 file
-#         And Type "This is just another test" in Summary Box
-#         And Click on Submit Button
-#         And verify submission Successful message
-#         And click on Packages
-#         And click on the Waivers tab
-#         And search for Initial Waiver Number 1 with 12 Characters
-#         And wait for parent row expander to be enabled
-#         And click parent row expander
-#         And click the Waiver Number link for the Amendment
-#         And verify the package details page is visible
-#         And click withdraw button
-#         And click withdraw confirmation
-#         And verify submission message for withdrawn amendment
-#         And verify the status on the card is "Withdrawn"
-#         And verify package actions header is visible
-#         And verify there are no package actions available
-#         And verify 90th day header exists
-#         And verify 90th day header is NA
-#         And verify the amendment details section exists
-#         And verify the Amendment Number header exists
-#         And verify the amendment number matches
-#         And verify the amendment title header exists
-#         And verify the amendment title is NA
-#         And verify the waiver authority header exists
-#         And verify the supporting documentation section exists
-#         And verify the download all button exists
-#         And verify the additional information section exists
-
-
-# OLD way
-# Feature: OY2-15971 Updated Waiver read-only form: Amendment details
-#     Background: Reoccuring Steps
-#         Given I am on Login Page
-#         When Clicking on Development Login
-#         When Login with state submitter user
-#         Then click on New Submission
-#         And Click on Waiver Action
-#         And Click on Waiver Action under Waiver Type
-#         And Click on New Waiver under Action type
-#         And Click on 1915 b 4 FFS Selective Contracting waivers under Waiver Authority
-#         And Type Unique Valid Waiver Number With 5 Characters
-#         And Upload 1915 b 4 file
-#         And Type "This is just a test" in Summary Box
-#         And Click on Submit Button
-#         And Return to dashboard Page
-#         #And click on Packages (until new Waiver Amendment form is done)
-#         And click on New Submission
-#         And Click on Waiver Action
-
-
-#     Scenario: Verify Amendment Details page - submitted
-#         And Click on Waiver Action under Waiver Type
-#         And Click on Waiver Amendment under Action type
-#         And Click on 1915 b 4 FFS Selective Contracting waivers under Waiver Authority
-#         And Type Unique Valid Waiver Amendment Number With 5 Characters
-#         And Upload 1915 b 4 file
-#         And Type "This is just another test" in Summary Box
-#         And Click on Submit Button
-#         And verify submission Successful message
-#         And click on Packages
-#         And click on the Waivers tab
-#         And search for Unique Valid Waiver Number with 5 Characters
-#         And wait for parent row expander to be enabled
-#         And click parent row expander
-#         And click the Waiver Number link for the Amendment
-#         And verify the package details page is visible
-#         And verify action card exists
-#         And verify the status on the card is "Submitted"
-#         And verify package actions header is visible
-#         And verify withdraw package action exists
-#         And verify 90th day header exists
-#         And verify 90th day header is NA
-#         And verify the amendment details section exists
-#         And verify the Amendment Number header exists
-#         And verify the amendment number matches
-#         And verify the amendment title header exists
-#         And verify the amendment title is NA
-#         And verify the waiver authority header exists
-#         And verify the supporting documentation section exists
-#         And verify the download all button exists
-#         And verify the additional information section exists
-
-#     Scenario: Verify Amendment Details page - withdrawn
-#         And Click on Waiver Action under Waiver Type
-#         And Click on Waiver Amendment under Action type
-#         And Click on 1915 b 4 FFS Selective Contracting waivers under Waiver Authority
-#         And Type Unique Valid Waiver Amendment Number With 5 Characters
-#         And Upload 1915 b 4 file
-#         And Type "This is just another test" in Summary Box
-#         And Click on Submit Button
-#         And verify submission Successful message
-#         And click on Packages
-#         And click on the Waivers tab
-#         And search for Unique Valid Waiver Number with 5 Characters
-#         And wait for parent row expander to be enabled
-#         And click parent row expander
-#         And click the Waiver Number link for the Amendment
-#         And verify the package details page is visible
-#         And click withdraw button
-#         And click withdraw confirmation
-#         And verify submission message for withdrawn amendment
-#         And verify the status on the card is "Withdrawn"
-#         And verify package actions header is visible
-#         And verify there are no package actions available
-#         And verify 90th day header exists
-#         And verify 90th day header is NA
-#         And verify the amendment details section exists
-#         And verify the Amendment Number header exists
-#         And verify the amendment number matches
-#         And verify the amendment title header exists
-#         And verify the amendment title is NA
-#         And verify the waiver authority header exists
-#         And verify the supporting documentation section exists
-#         And verify the download all button exists
-#         And verify the additional information section exists
+    Scenario: Screen Enhance: Initial Waiver Details View - Submitted
+        And click 1915b Waiver Amendment check box
+        And click on Type
+        And click on Status
+        And uncheck all of the status checkboxes
+        And click Submitted checkbox
+        And click the Waiver Number link in the first row
+        And verify the package details page is visible
+        And verify action card exists
+        And verify the status on the card is "Submitted"
+        And verify package actions header is visible
+        And verify withdraw package action exists
+        And verify the details section exists
+        And verify there is a Type header in the details section
+        And verify the type is 1915b Waiver Amendment
+        And verify there is a State header in the details section
+        And verify a state exists for the State
+        And verify there is an Initial Submission Date header in the details section
+        And verify a date exists for the Initial Submission Date
+        And verify there is a Proposed Effective Date header in the details section
+        And verify the supporting documentation section exists
+        And verify the download all button exists
+        And verify the additional information section exists

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -1513,6 +1513,9 @@ And("click 1915b Waiver Renewal check box", () => {
 And("click 1915c Appendix K Amendment check box", () => {
   OneMacPackagePage.click1915cAppendixKAmendmentCheckBox();
 });
+And("click 1915b Waiver Amendment check box", () => {
+  OneMacPackagePage.click1915bWaiverAmendmentCheckBox();
+});
 And("click CHIP SPA check box", () => {
   OneMacPackagePage.clickCHIPSPACheckBox();
 });
@@ -2156,6 +2159,9 @@ And("verify the type is Waiver Renewal", () => {
 });
 And("verify the type is 1915b Temporary Extension", () => {
   OneMacPackageDetailsPage.verifyTypeContainsTempExtension();
+});
+And("verify the type is 1915b Waiver Amendment", () => {
+  OneMacPackageDetailsPage.verifyTypeContains1915bWaiverAmendment();
 });
 And(
   "verify there is a Approved Initial or Renewal Number header in the details section",

--- a/tests/cypress/support/pages/oneMacPackageDetailsPage.js
+++ b/tests/cypress/support/pages/oneMacPackageDetailsPage.js
@@ -121,6 +121,9 @@ export class oneMacPackageDetailsPage {
   verifyTypeContainsTempExtension() {
     cy.xpath(typeHeader).next().contains("Temporary Extension");
   }
+  verifyTypeContains1915bWaiverAmendment() {
+    cy.xpath(typeHeader).next().contains("1915(b) Waiver Amendment");
+  }
   verifyParentWaiverNumberHeaderExists() {
     cy.xpath(parentWaiverNumberHeader).should("be.visible");
   }

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -82,6 +82,8 @@ const waiverRenewal1915bCheckBox =
   "//label[contains(@for,'checkbox_componentType-1915(b) Waiver Renewal')]";
 const appendixKAmendmentCheckBox =
   "//label[contains(@for,'checkbox_componentType-1915(c) Appendix K Amendment')]";
+const waiverAmmendment1915bCheckbox =
+  "//label[contains(@for,'checkbox_componentType-1915(b) Waiver Amendment')]";
 //Element is Xpath use cy.xpath instead of cy.get
 const CHIPSPACheckBox =
   "//label[contains(@for,'checkbox_componentType-CHIP SPA')]";
@@ -451,6 +453,9 @@ export class oneMacPackagePage {
   }
   click1915cAppendixKAmendmentCheckBox() {
     cy.xpath(appendixKAmendmentCheckBox).click();
+  }
+  click1915bWaiverAmendmentCheckBox() {
+    cy.xpath(waiverAmmendment1915bCheckbox).click();
   }
   clickCHIPSPACheckBox() {
     cy.xpath(CHIPSPACheckBox).click();

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -82,7 +82,7 @@ const waiverRenewal1915bCheckBox =
   "//label[contains(@for,'checkbox_componentType-1915(b) Waiver Renewal')]";
 const appendixKAmendmentCheckBox =
   "//label[contains(@for,'checkbox_componentType-1915(c) Appendix K Amendment')]";
-const waiverAmmendment1915bCheckbox =
+const waiverAmendment1915bCheckbox =
   "//label[contains(@for,'checkbox_componentType-1915(b) Waiver Amendment')]";
 //Element is Xpath use cy.xpath instead of cy.get
 const CHIPSPACheckBox =
@@ -455,7 +455,7 @@ export class oneMacPackagePage {
     cy.xpath(appendixKAmendmentCheckBox).click();
   }
   click1915bWaiverAmendmentCheckBox() {
-    cy.xpath(waiverAmmendment1915bCheckbox).click();
+    cy.xpath(waiverAmendment1915bCheckbox).click();
   }
   clickCHIPSPACheckBox() {
     cy.xpath(CHIPSPACheckBox).click();


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-22026
Endpoint: See github-actions bot comment


### Test Plan

```
Feature: Amendment details
    Background: Reoccuring Steps
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And click on the Waivers tab
        And Click on Filter Button
        And click on Type
        And uncheck all of the type checkboxes

    Scenario: Screen Enhance: Initial Waiver Details View - Submitted
        And click 1915b Waiver Amendment check box
        And click on Type
        And click on Status
        And uncheck all of the status checkboxes
        And click Submitted checkbox
        And click the Waiver Number link in the first row
        And verify the package details page is visible
        And verify action card exists
        And verify the status on the card is "Submitted"
        And verify package actions header is visible
        And verify withdraw package action exists
        And verify the details section exists
        And verify there is a Type header in the details section
        And verify the type is 1915b Waiver Amendment
        And verify there is a State header in the details section
        And verify a state exists for the State
        And verify there is an Initial Submission Date header in the details section
        And verify a date exists for the Initial Submission Date
        And verify there is a Proposed Effective Date header in the details section
        And verify the supporting documentation section exists
        And verify the download all button exists
        And verify the additional information section exists
```
