### PR TITLE
OY2-22019tests

### DIFF
--- a/tests/cypress/cypress/integration/Mini_Dashboard_Package_Details_Waivers.spec.feature
+++ b/tests/cypress/cypress/integration/Mini_Dashboard_Package_Details_Waivers.spec.feature
@@ -93,8 +93,11 @@ Feature: OY2-11585 Waiver Package Details View: Initial Waivers and Waiver Renew
         And verify action card exists
         And verify the status on the card is "Submitted"
         And verify package actions header is visible
-        And verify withdraw package action exists
+        And verify there are no package actions available
         And verify the details section exists
+        And verify the title contains "Waiver Renewal Package"
+        And verify there is a Type header in the details section
+        And verify the type is Waiver Renewal
         And verify there is a State header in the details section
         And verify a state exists for the State
         And verify there is an Initial Submission Date header in the details section
@@ -118,6 +121,9 @@ Feature: OY2-11585 Waiver Package Details View: Initial Waivers and Waiver Renew
         And verify Add Amendment package action exists
         And verify Request a Temporary Extension package action exists
         And verify the details section exists
+        And verify the title contains "Waiver Renewal Package"
+        And verify there is a Type header in the details section
+        And verify the type is Waiver Renewal
         And verify there is a State header in the details section
         And verify a state exists for the State
         And verify there is an Initial Submission Date header in the details section

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -2139,6 +2139,9 @@ And("click on Respond to RAI package action", () => {
 And("verify the details section exists", () => {
   OneMacPackageDetailsPage.verifyDetailSectionExists();
 });
+And("verify the title contains {string}", (string) => {
+  OneMacPackageDetailsPage.verifyTitleContains(string);
+});
 And("verify there is a SPA ID header in the details section", () => {
   OneMacPackageDetailsPage.verifyCHIPSPAIDHeaderExists();
 });

--- a/tests/cypress/support/pages/oneMacPackageDetailsPage.js
+++ b/tests/cypress/support/pages/oneMacPackageDetailsPage.js
@@ -100,6 +100,9 @@ export class oneMacPackageDetailsPage {
   verifyDetailSectionExists() {
     cy.xpath(detailSection).should("be.visible");
   }
+  verifyTitleContains(s) {
+    cy.get("h2").first().contains(s);
+  }
   verifyCHIPSPAIDHeaderExists() {
     cy.xpath(CHIPSPAIDHeader).should("be.visible");
   }


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-22019
Endpoint: See github-actions bot comment


Test updated.

### Test Plan

```
    Scenario: Screen Enhance: Waiver Renewals Details View - Submitted
        And click 1915b Waiver Renewal check box
        And click on Type
        And click on Status
        And uncheck all of the status checkboxes
        And click Submitted checkbox
        And click the Waiver Number link in the first row
        And verify the package details page is visible
        And verify action card exists
        And verify the status on the card is "Submitted"
        And verify package actions header is visible
        And verify there are no package actions available
        And verify the details section exists
        And verify the title contains "Waiver Renewal Package"
        And verify there is a Type header in the details section
        And verify the type is Waiver Renewal
        And verify there is a State header in the details section
        And verify a state exists for the State
        And verify there is an Initial Submission Date header in the details section
        And verify a date exists for the Initial Submission Date
        And verify there is a Proposed Effective Date header in the details section
        And verify the supporting documentation section exists
        And verify the download all button exists
        And verify the additional information section exists
```
