### PR TITLE
OY2 22310: Need to pull proposed effective date from SEA Tool

### DIFF
--- a/services/admin/handlers/convertChangeRequests.js
+++ b/services/admin/handlers/convertChangeRequests.js
@@ -74,7 +74,7 @@ export const main = async (event) => {
           if (item.parentType !== "")
             putParams.Item.parentType = item.parentType;
           // default to only processing new
-          if (event.processAll !== "true")
+          if (event?.processAll !== "true")
             putParams.ConditionExpression = "attribute_not_exists(pk)";
 
           console.log(

--- a/services/admin/serverless.yml
+++ b/services/admin/serverless.yml
@@ -72,6 +72,8 @@ functions:
   convertChangeRequests:
     handler: ./handlers/convertChangeRequests.main
     timeout: 180
+    events:
+      - schedule: cron(*/15 * * * *)
 
   verifyChangeRequests:
     handler: ./handlers/verifyChangeRequests.main

--- a/services/admin/serverless.yml
+++ b/services/admin/serverless.yml
@@ -73,7 +73,7 @@ functions:
     handler: ./handlers/convertChangeRequests.main
     timeout: 180
     events:
-      - schedule: cron(*/15 * * * *)
+      - schedule: rate(15 minutes)
 
   verifyChangeRequests:
     handler: ./handlers/verifyChangeRequests.main

--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -1,5 +1,7 @@
 const _ = require("lodash");
 import AWS from "aws-sdk";
+import { DateTime } from "luxon";
+
 import { dynamoConfig, Workflow } from "cmscommonlib";
 
 const dynamoDb = new AWS.DynamoDB.DocumentClient(dynamoConfig);
@@ -141,6 +143,9 @@ export const buildAnyPackage = async (packageId, config) => {
           seaToolStatus
         );
         putParams.Item.currentStatus = SEATOOL_TO_ONEMAC_STATUS[seaToolStatus];
+        putParams.Item.proposedEffectiveDate = DateTime.fromMillis(
+          anEvent.STATE_PLAN.PROPOSED_DATE
+        ).toFormat("yyyy-LL-dd");
         return;
       }
 

--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -142,10 +142,17 @@ export const buildAnyPackage = async (packageId, config) => {
           anEvent.STATE_PLAN.SPW_STATUS_ID,
           seaToolStatus
         );
-        putParams.Item.currentStatus = SEATOOL_TO_ONEMAC_STATUS[seaToolStatus];
-        putParams.Item.proposedEffectiveDate = DateTime.fromMillis(
-          anEvent.STATE_PLAN.PROPOSED_DATE
-        ).toFormat("yyyy-LL-dd");
+        seaToolStatus &&
+          (putParams.Item.currentStatus =
+            SEATOOL_TO_ONEMAC_STATUS[seaToolStatus]);
+        if (
+          anEvent.STATE_PLAN.PROPOSED_DATE &&
+          typeof anEvent.STATE_PLAN.PROPOSED_DATE === "number"
+        )
+          putParams.Item.proposedEffectiveDate = DateTime.fromMillis(
+            anEvent.STATE_PLAN.PROPOSED_DATE
+          ).toFormat("yyyy-LL-dd");
+        else putParams.Item.proposedEffectiveDate = "none";
         return;
       }
 


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-22310
Endpoint: See github-actions bot comment

### Details
Submission View Submissions do not have Proposed Effective Date in their data.  SEA Tool does capture this date (though it is not a required field).  Because SEA Tool is the source of truth... the value in SEA Tool for PROPOSED_DATE is pulled into the package.  

NOTE: This may mean that a OneMAC package that was submitted with a Proposed Effective Date will "lose" that date if it is not properly entered into SEA Tool.

### Changes
- Update the Package details proposedEffectiveDate with the most recent SEA Tool value
- Use "none" if there is no PROPOSED_DATE included in the SEA Tool event
- Fixed the currentStatus disappearing while we wait for second SEA Tool event
- added a schedule to the convertChangeRequests lambda to manage migrations (testing and PROD)

### Test Plan
3. Login as a submitting user
4. Use the Submission Dashboard to create a new package
5. Go to AWS Console
6. Duplicate a SEATool event, update the ID_NUMBER to match the new package, update the timestamp in the sk to be a few milliseconds after the new package submission timestamp, and save the new event
7. Wait for convert lambda to run (every 15 minutes)
8. Verify that the package got created in OneMAC
9. Verify that the proposed effective date matches what is in SEA Tool ("none" if SEA Tool is null)
10. Feel free to use console to update the PROPOSED_DATE on the SEA Tool event and verify that the date on the package details updates to the new date.  (PROPOSED_DATE is not a required field in SEA Tool, so, in DEV, there are very few filled in)
