### PR TITLE
PROD Migrate: Update Workflows to perform Migration automatically

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -158,13 +158,13 @@ jobs:
         if: ${{ env.branch_name != 'production'}}
         run: ./loadTestUsers.py $STAGE_PREFIX$branch_name
       - name: Reset One Table Data
-        if: ${{ env.branch_name != 'production'}}
+#        if: ${{ env.branch_name != 'production'}}
         run: cd ./services/admin && sls invoke -s $STAGE_PREFIX$branch_name -f resetOneTable -p ./handlers/workflowResetOneTable.json
       - name: Convert Change Requests
-        if: ${{ env.branch_name != 'production'}}
+#        if: ${{ env.branch_name != 'production'}}
         run: cd ./services/admin && sls invoke -s $STAGE_PREFIX$branch_name -f convertChangeRequests -p ./handlers/workflowConvertChangeRequests.json
       - name: Verify Change Requests
-        if: ${{ env.branch_name != 'production'}}
+#        if: ${{ env.branch_name != 'production'}}
         run: cd ./services/admin && sls invoke -s $STAGE_PREFIX$branch_name -f verifyChangeRequests -p ./handlers/workflowVerifyChangeRequests.json
       - name: Migrate Data
         if: ${{ env.branch_name != 'production'}}


### PR DESCRIPTION
Endpoint: See github-actions bot comment

### Details
We usually keep migration scripts from running automatically on the production branch.  For this major deployment, we are going to run the workflows for the migration on production, so need to ediit the workflow scripts accordingly.

### Changes
- commented out the production if: conditions for the resetOneTable, convertChangeRequests, and verifyChangeRequests lambdas

### Test Plan
1. workflow should deploy
