### PR TITLE
update formatPackageDetails

### DIFF
--- a/services/app-api/email/formatPackageDetails.js
+++ b/services/app-api/email/formatPackageDetails.js
@@ -11,9 +11,9 @@ export const formatPackageDetails = (data, config) => {
       <p>
         <br><b>State or territory</b>: ${data.componentId.substring(0, 2)}
         ${
-          data.withdrawnByName
-            ? `<br><b>Withdrawn By</b>: ${data.withdrawnByName}<br><b>Email Address</b>: ${data.withdrawnByEmail}`
-            : `<br><b>Name</b>: ${data.submitterName}<br><b>Email Address</b>: ${data.submitterEmail}`
+          data.submitterName
+            ? `<br><b>Name</b>: ${data.submitterName}<br><b>Email Address</b>: ${data.submitterEmail}`
+            : ""
         }
         ${data.title ? `<br><b>Amendment Title</b>: ${data.title}` : ""}
         <br><b>${config.idLabel}</b>: ${data.componentId}


### PR DESCRIPTION

Story: https://qmacbis.atlassian.net/browse/OY2-22457
Endpoint: See github-actions bot comment

### Details

data.withdrawnByName and data.withdrawnByEmail were never being set/used. Therefore just remove this logic and only print a submittername if it is available. Verified new submisssions still include this data point but withdraw does not.

### Changes

- removed logic for including withdrawn by name and email from formatpackagedetails


### Test Plan

1. Login as statesubmitter
2. submit new package
3. verify email still contains proper information (including submitter name)
4. update status to In Review or locate another package that is available for withdraw
5. withdraw package and verify email does not include "undefined" name and email
