### PR TITLE
OY2 22510: Status is not getting updated in OneMAC is the user changes the "Action Type" in SEATool.

### DIFF
--- a/services/one-stream/handleOneStream.js
+++ b/services/one-stream/handleOneStream.js
@@ -87,6 +87,12 @@ export const main = async (eventBatch) => {
             break;
           case "SEATool": {
             const [, topic] = newEventData.GSI1pk.S.split("#");
+            const actionType = newEventData.ACTIONTYPES?.L.map((oneType) =>
+              newEventData.STATE_PLAN.M.ACTION_TYPE.N === oneType.M.ACTION_ID.N
+                ? oneType.M.ACTION_NAME.S
+                : null
+            ).filter(Boolean)[0];
+
             switch (topic) {
               case "Medicaid_SPA":
                 packageToBuild.type = Workflow.ONEMAC_TYPE.MEDICAID_SPA;
@@ -95,23 +101,16 @@ export const main = async (eventBatch) => {
                 packageToBuild.type = Workflow.ONEMAC_TYPE.CHIP_SPA;
                 break;
               case "1915b_waivers":
-                if (newEventData?.ACTIONTYPES?.L[0].M.ACTION_NAME.S === "Renew")
+                if (actionType === "Renew")
                   packageToBuild.type = Workflow.ONEMAC_TYPE.WAIVER_RENEWAL;
-                else if (
-                  newEventData?.ACTIONTYPES?.L[0].M.ACTION_NAME.S === "Amend"
-                )
+                else if (actionType === "Amend")
                   packageToBuild.type = Workflow.ONEMAC_TYPE.WAIVER_AMENDMENT;
-                else if (
-                  newEventData?.ACTIONTYPES?.L[0].M.ACTION_NAME.S === "New"
-                )
+                else if (actionType === "New")
                   packageToBuild.type = Workflow.ONEMAC_TYPE.WAIVER_INITIAL;
                 break;
               case "1915c_waivers":
-                console.log(
-                  "newEventData?.ACTIONTYPES?.M.ACTION_NAME.S is: ",
-                  newEventData?.ACTIONTYPES?.L[0].M.ACTION_NAME.S
-                );
-                if (newEventData?.ACTIONTYPES?.L[0].M.ACTION_NAME.S === "Amend")
+                console.log("actionType is: ", actionType);
+                if (actionType === "Amend")
                   packageToBuild.type = Workflow.ONEMAC_TYPE.WAIVER_APP_K;
                 else console.log("newEventData is: ", newEventData);
                 break;


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-22510
Endpoint: See github-actions bot comment

### Details
OneMAC assumed SEATool was only sending the lookup value for the value needed... turns out, we are sent the list of possible lookups that the package has ever received.... we fixed the issue with Statuses because it was immediately a problem.... Padma's testing revealed that Action Types (waiver new renewal and amend) had the same problem.  Changes made to the action type of a SEA Tool package cause more than one lookup value in the event.

### Changes
- Updated the Action Type handling to use the same pattern as the Status lookups

### Test Plan
1. Use the console to view the items for MD-0027.R01.00
2. View the package in the OneMAC Application as well
3. Update the item with sk of SEATool#1662388588750 and change the relationship between STATE_PLAN.ACTION_TYPE and ACTIONTYPES[].ACTION_ID
4. Verify that changes made are reflected in the OneMAC Package 
5. NOTE: you can update fields that make the OneMAC Packages "wrong" - this is ok because SEA Tool is the source of truth and therefore cannot be wrong :) 
