### PR TITLE
Made rai response addl info section use the AdditionalInfoSection component

### DIFF
--- a/services/ui-src/src/page/DetailView.tsx
+++ b/services/ui-src/src/page/DetailView.tsx
@@ -172,7 +172,9 @@ const DetailView: React.FC<{ pageConfig: OneMACDetail }> = ({ pageConfig }) => {
                 setAlertCode={setAlertCode}
               />
 
-              <AdditionalInfoSection detail={detail} />
+              <AdditionalInfoSection
+                additionalInfo={detail.additionalInformation}
+              />
             </article>
           </div>
         </div>

--- a/services/ui-src/src/page/section/AdditionalInfoSection.tsx
+++ b/services/ui-src/src/page/section/AdditionalInfoSection.tsx
@@ -1,19 +1,19 @@
 import { Review } from "@cmsgov/design-system";
 import React, { FC } from "react";
-import { ComponentDetail } from "../DetailView";
 
-export const AdditionalInfoSection: FC<{ detail: ComponentDetail }> = ({
-  detail,
-}) => {
+export const AdditionalInfoSection: FC<{
+  additionalInfo: string;
+  id?: string;
+}> = ({ additionalInfo, id = "addl-info-base" }) => {
   return (
     <>
-      <section id="addl-info-base" className="read-only-submission">
+      <section id={id} className="read-only-submission">
         <h2>Additional Information</h2>
         <Review
           className="original-review-component preserve-spacing"
           headingLevel="2"
         >
-          {detail.additionalInformation || (
+          {additionalInfo || (
             <i>No Additional Information has been submitted.</i>
           )}
         </Review>

--- a/services/ui-src/src/page/section/DetailSection.tsx
+++ b/services/ui-src/src/page/section/DetailSection.tsx
@@ -7,6 +7,7 @@ import { ComponentDetail } from "../DetailView";
 import { OneMACDetail } from "../../libs/detailLib";
 import FileList from "../../components/FileList";
 import { actionComponent } from "../../libs/actionLib";
+import { AdditionalInfoSection } from "./AdditionalInfoSection";
 
 export const DetailSection = ({
   pageConfig,
@@ -141,20 +142,10 @@ export const DetailSection = ({
                       uploadList={raiResponse.attachments}
                       zipId={raiResponse.componentType + index}
                     />
-                    {raiResponse.additionalInformation && (
-                      <section
-                        id={"addl-info-rai-" + index}
-                        className="detail-section"
-                      >
-                        <h2>Additional Information</h2>
-                        <Review
-                          className="original-review-component"
-                          headingLevel="2"
-                        >
-                          {raiResponse.additionalInformation}
-                        </Review>
-                      </section>
-                    )}
+                    <AdditionalInfoSection
+                      additionalInfo={raiResponse.additionalInformation}
+                      id={"addl-info-rai-" + index}
+                    />
                   </AccordionItem>
                 );
               })}


### PR DESCRIPTION

Story: https://qmacbis.atlassian.net/browse/OY2-22495
Endpoint: See github-actions bot comment

### Details

Format RAI Response addl info same as main content to always show section but display custom message if no content

### Changes

- updated AdditionalInfoComponent to pass a string with content and optional custom id
- updated existing usage of component to pass in only content string
- updated detail section component to use additionalInfo component in the RAI section


### Test Plan

1. Login as state submitter
2. Locate or submit a package with an rai response without additional information
3. verify rai response section of detail view contains additional information section with default text
