### PR TITLE
FIXES: package builder too dependent on Action Types

### DIFF
--- a/services/admin/handlers/createOneMacPackage.json
+++ b/services/admin/handlers/createOneMacPackage.json
@@ -1,9 +1,8 @@
 {
     "componentId": "MD-22-0002",
     "territory": "MD",
-    "componentType": "medicaidspa",
+    "componentType": "Medicaid SPA",
     "waiverAuthority": null,
     "submissionDate": "04/14/2022",
-    "proposedEffectiveDate": "06/21/2022",
     "additionalInformation": "This package was created outside the OneMAC application."
 }

--- a/services/one-stream/handleOneStream.js
+++ b/services/one-stream/handleOneStream.js
@@ -52,8 +52,9 @@ export const main = async (eventBatch) => {
           case "SEATool": {
             const [, topic] = newEventData.GSI1pk.S.split("#");
             let actionType;
-            if (newEventData.ACTIONTYPES)
-              actionType = newEventData.ACTIONTYPES?.L.map((oneType) =>
+            console.log("%s ACTIONTYPES: ", inPK, newEventData.ACTIONTYPES);
+            if (!newEventData.ACTIONTYPES.NULL)
+              actionType = newEventData.ACTIONTYPES.L.map((oneType) =>
                 newEventData.STATE_PLAN.M.ACTION_TYPE.N ===
                 oneType.M.ACTION_ID.N
                   ? oneType.M.ACTION_NAME.S

--- a/services/one-stream/handleOneStream.js
+++ b/services/one-stream/handleOneStream.js
@@ -8,18 +8,6 @@ import { buildWaiverAmendment } from "./package/buildWaiverAmendment";
 import { buildWaiverAppendixK } from "./package/buildWaiverAppendixK";
 import { buildWaiverExtension } from "./package/buildWaiverExtension";
 
-const BUILD_PACKAGE_CALL = {
-  [Workflow.ONEMAC_TYPE.CHIP_SPA]: buildChipSpa,
-  [Workflow.ONEMAC_TYPE.CHIP_SPA_RAI]: buildChipSpa,
-  [Workflow.ONEMAC_TYPE.MEDICAID_SPA]: buildMedicaidSpa,
-  [Workflow.ONEMAC_TYPE.MEDICAID_SPA_RAI]: buildMedicaidSpa,
-  [Workflow.ONEMAC_TYPE.WAIVER_INITIAL]: buildInitialWaiver,
-  [Workflow.ONEMAC_TYPE.WAIVER_RENEWAL]: buildWaiverRenewal,
-  [Workflow.ONEMAC_TYPE.WAIVER_APP_K]: buildWaiverAppendixK,
-  [Workflow.ONEMAC_TYPE.WAIVER_APP_K_RAI]: buildWaiverAppendixK,
-  [Workflow.ONEMAC_TYPE.WAIVER_EXTENSION]: buildWaiverExtension,
-  [Workflow.ONEMAC_TYPE.WAIVER_AMENDMENT]: buildWaiverAmendment,
-};
 export const main = async (eventBatch) => {
   console.log("One Stream event: ", eventBatch);
 
@@ -42,48 +30,24 @@ export const main = async (eventBatch) => {
 
         console.log("pk: %s sk: %s", inPK, inSK);
 
-        const [eventSource] = inSK.split("#");
+        const [eventSource, , offset] = inSK.split("#");
+        if (offset) {
+          console.log("%s ignoring old %s event: ", inPK, inSK, newEventData);
+          return;
+        }
+
         switch (eventSource) {
           case "Package":
             packageToBuild.type = newEventData?.parentType?.S;
             packageToBuild.id = newEventData?.parentId?.S;
             break;
           case "OneMAC":
-            // for all but Waiver RAIs, the type maps to the build
+            // RAIs build parent type, all else build themselves
             if (
               newEventData.componentType.S === Workflow.ONEMAC_TYPE.WAIVER_RAI
             )
               packageToBuild.type = newEventData?.parentType?.S;
             else packageToBuild.type = newEventData.componentType.S;
-            // switch (packageType) {
-            //   case ONEMAC_TYPE.MEDICAID_SPA:
-            //   case ONEMAC_TYPE.MEDICAID_SPA_RAI:
-            //     await buildMedicaidSpa(inPK);
-            //     break;
-            //   case ONEMAC_TYPE.CHIP_SPA:
-            //   case ONEMAC_TYPE.CHIP_SPA_RAI:
-            //     await buildChipSpa(inPK);
-            //     break;
-            //   case ONEMAC_TYPE.WAIVER_INITIAL:
-            //     await buildInitialWaiver(inPK);
-            //     break;
-            //   case ONEMAC_TYPE.WAIVER_AMENDMENT:
-            //     await buildWaiverAmendment(inPK);
-            //     break;
-            //   case ONEMAC_TYPE.WAIVER_RENEWAL:
-            //     await buildWaiverRenewal(inPK);
-            //     break;
-            //   case ONEMAC_TYPE.WAIVER_EXTENSION:
-            //     await buildWaiverExtension(inPK);
-            //     break;
-            //   case ONEMAC_TYPE.WAIVER_APP_K:
-            //   case ONEMAC_TYPE.WAIVER_APP_K_RAI:
-            //     await buildWaiverAppendixK(inPK);
-            //     break;
-            //   default:
-            //     console.log("type not handled");
-            //     break;
-            // }
             break;
           case "SEATool": {
             const [, topic] = newEventData.GSI1pk.S.split("#");
@@ -143,14 +107,39 @@ export const main = async (eventBatch) => {
           );
           return;
         }
-        if (typeof BUILD_PACKAGE_CALL[packageToBuild.type] === "function")
-          await BUILD_PACKAGE_CALL[packageToBuild.type](packageToBuild.id);
-        else
-          console.log(
-            `%s with type <%s> has no build package function??`,
-            inPK,
-            packageToBuild.type
-          );
+        switch (packageToBuild.type) {
+          case Workflow.ONEMAC_TYPE.CHIP_SPA:
+          case Workflow.ONEMAC_TYPE.CHIP_SPA_RAI:
+            buildChipSpa(packageToBuild.id);
+            break;
+          case Workflow.ONEMAC_TYPE.MEDICAID_SPA:
+          case Workflow.ONEMAC_TYPE.MEDICAID_SPA_RAI:
+            buildMedicaidSpa(packageToBuild.id);
+            break;
+          case Workflow.ONEMAC_TYPE.WAIVER_INITIAL:
+            buildInitialWaiver(packageToBuild.id);
+            break;
+          case Workflow.ONEMAC_TYPE.WAIVER_RENEWAL:
+            buildWaiverRenewal(packageToBuild.id);
+            break;
+          case Workflow.ONEMAC_TYPE.WAIVER_APP_K:
+          case Workflow.ONEMAC_TYPE.WAIVER_APP_K_RAI:
+            buildWaiverAppendixK(packageToBuild.id);
+            break;
+          case Workflow.ONEMAC_TYPE.WAIVER_EXTENSION:
+            buildWaiverExtension(packageToBuild.id);
+            break;
+          case Workflow.ONEMAC_TYPE.WAIVER_AMENDMENT:
+            buildWaiverAmendment(packageToBuild.id);
+            break;
+          default:
+            console.log(
+              `%s with type <%s> has no build package function??`,
+              inPK,
+              packageToBuild.type
+            );
+            break;
+        }
       } else {
         console.log(`skipping %s of: `, event.eventName, event.dynamodb);
       }

--- a/services/one-stream/handleOneStream.js
+++ b/services/one-stream/handleOneStream.js
@@ -87,11 +87,15 @@ export const main = async (eventBatch) => {
             break;
           case "SEATool": {
             const [, topic] = newEventData.GSI1pk.S.split("#");
-            const actionType = newEventData.ACTIONTYPES?.L.map((oneType) =>
-              newEventData.STATE_PLAN.M.ACTION_TYPE.N === oneType.M.ACTION_ID.N
-                ? oneType.M.ACTION_NAME.S
-                : null
-            ).filter(Boolean)[0];
+            let actionType;
+            if (newEventData.ACTIONTYPES)
+              actionType = newEventData.ACTIONTYPES?.L.map((oneType) =>
+                newEventData.STATE_PLAN.M.ACTION_TYPE.N ===
+                oneType.M.ACTION_ID.N
+                  ? oneType.M.ACTION_NAME.S
+                  : null
+              ).filter(Boolean)[0];
+            console.log("%s actionType resolves to: ", inPK, actionType);
 
             switch (topic) {
               case "Medicaid_SPA":

--- a/services/one-stream/handleOneStream.js
+++ b/services/one-stream/handleOneStream.js
@@ -110,27 +110,27 @@ export const main = async (eventBatch) => {
         switch (packageToBuild.type) {
           case Workflow.ONEMAC_TYPE.CHIP_SPA:
           case Workflow.ONEMAC_TYPE.CHIP_SPA_RAI:
-            buildChipSpa(packageToBuild.id);
+            await buildChipSpa(packageToBuild.id);
             break;
           case Workflow.ONEMAC_TYPE.MEDICAID_SPA:
           case Workflow.ONEMAC_TYPE.MEDICAID_SPA_RAI:
-            buildMedicaidSpa(packageToBuild.id);
+            await buildMedicaidSpa(packageToBuild.id);
             break;
           case Workflow.ONEMAC_TYPE.WAIVER_INITIAL:
-            buildInitialWaiver(packageToBuild.id);
+            await buildInitialWaiver(packageToBuild.id);
             break;
           case Workflow.ONEMAC_TYPE.WAIVER_RENEWAL:
-            buildWaiverRenewal(packageToBuild.id);
+            await buildWaiverRenewal(packageToBuild.id);
             break;
           case Workflow.ONEMAC_TYPE.WAIVER_APP_K:
           case Workflow.ONEMAC_TYPE.WAIVER_APP_K_RAI:
-            buildWaiverAppendixK(packageToBuild.id);
+            await buildWaiverAppendixK(packageToBuild.id);
             break;
           case Workflow.ONEMAC_TYPE.WAIVER_EXTENSION:
-            buildWaiverExtension(packageToBuild.id);
+            await buildWaiverExtension(packageToBuild.id);
             break;
           case Workflow.ONEMAC_TYPE.WAIVER_AMENDMENT:
-            buildWaiverAmendment(packageToBuild.id);
+            await buildWaiverAmendment(packageToBuild.id);
             break;
           default:
             console.log(

--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -15,7 +15,6 @@ const SEATOOL_TO_ONEMAC_STATUS = {
   [Workflow.SEATOOL_STATUS.TERMINATED]: Workflow.ONEMAC_STATUS.TERMINATED,
   [Workflow.SEATOOL_STATUS.PENDING_CONCURRENCE]:
     Workflow.ONEMAC_STATUS.PENDING_CONCURRENCE,
-  [Workflow.SEATOOL_STATUS.UNSUBMITTED]: Workflow.ONEMAC_STATUS.UNSUBMITTED,
   [Workflow.SEATOOL_STATUS.PENDING_APPROVAL]:
     Workflow.ONEMAC_STATUS.PENDING_APPROVAL,
   [Workflow.SEATOOL_STATUS.UNKNOWN]: Workflow.ONEMAC_STATUS.SUBMITTED,
@@ -144,6 +143,7 @@ export const buildAnyPackage = async (packageId, config) => {
           seaToolStatus
         );
         seaToolStatus &&
+          SEATOOL_TO_ONEMAC_STATUS[seaToolStatus] &&
           (putParams.Item.currentStatus =
             SEATOOL_TO_ONEMAC_STATUS[seaToolStatus]);
         if (

--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -33,6 +33,7 @@ export const buildAnyPackage = async (packageId, config) => {
       ":pk": packageId,
     },
   };
+  console.log("%s the new query params are: ", packageId, queryParams);
 
   try {
     const result = await dynamoDb.query(queryParams).promise();
@@ -201,4 +202,5 @@ export const buildAnyPackage = async (packageId, config) => {
   } catch (e) {
     console.log("%s buildAnyPackage error: ", packageId, e);
   }
+  console.log("%s the end of things", packageId);
 };


### PR DESCRIPTION
### Story: PROD MIGRATION
Endpoint: See github-actions bot comment

### Details
updates to handle the Waiver RAIs broke the handling of the other packages.  Need to account for the field being present, but with a null value.

### Changes
- add a check for null in ACTIONTYPES
- reorganized the build switcher so that it does not trigger CodeQL findings
- sample json for createOneMacPackage updated to use the correct type format
- ignore events from the old SEATool topics State_Plan and RAI
- ONEMAC_STATUS.UNSUBMITTED did not exist... remove it from the mapping so the OneMAC status will take priority

### Test Plan
1. branch should deploy
2. All Component types (except for Temporary Extensions) should receive Status updates when their status is updated in SEA Tool
3. Waiver RAIs should still correctly map to the "closest" parent (based on ID parsing, so not always correct)
