### PR TITLE
Oy2 22443 - update excel export for package view

### DIFF
--- a/services/ui-src/src/utils/tableListExportToCSV.js
+++ b/services/ui-src/src/utils/tableListExportToCSV.js
@@ -1,11 +1,11 @@
-import { roleLabels, ChangeRequest } from "cmscommonlib";
+import { roleLabels, Workflow } from "cmscommonlib";
 import { format } from "date-fns";
 
 const CSV_HEADER = {
   "submission-table":
     "SPA ID/Waiver Number,Type,State,Date Submitted,Submitted By",
   "package-dashboard":
-    "SPA ID/Waiver Number,Type,State,Date Submitted,Submitted By",
+    "SPA ID/Waiver Number,Type,State,Initial Submission Date,Submitted By",
   "user-table": "Name,Email,State,Status,Role,Last Modified,Modified By",
 };
 
@@ -48,7 +48,7 @@ const rowTransformer = {
   ],
   "package-dashboard": (row) => [
     row.componentId,
-    ChangeRequest.LABEL[row.componentType],
+    Workflow.ONEMAC_LABEL[row.componentType],
     row.componentId ? row.componentId.toString().substring(0, 2) : "--",
     serializeDate(row.submissionTimestamp),
     JSON.stringify(row.submitterName),

--- a/services/ui-src/src/utils/tableListExportToCSV.test.js
+++ b/services/ui-src/src/utils/tableListExportToCSV.test.js
@@ -1,4 +1,4 @@
-import { ChangeRequest } from "cmscommonlib";
+import { ChangeRequest, Workflow } from "cmscommonlib";
 import { format } from "date-fns";
 
 import {
@@ -35,7 +35,7 @@ it("provides correct header row for package dashboard", () => {
   expect(outputElements).toContain("SPA ID/Waiver Number");
   expect(outputElements).toContain("Type");
   expect(outputElements).toContain("State");
-  expect(outputElements).toContain("Date Submitted");
+  expect(outputElements).toContain("Initial Submission Date");
   expect(outputElements).toContain("Submitted By");
 });
 
@@ -74,7 +74,7 @@ it("formats package data", () => {
   const output = tableToCSV("package-dashboard", [
     {
       componentId: "ZZ-12-1234",
-      componentType: ChangeRequest.TYPE.SPA,
+      componentType: Workflow.ONEMAC_TYPE.MEDICAID_SPA,
       submissionTimestamp: 1234567898765,
       submitterName: "Me Myself",
     },


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-22443
Endpoint: See github-actions bot comment

### Details

Fix package view export to excel

### Changes

- Use new column header names
- Use package view onemac type lookup instead of change request type lookup

### Test Plan

1. Login as system admin
2. Navigate to package view
3. export spa list
4. verify spa list export has new header value "Initial Submission Date" and Type of "Medicaid SPA"
5. export waiver list
6. verify waiver list export has new header value "Initial Submission Date" and Type of "Temporary Extension"
