### PR TITLE
Helper lambda: getPackageItems

### DIFF
--- a/services/admin/handlers/getPackageItems.js
+++ b/services/admin/handlers/getPackageItems.js
@@ -1,0 +1,31 @@
+import AWS from "aws-sdk";
+import { dynamoConfig } from "cmscommonlib";
+
+const dynamoDb = new AWS.DynamoDB.DocumentClient(dynamoConfig);
+
+export const main = async (event) => {
+  console.log("getPackageItems event: ", event);
+
+  const queryParams = {
+    TableName: event.tableName ? event.tableName : process.env.oneMacTableName,
+    KeyConditionExpression: "pk = :pk",
+    ExpressionAttributeValues: {
+      ":pk": event.packageId,
+    },
+  };
+  console.log("%s queryParams: ", packageId, queryParams);
+
+  try {
+    const result = await dynamoDb.query(queryParams).promise();
+    console.log("%s query result: ", packageId, result);
+    if (result?.Items.length <= 0) {
+      console.log("%s did not have Items?", packageId);
+      return;
+    }
+
+    return result.Items;
+  } catch (e) {
+    console.log("%s getPackageItems error: ", packageId, e);
+    throw e;
+  }
+};

--- a/services/admin/handlers/getPackageItems.js
+++ b/services/admin/handlers/getPackageItems.js
@@ -23,6 +23,17 @@ export const main = async (event) => {
       return;
     }
 
+    if (event.addToTable) {
+      await Promise.all(
+        result.Items.map((item) => {
+          dynamoDb.put({
+            TableName: event.addToTable,
+            Item: { ...item },
+          });
+        })
+      );
+    }
+
     return result.Items;
   } catch (e) {
     console.log("%s getPackageItems error: ", event.packageId, e);

--- a/services/admin/handlers/getPackageItems.js
+++ b/services/admin/handlers/getPackageItems.js
@@ -13,19 +13,19 @@ export const main = async (event) => {
       ":pk": event.packageId,
     },
   };
-  console.log("%s queryParams: ", packageId, queryParams);
+  console.log("%s queryParams: ", event.packageId, queryParams);
 
   try {
     const result = await dynamoDb.query(queryParams).promise();
-    console.log("%s query result: ", packageId, result);
+    console.log("%s query result: ", event.packageId, result);
     if (result?.Items.length <= 0) {
-      console.log("%s did not have Items?", packageId);
+      console.log("%s did not have Items?", event.packageId);
       return;
     }
 
     return result.Items;
   } catch (e) {
-    console.log("%s getPackageItems error: ", packageId, e);
+    console.log("%s getPackageItems error: ", event.packageId, e);
     throw e;
   }
 };

--- a/services/admin/handlers/getPackageItems.js
+++ b/services/admin/handlers/getPackageItems.js
@@ -24,12 +24,16 @@ export const main = async (event) => {
     }
 
     if (event.addToTable) {
+      console.log("adding %s to %s", event.packageId, event.addToTable);
       await Promise.all(
         result.Items.map((item) => {
-          dynamoDb.put({
-            TableName: event.addToTable,
-            Item: { ...item },
-          });
+          if (item.sk === "Package") return;
+          return dynamoDb
+            .put({
+              TableName: event.addToTable,
+              Item: { ...item },
+            })
+            .promise();
         })
       );
     }

--- a/services/admin/serverless.yml
+++ b/services/admin/serverless.yml
@@ -36,7 +36,7 @@ provider:
             - dynamodb:UpdateItem
             - dynamodb:DeleteItem
           Resource:
-            - arn:aws:dynamodb:*:*:table/product-change-request-2
+            - arn:aws:dynamodb:*:*:table/onemac-develop-one
             - arn:aws:dynamodb:*:*:table/${self:custom.oneMacTableName}
             - arn:aws:dynamodb:*:*:table/${self:custom.oneMacTableName}/index/*
             - arn:aws:dynamodb:*:*:table/${self:custom.tableName}

--- a/services/admin/serverless.yml
+++ b/services/admin/serverless.yml
@@ -86,3 +86,7 @@ functions:
   batchCreateOMP:
     handler: ./handlers/batchCreateOMP.main
     timeout: 180
+
+  getPackageItems:
+    handler: ./handlers/getPackageItems.main
+    timeout: 180

--- a/services/app-api/one-seed.json
+++ b/services/app-api/one-seed.json
@@ -9876,5 +9876,9231 @@
     },
     "pk": "MD-22-2200-VM",
     "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1681066249711,
+    "componentType": "waiveramendment",
+    "eventTimestamp": 1673293849711,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1673293847615/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673293847615/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22007.R00.01",
+    "additionalInformation": "approved status test.",
+    "submissionTimestamp": 1673293849711,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#submitwaiveramendment",
+    "convertTimestamp": 1673973230923,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1673293849711",
+    "componentId": "MD-22007.R00.01",
+    "pk": "MD-22007.R00.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1681066249711,
+    "componentType": "waiveramendment",
+    "currentStatus": "Approved",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1673293847615/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673293847615/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "2023-03-08",
+    "GSI1sk": "MD-22007.R00.01",
+    "additionalInformation": "approved status test.",
+    "submissionTimestamp": 1673293849711,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22007.R00.01",
+    "raiResponses": [],
+    "lastEventTimestamp": 1673293957870,
+    "pk": "MD-22007.R00.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680998400000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "B7F4D79E-9D8E-452B-9B34-10213EBF5290",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1673222400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1673222400000,
+      "STATUS_DATE": 1673222400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22007.R00.01",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1673293874270,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22007.R00.01",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1673293874270",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22007.R00.01",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22007.R00.01",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22007.R00.01",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": 3996,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "approved status",
+      "SPW_STATUS_ID": 4,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": 1678233600000,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680998400000,
+      "PRIORITY_CODE_ID": 3,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": 3993,
+      "GAP3": null,
+      "UUID": "B7F4D79E-9D8E-452B-9B34-10213EBF5290",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1673222400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1673222400000,
+      "STATUS_DATE": 1673275957807,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 1,
+      "ACTUAL_EFFECTIVE_DATE": 1678320000000,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22007.R00.01",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": 1673222400000,
+      "CHANGED_DATE": 1673293957870,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": "test",
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 73,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 76,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": 3,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": 1673222400000,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22007.R00.01",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22007.R00.01",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      },
+      {
+        "OCD_REVIEW_DESCRIPTION": "Yes",
+        "OCD_REVIEW_ID": 1
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 4,
+        "SPW_STATUS_DESC": "Approved"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 73
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 821,
+        "ID_NUMBER": "MD-22007.R00.01"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1673293957870",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P3",
+        "PRIORITY_CODE_DESCRIPTION": "Routine action test",
+        "PRIORITY_CODE_ID": 3
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": [
+      {
+        "CODE_AFTER_INIT_ASSESS_ID": 3,
+        "CODE_AFTER_INIT_ASSESS_DESC": "Same"
+      }
+    ],
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 76,
+        "COMPONENT_NAME": "Test 9"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": false,
+          "ID_NUMBER": "MD-22007.R00.01",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": true,
+          "ID_NUMBER": "MD-22007.R00.01",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22007.R00.01",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1681056141144,
+    "componentType": "waiverrenewal",
+    "eventTimestamp": 1673283741144,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1673283739098/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673283739098/excel.xlsx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22008.R01.00",
+    "additionalInformation": "pending-approval test for automation.",
+    "submissionTimestamp": 1673283741144,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#submitwaiverrenewal",
+    "convertTimestamp": 1673973221525,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1673283741144",
+    "componentId": "MD-22008.R01.00",
+    "pk": "MD-22008.R01.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1681056141144,
+    "componentType": "waiverrenewal",
+    "currentStatus": "Approved",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1673283739098/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673283739098/excel.xlsx"
+      }
+    ],
+    "proposedEffectiveDate": "2023-03-28",
+    "GSI1sk": "MD-22008.R01.00",
+    "additionalInformation": "pending-approval test for automation.",
+    "submissionTimestamp": 1673283741144,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22008.R01.00",
+    "raiResponses": [],
+    "lastEventTimestamp": 1673284749653,
+    "pk": "MD-22008.R01.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680998400000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "646EA91A-C7AC-464B-AD6D-E059CF6FE041",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1673222400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1673222400000,
+      "STATUS_DATE": 1673222400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22008.R01.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1673283828163,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22008.R01.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1673283828163",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22008.R01.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22008.R01.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22008.R01.00",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": 3993,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "approval status",
+      "SPW_STATUS_ID": 4,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": 1679961600000,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680998400000,
+      "PRIORITY_CODE_ID": 3,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": 3996,
+      "GAP3": null,
+      "UUID": "646EA91A-C7AC-464B-AD6D-E059CF6FE041",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1673222400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1673222400000,
+      "STATUS_DATE": 1673266749587,
+      "COMPANION_LETTER_RECEIVED_DATE": 1673222400000,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 1,
+      "ACTUAL_EFFECTIVE_DATE": 1679961600000,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22008.R01.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": 1673222400000,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": 1673222400000,
+      "CHANGED_DATE": 1673284749653,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": "test",
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 75,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 76,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": 3,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": 1673222400000,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22008.R01.00",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22008.R01.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      },
+      {
+        "OCD_REVIEW_DESCRIPTION": "Yes",
+        "OCD_REVIEW_ID": 1
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 4,
+        "SPW_STATUS_DESC": "Approved"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "Renew",
+        "ACTION_ID": 75
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-22008.R01.00"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1673284749653",
+    "ACTION_OFFICERS": [
+      {
+        "INITIALS": "A",
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3996,
+        "LAST_NAME": "Test1",
+        "EMAIL": "abc@exampl.com",
+        "FIRST_NAME": "Demo1"
+      }
+    ],
+    "SP1115": null,
+    "COMPONENTS_SP": [
+      {
+        "ALERTS_INBOX_ADDRESS": "Test#2",
+        "COMPONENT_ID": 119,
+        "COMPONENT_NAME": "Test-5"
+      }
+    ],
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P3",
+        "PRIORITY_CODE_DESCRIPTION": "Routine action test",
+        "PRIORITY_CODE_ID": 3
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": [
+      {
+        "CODE_AFTER_INIT_ASSESS_ID": 3,
+        "CODE_AFTER_INIT_ASSESS_DESC": "Same"
+      }
+    ],
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 76,
+        "COMPONENT_NAME": "Test 9"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": false,
+          "ID_NUMBER": "MD-22008.R01.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": true,
+          "ID_NUMBER": "MD-22008.R01.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22008.R01.00",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1679459888685,
+    "componentType": "waivernew",
+    "eventTimestamp": 1671687488685,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1671687486394/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1671687486394/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-2200.R00.00",
+    "additionalInformation": "",
+    "submissionTimestamp": 1671687488685,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#submitwaivernew",
+    "convertTimestamp": 1673973229111,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1671687488685",
+    "componentId": "MD-2200.R00.00",
+    "pk": "MD-2200.R00.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1679459888685,
+    "componentType": "waivernew",
+    "currentStatus": "Approved",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1671687486394/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1671687486394/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "2023-02-16",
+    "GSI1sk": "MD-2200.R00.00",
+    "submissionTimestamp": 1671687488685,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-2200.R00.00",
+    "raiResponses": [],
+    "lastEventTimestamp": 1673037978643,
+    "pk": "MD-2200.R00.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1679443200000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "8E3773FD-715A-4FD1-8B14-2DF2AF93765B",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1671667200000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1671667200000,
+      "STATUS_DATE": 1671667200000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-2200.R00.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1671687529377,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-2200.R00.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1671687529377",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-2200.R00.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-2200.R00.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-2200.R00.00",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "waiver - approved",
+      "SPW_STATUS_ID": 8,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1679443200000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "8E3773FD-715A-4FD1-8B14-2DF2AF93765B",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1671667200000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1671667200000,
+      "STATUS_DATE": 1671667200000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-2200.R00.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1671687654347,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 74,
+      "PENDING_CONCURRENCE_DATE": 1671667200000,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-2200.R00.00",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-2200.R00.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 8,
+        "SPW_STATUS_DESC": "Pending-Concurrence"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "New",
+        "ACTION_ID": 74
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-2200.R00.00"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1671687654347",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-2200.R00.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-2200.R00.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-2200.R00.00",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": 3993,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": 11,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": false,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "waiver - approved",
+      "SPW_STATUS_ID": 11,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": "test",
+      "PROPOSED_DATE": 1676505600000,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1679443200000,
+      "PRIORITY_CODE_ID": 3,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": 3993,
+      "GAP3": null,
+      "UUID": "8E3773FD-715A-4FD1-8B14-2DF2AF93765B",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1671667200000,
+      "BACKUP_FM_ANALYST_ID": 3996,
+      "SUBMISSION_DATE": 1671667200000,
+      "STATUS_DATE": 1672185600000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": "none",
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": 1677628800000,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": 3996,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-2200.R00.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": 1672099200000,
+      "CHANGED_DATE": 1672250468420,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": "none",
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 74,
+      "PENDING_CONCURRENCE_DATE": 1671667200000,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 76,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": 1672185600000,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-2200.R00.00",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-2200.R00.00",
+    "FM_ANALYST": [
+      {
+        "INITIALS": "A",
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3996,
+        "LAST_NAME": "Test1",
+        "EMAIL": "abc@exampl.com",
+        "FIRST_NAME": "Demo1"
+      }
+    ],
+    "LEAD_ANALYST": [
+      {
+        "INITIALS": null,
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3993,
+        "LAST_NAME": "Test2",
+        "EMAIL": null,
+        "FIRST_NAME": "Test1"
+      }
+    ],
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": [
+      {
+        "INITIALS": "A",
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3996,
+        "LAST_NAME": "Test1",
+        "EMAIL": "abc@exampl.com",
+        "FIRST_NAME": "Demo1"
+      }
+    ],
+    "CALLHELDREASONS": [
+      {
+        "CALL_HELD_REASON_ID": 11,
+        "REASON_DESCRIPTION": "Test"
+      }
+    ],
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 8,
+        "SPW_STATUS_DESC": "Pending-Concurrence"
+      },
+      {
+        "SPW_STATUS_ID": 11,
+        "SPW_STATUS_DESC": "Pending-Approval"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "New",
+        "ACTION_ID": 74
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-2200.R00.00"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672250468420",
+    "ACTION_OFFICERS": [
+      {
+        "INITIALS": null,
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3993,
+        "LAST_NAME": "Test2",
+        "EMAIL": null,
+        "FIRST_NAME": "Test1"
+      }
+    ],
+    "SP1115": null,
+    "COMPONENTS_SP": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 76,
+        "COMPONENT_NAME": "Test 9"
+      }
+    ],
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P3",
+        "PRIORITY_CODE_DESCRIPTION": "Routine action test",
+        "PRIORITY_CODE_ID": 3
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 76,
+        "COMPONENT_NAME": "Test 9"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": false,
+          "ID_NUMBER": "MD-2200.R00.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": true,
+          "ID_NUMBER": "MD-2200.R00.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-2200.R00.00",
+    "RO_ANALYST": [
+      {
+        "INITIALS": null,
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3993,
+        "LAST_NAME": "Test2",
+        "EMAIL": null,
+        "FIRST_NAME": "Test1"
+      }
+    ]
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": 3993,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": 11,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": false,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "waiver - approved",
+      "SPW_STATUS_ID": 4,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": "test",
+      "PROPOSED_DATE": 1676505600000,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1679443200000,
+      "PRIORITY_CODE_ID": 1,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": 3993,
+      "GAP3": null,
+      "UUID": "8E3773FD-715A-4FD1-8B14-2DF2AF93765B",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1671667200000,
+      "BACKUP_FM_ANALYST_ID": 3996,
+      "SUBMISSION_DATE": 1671667200000,
+      "STATUS_DATE": 1673019978437,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": "none",
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 1,
+      "ACTUAL_EFFECTIVE_DATE": 1677628800000,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": 3996,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-2200.R00.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": 1672099200000,
+      "CHANGED_DATE": 1673037978643,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": "test",
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": "none",
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 74,
+      "PENDING_CONCURRENCE_DATE": 1671667200000,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 76,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": 3,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": 1672185600000,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-2200.R00.00",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-2200.R00.00",
+    "FM_ANALYST": [
+      {
+        "INITIALS": "A",
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3996,
+        "LAST_NAME": "Test1",
+        "EMAIL": "abc@exampl.com",
+        "FIRST_NAME": "Demo1"
+      }
+    ],
+    "LEAD_ANALYST": [
+      {
+        "INITIALS": null,
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3993,
+        "LAST_NAME": "Test2",
+        "EMAIL": null,
+        "FIRST_NAME": "Test1"
+      }
+    ],
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      },
+      {
+        "OCD_REVIEW_DESCRIPTION": "Yes",
+        "OCD_REVIEW_ID": 1
+      }
+    ],
+    "PROGRAM_ANALYST": [
+      {
+        "INITIALS": "A",
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3996,
+        "LAST_NAME": "Test1",
+        "EMAIL": "abc@exampl.com",
+        "FIRST_NAME": "Demo1"
+      }
+    ],
+    "CALLHELDREASONS": [
+      {
+        "CALL_HELD_REASON_ID": 11,
+        "REASON_DESCRIPTION": "Test"
+      }
+    ],
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 8,
+        "SPW_STATUS_DESC": "Pending-Concurrence"
+      },
+      {
+        "SPW_STATUS_ID": 11,
+        "SPW_STATUS_DESC": "Pending-Approval"
+      },
+      {
+        "SPW_STATUS_ID": 4,
+        "SPW_STATUS_DESC": "Approved"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "New",
+        "ACTION_ID": 74
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-2200.R00.00"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1673037978643",
+    "ACTION_OFFICERS": [
+      {
+        "INITIALS": null,
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3993,
+        "LAST_NAME": "Test2",
+        "EMAIL": null,
+        "FIRST_NAME": "Test1"
+      }
+    ],
+    "SP1115": null,
+    "COMPONENTS_SP": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 76,
+        "COMPONENT_NAME": "Test 9"
+      }
+    ],
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P3",
+        "PRIORITY_CODE_DESCRIPTION": "Routine action test",
+        "PRIORITY_CODE_ID": 3
+      },
+      {
+        "PRIORITY_CODE": "P1",
+        "PRIORITY_CODE_DESCRIPTION": "Must go through OCD",
+        "PRIORITY_CODE_ID": 1
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": [
+      {
+        "CODE_AFTER_INIT_ASSESS_ID": 3,
+        "CODE_AFTER_INIT_ASSESS_DESC": "Same"
+      }
+    ],
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 76,
+        "COMPONENT_NAME": "Test 9"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        },
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": true,
+          "ID_NUMBER": "MD-2200.R00.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": true,
+          "ID_NUMBER": "MD-2200.R00.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-2200.R00.00",
+    "RO_ANALYST": [
+      {
+        "INITIALS": null,
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3993,
+        "LAST_NAME": "Test2",
+        "EMAIL": null,
+        "FIRST_NAME": "Test1"
+      }
+    ]
+  },
+  {
+    "clockEndTimestamp": 1680187441014,
+    "componentType": "waiveramendment",
+    "eventTimestamp": 1672415041014,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672415039327/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672415039327/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22001.R01.01",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672415041014,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#submitwaiveramendment",
+    "convertTimestamp": 1673973228741,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672415041014",
+    "componentId": "MD-22001.R01.01",
+    "pk": "MD-22001.R01.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680187441014,
+    "componentType": "waiveramendment",
+    "currentStatus": "Disapproved",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672415039327/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672415039327/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22001.R01.01",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672415041014,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22001.R01.01",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672415365140,
+    "pk": "MD-22001.R01.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680134400000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "0B12508D-B404-4250-B784-A0B1F93A9E38",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672358400000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22001.R01.01",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672415326020,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22001.R01.01",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672415326020",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22001.R01.01",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22001.R01.01",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22001.R01.01",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "disapproved status",
+      "SPW_STATUS_ID": 5,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680134400000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "0B12508D-B404-4250-B784-A0B1F93A9E38",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672358400000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22001.R01.01",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672415365140,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 73,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22001.R01.01",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22001.R01.01",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 5,
+        "SPW_STATUS_DESC": "Disapproved"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 73
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-22001.R01.01"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672415365140",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22001.R01.01",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22001.R01.01",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22001.R01.01",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680108649335,
+    "componentType": "waiverrenewal",
+    "eventTimestamp": 1672336249335,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672336246808/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672336246808/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22002.R01.00",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672336249335,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#submitwaiverrenewal",
+    "convertTimestamp": 1673973220872,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672336249335",
+    "componentId": "MD-22002.R01.00",
+    "pk": "MD-22002.R01.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680108649335,
+    "componentType": "waiverrenewal",
+    "currentStatus": "Disapproved",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672336246808/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672336246808/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "2023-04-12",
+    "GSI1sk": "MD-22002.R01.00",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672336249335,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22002.R01.00",
+    "raiResponses": [],
+    "lastEventTimestamp": 1673015625233,
+    "pk": "MD-22002.R01.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "99D41B91-DAE8-446F-9AF9-41C71A7E5CB0",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672963200000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22002.R01.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1673015566133,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22002.R01.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1673015566133",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22002.R01.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22002.R01.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22002.R01.00",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "disapproved status",
+      "SPW_STATUS_ID": 5,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": 1681257600000,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "99D41B91-DAE8-446F-9AF9-41C71A7E5CB0",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672963200000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22002.R01.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1673015625233,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 75,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22002.R01.00",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22002.R01.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 5,
+        "SPW_STATUS_DESC": "Disapproved"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "Renew",
+        "ACTION_ID": 75
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-22002.R01.00"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1673015625233",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22002.R01.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22002.R01.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22002.R01.00",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1679460315200,
+    "componentType": "waivernew",
+    "eventTimestamp": 1671687915200,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1671687914106/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1671687914106/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22002.R00.00",
+    "additionalInformation": "",
+    "submissionTimestamp": 1671687915200,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#submitwaivernew",
+    "convertTimestamp": 1673973229061,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1671687915200",
+    "componentId": "MD-22002.R00.00",
+    "pk": "MD-22002.R00.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1679460315200,
+    "componentType": "waivernew",
+    "currentStatus": "Disapproved",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1671687914106/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1671687914106/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22002.R00.00",
+    "submissionTimestamp": 1671687915200,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22002.R00.00",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672248687277,
+    "pk": "MD-22002.R00.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1679443200000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "9068087A-4E7E-491C-8F0E-4C8B43DA49B5",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1671667200000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1671667200000,
+      "STATUS_DATE": 1672185600000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22002.R00.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672248640440,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22002.R00.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672248640440",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22002.R00.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22002.R00.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22002.R00.00",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "disapproved status",
+      "SPW_STATUS_ID": 5,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1679443200000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "9068087A-4E7E-491C-8F0E-4C8B43DA49B5",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1671667200000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1671667200000,
+      "STATUS_DATE": 1672185600000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22002.R00.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672248687277,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 74,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22002.R00.00",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22002.R00.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 5,
+        "SPW_STATUS_DESC": "Disapproved"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "New",
+        "ACTION_ID": 74
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-22002.R00.00"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672248687277",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22002.R00.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22002.R00.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22002.R00.00",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680190417772,
+    "componentType": "waiverappk",
+    "eventTimestamp": 1672418017772,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672418015341/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "1915(c) Appendix K Amendment Waiver Template",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672418015341/excel.xlsx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22102.R01.01",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672418017772,
+    "GSI1pk": "OneMAC#submitwaiverappk",
+    "convertTimestamp": 1673973227181,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672418017772",
+    "componentId": "MD-22102.R01.01",
+    "pk": "MD-22102.R01.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680190417772,
+    "componentType": "waiverappk",
+    "currentStatus": "Package Withdrawn",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672418015341/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "1915(c) Appendix K Amendment Waiver Template",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672418015341/excel.xlsx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22102.R01.01",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672418017772,
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22102.R01.01",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672757629870,
+    "pk": "MD-22102.R01.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680134400000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "95CAA427-7EB7-4D29-BC45-8D11DACCA01F",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672358400000,
+      "STATUS_DATE": 1672704000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22102.R01.01",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672757493853,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22102.R01.01",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672757493853",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22102.R01.01",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22102.R01.01",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22102.R01.01",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680134400000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "A492778C-5CDC-4BF8-814C-23FF605B2338",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672358400000,
+      "STATUS_DATE": 1672704000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 123,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22102.R01.01",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672757554360,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22102.R01.01",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672757554360",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      },
+      {
+        "PLAN_TYPE_ID": 123,
+        "PLAN_TYPE_NAME": "1915(c)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915c_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22102.R01.01",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22102.R01.01",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22102.R01.01",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "test",
+      "SPW_STATUS_ID": 6,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680134400000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "A492778C-5CDC-4BF8-814C-23FF605B2338",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672358400000,
+      "STATUS_DATE": 1672704000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 123,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22102.R01.01",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672757629870,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 76,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22102.R01.01",
+        "SERVICE_TYPE_ID": 112
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22102.R01.01",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 6,
+        "SPW_STATUS_DESC": "Withdrawn"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 123,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 76
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 827,
+        "ID_NUMBER": "MD-22102.R01.01"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672757629870",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      },
+      {
+        "PLAN_TYPE_ID": 123,
+        "PLAN_TYPE_NAME": "1915(c)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915c_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22102.R01.01",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22102.R01.01",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22102.R01.01",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680108711943,
+    "componentType": "waiverrenewal",
+    "eventTimestamp": 1672336311943,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672336310439/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672336310439/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22003.R01.00",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672336311943,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#submitwaiverrenewal",
+    "convertTimestamp": 1673973223622,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672336311943",
+    "componentId": "MD-22003.R01.00",
+    "pk": "MD-22003.R01.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680108711943,
+    "componentType": "waiverrenewal",
+    "currentStatus": "Package Withdrawn",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672336310439/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672336310439/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "2023-04-26",
+    "GSI1sk": "MD-22003.R01.00",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672336311943,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22003.R01.00",
+    "raiResponses": [],
+    "lastEventTimestamp": 1673016353753,
+    "pk": "MD-22003.R01.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "0A25A5A1-0C6C-4BD3-B6F5-AE74DD076154",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672963200000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22003.R01.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1673015842930,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22003.R01.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1673015842930",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22003.R01.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22003.R01.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22003.R01.00",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "with",
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": 1682467200000,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "0A25A5A1-0C6C-4BD3-B6F5-AE74DD076154",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672963200000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22003.R01.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1673016147423,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 75,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22003.R01.00",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22003.R01.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "Renew",
+        "ACTION_ID": 75
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-22003.R01.00"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1673016147423",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22003.R01.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22003.R01.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22003.R01.00",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "with",
+      "SPW_STATUS_ID": 6,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": 1682467200000,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "0A25A5A1-0C6C-4BD3-B6F5-AE74DD076154",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672963200000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22003.R01.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1673016353753,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 75,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22003.R01.00",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22003.R01.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 6,
+        "SPW_STATUS_DESC": "Withdrawn"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "Renew",
+        "ACTION_ID": 75
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-22003.R01.00"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1673016353753",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22003.R01.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22003.R01.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22003.R01.00",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1679460342769,
+    "componentType": "waivernew",
+    "eventTimestamp": 1671687942769,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1671687941706/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1671687941706/excel.xlsx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22003.R00.00",
+    "additionalInformation": "",
+    "submissionTimestamp": 1671687942769,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#submitwaivernew",
+    "convertTimestamp": 1673973229729,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1671687942769",
+    "componentId": "MD-22003.R00.00",
+    "pk": "MD-22003.R00.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1679460342769,
+    "componentType": "waivernew",
+    "currentStatus": "Package Withdrawn",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1671687941706/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1671687941706/excel.xlsx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22003.R00.00",
+    "submissionTimestamp": 1671687942769,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22003.R00.00",
+    "raiResponses": [],
+    "lastEventTimestamp": 1671688301173,
+    "pk": "MD-22003.R00.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "Initial Waiver - withdrawn",
+      "SPW_STATUS_ID": 6,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1679443200000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "E2FB8DF3-0401-42DE-B81A-30C63B27D83E",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1671667200000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1671667200000,
+      "STATUS_DATE": 1671667200000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22003.R00.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1671688301173,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 74,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22003.R00.00",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22003.R00.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 6,
+        "SPW_STATUS_DESC": "Withdrawn"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "New",
+        "ACTION_ID": 74
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-22003.R00.00"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1671688301173",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22003.R00.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22003.R00.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22003.R00.00",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680190337139,
+    "componentType": "waiverappk",
+    "eventTimestamp": 1672417937139,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672417935779/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "1915(c) Appendix K Amendment Waiver Template",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672417935779/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22100.R00.01",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672417937139,
+    "GSI1pk": "OneMAC#submitwaiverappk",
+    "convertTimestamp": 1673973224192,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672417937139",
+    "componentId": "MD-22100.R00.01",
+    "pk": "MD-22100.R00.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680190337139,
+    "componentType": "waiverappk",
+    "currentStatus": "RAI Issued",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672417935779/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "1915(c) Appendix K Amendment Waiver Template",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672417935779/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22100.R00.01",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672417937139,
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22100.R00.01",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672418210170,
+    "pk": "MD-22100.R00.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680134400000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "DC5F18F4-54F1-42C0-9950-C3E0B55F1822",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672358400000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 123,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22100.R00.01",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672418171627,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22100.R00.01",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672418171627",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 123,
+        "PLAN_TYPE_NAME": "1915(c)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915c_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22100.R00.01",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22100.R00.01",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22100.R00.01",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "pending-rai",
+      "SPW_STATUS_ID": 2,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": null,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "DC5F18F4-54F1-42C0-9950-C3E0B55F1822",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": null,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672358400000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 123,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22100.R00.01",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672418210170,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 76,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22100.R00.01",
+        "SERVICE_TYPE_ID": 112
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22100.R00.01",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 2,
+        "SPW_STATUS_DESC": "Pending-RAI"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 123,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 76
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 827,
+        "ID_NUMBER": "MD-22100.R00.01"
+      }
+    ],
+    "RAI": [
+      {
+        "RAI_WITHDRAWN_DATE": null,
+        "ID_NUMBER": "MD-22100.R00.01",
+        "RAI_RECEIVED_DATE": null,
+        "RAI_REQUESTED_DATE": 1672358400000
+      }
+    ],
+    "sk": "SEATool#1672418210170",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 123,
+        "PLAN_TYPE_NAME": "1915(c)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915c_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22100.R00.01",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22100.R00.01",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22100.R00.01",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680187390025,
+    "componentType": "waiveramendment",
+    "eventTimestamp": 1672414990025,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672414988384/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672414988384/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22006.R00.01",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672414990025,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#submitwaiveramendment",
+    "convertTimestamp": 1673973226564,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672414990025",
+    "componentId": "MD-22006.R00.01",
+    "pk": "MD-22006.R00.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680187390025,
+    "componentType": "waiveramendment",
+    "currentStatus": "RAI Issued",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672414988384/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672414988384/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22006.R00.01",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672414990025,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22006.R00.01",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672415166013,
+    "pk": "MD-22006.R00.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680134400000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "6B1FEA14-BC53-4EFD-A273-97EDA153D44C",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672358400000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22006.R00.01",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672415132537,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22006.R00.01",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672415132537",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22006.R00.01",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22006.R00.01",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22006.R00.01",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "pending-rai",
+      "SPW_STATUS_ID": 2,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": null,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "6B1FEA14-BC53-4EFD-A273-97EDA153D44C",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": null,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672358400000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22006.R00.01",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672415166013,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 73,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22006.R00.01",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22006.R00.01",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 2,
+        "SPW_STATUS_DESC": "Pending-RAI"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 73
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-22006.R00.01"
+      }
+    ],
+    "RAI": [
+      {
+        "RAI_WITHDRAWN_DATE": null,
+        "ID_NUMBER": "MD-22006.R00.01",
+        "RAI_RECEIVED_DATE": null,
+        "RAI_REQUESTED_DATE": 1672358400000
+      }
+    ],
+    "sk": "SEATool#1672415166013",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22006.R00.01",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22006.R00.01",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22006.R00.01",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680108775403,
+    "componentType": "waiverrenewal",
+    "eventTimestamp": 1672336375403,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672336373740/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672336373740/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22006.R01.00",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672336375403,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#submitwaiverrenewal",
+    "convertTimestamp": 1673973226211,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672336375403",
+    "componentId": "MD-22006.R01.00",
+    "pk": "MD-22006.R01.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680108775403,
+    "componentType": "waiverrenewal",
+    "currentStatus": "RAI Issued",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672336373740/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672336373740/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22006.R01.00",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672336375403,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22006.R01.00",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672756596417,
+    "pk": "MD-22006.R01.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "22104CF7-40B9-474C-A5C7-3E8C9845CE73",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672704000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22006.R01.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672756559300,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22006.R01.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672756559300",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22006.R01.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22006.R01.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22006.R01.00",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "pending-rai",
+      "SPW_STATUS_ID": 2,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": null,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "22104CF7-40B9-474C-A5C7-3E8C9845CE73",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": null,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672704000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22006.R01.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672756596417,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": "test",
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 75,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22006.R01.00",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22006.R01.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 2,
+        "SPW_STATUS_DESC": "Pending-RAI"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "Renew",
+        "ACTION_ID": 75
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-22006.R01.00"
+      }
+    ],
+    "RAI": [
+      {
+        "RAI_WITHDRAWN_DATE": null,
+        "ID_NUMBER": "MD-22006.R01.00",
+        "RAI_RECEIVED_DATE": null,
+        "RAI_REQUESTED_DATE": 1672704000000
+      }
+    ],
+    "sk": "SEATool#1672756596417",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22006.R01.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22006.R01.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22006.R01.00",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1679460422561,
+    "componentType": "waivernew",
+    "eventTimestamp": 1671688022561,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1671688021447/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1671688021447/excel.xlsx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22006.R00.00",
+    "additionalInformation": "",
+    "submissionTimestamp": 1671688022561,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#submitwaivernew",
+    "convertTimestamp": 1673973214426,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1671688022561",
+    "componentId": "MD-22006.R00.00",
+    "pk": "MD-22006.R00.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1679460422561,
+    "componentType": "waivernew",
+    "currentStatus": "RAI Issued",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1671688021447/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1671688021447/excel.xlsx"
+      }
+    ],
+    "proposedEffectiveDate": "2023-03-23",
+    "GSI1sk": "MD-22006.R00.00",
+    "submissionTimestamp": 1671688022561,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22006.R00.00",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672250244373,
+    "pk": "MD-22006.R00.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1679443200000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "DFE539FD-4BE1-499A-A67B-E7D0E1573844",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1671667200000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1671667200000,
+      "STATUS_DATE": 1672185600000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22006.R00.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672250180023,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22006.R00.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672250180023",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22006.R00.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22006.R00.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22006.R00.00",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "pending-rai status",
+      "SPW_STATUS_ID": 2,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": 1679529600000,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": null,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "DFE539FD-4BE1-499A-A67B-E7D0E1573844",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": null,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1671667200000,
+      "STATUS_DATE": 1672185600000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22006.R00.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672250244373,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 74,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22006.R00.00",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22006.R00.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 2,
+        "SPW_STATUS_DESC": "Pending-RAI"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "New",
+        "ACTION_ID": 74
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-22006.R00.00"
+      }
+    ],
+    "RAI": [
+      {
+        "RAI_WITHDRAWN_DATE": null,
+        "ID_NUMBER": "MD-22006.R00.00",
+        "RAI_RECEIVED_DATE": null,
+        "RAI_REQUESTED_DATE": 1672185600000
+      }
+    ],
+    "sk": "SEATool#1672250244373",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22006.R00.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22006.R00.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22006.R00.00",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680814664614,
+    "componentType": "waivernew",
+    "eventTimestamp": 1673042264614,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1673042263336/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673042263336/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22008.R00.00",
+    "additionalInformation": "withdrawal requested for test automation.",
+    "submissionTimestamp": 1673042264614,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#submitwaivernew",
+    "convertTimestamp": 1673973216063,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1673042264614",
+    "componentId": "MD-22008.R00.00",
+    "pk": "MD-22008.R00.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680814664614,
+    "componentType": "waivernew",
+    "currentStatus": "Under Review",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1673042263336/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673042263336/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22008.R00.00",
+    "additionalInformation": "withdrawal requested for test automation.",
+    "submissionTimestamp": 1673042264614,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22008.R00.00",
+    "raiResponses": [],
+    "lastEventTimestamp": 1673042301077,
+    "pk": "MD-22008.R00.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680739200000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "E251AD6E-B891-4B64-B815-219462C60153",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672963200000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672963200000,
+      "STATUS_DATE": 1672963200000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22008.R00.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1673042301077,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22008.R00.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1673042301077",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22008.R00.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22008.R00.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22008.R00.00",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680187496128,
+    "componentType": "waiveramendment",
+    "eventTimestamp": 1672415096128,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672415094651/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672415094651/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22004.R01.01",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672415096128,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#submitwaiveramendment",
+    "convertTimestamp": 1673973230866,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672415096128",
+    "componentId": "MD-22004.R01.01",
+    "pk": "MD-22004.R01.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680187496128,
+    "componentType": "waiveramendment",
+    "currentStatus": "Pending - Concurrence",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672415094651/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672415094651/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "2023-02-03",
+    "GSI1sk": "MD-22004.R01.01",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672415096128,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22004.R01.01",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672415524800,
+    "pk": "MD-22004.R01.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "pending-concurrence",
+      "SPW_STATUS_ID": 8,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": 1675382400000,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680134400000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "085EC8AD-D22D-4963-ADA5-E05AD270919A",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672358400000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": 1680739200000,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22004.R01.01",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": 1672358400000,
+      "CHANGED_DATE": 1672415524800,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 73,
+      "PENDING_CONCURRENCE_DATE": 1672358400000,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22004.R01.01",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22004.R01.01",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 8,
+        "SPW_STATUS_DESC": "Pending-Concurrence"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 73
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-22004.R01.01"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672415524800",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22004.R01.01",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22004.R01.01",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22004.R01.01",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680108833914,
+    "componentType": "waiverrenewal",
+    "eventTimestamp": 1672336433914,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672336432040/file.docx",
+        "filename": "file.docx",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672336432040/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22004.R01.00",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672336433914,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#submitwaiverrenewal",
+    "convertTimestamp": 1673973228521,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672336433914",
+    "componentId": "MD-22004.R01.00",
+    "pk": "MD-22004.R01.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680108833914,
+    "componentType": "waiverrenewal",
+    "currentStatus": "Pending - Approval",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672336432040/file.docx",
+        "filename": "file.docx",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672336432040/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "2023-03-15",
+    "GSI1sk": "MD-22004.R01.00",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672336433914,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22004.R01.00",
+    "raiResponses": [],
+    "lastEventTimestamp": 1673283675317,
+    "pk": "MD-22004.R01.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "F904E4C8-B93D-4C4A-A837-CF0CD0B9D2B4",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1673222400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22004.R01.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1673283452680,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22004.R01.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1673283452680",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22004.R01.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22004.R01.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22004.R01.00",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": 3996,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": 11,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": false,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "pending-approval",
+      "SPW_STATUS_ID": 11,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": "test",
+      "PROPOSED_DATE": 1678838400000,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": 3,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": 3993,
+      "GAP3": null,
+      "UUID": "F904E4C8-B93D-4C4A-A837-CF0CD0B9D2B4",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1673222400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22004.R01.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": 1672617600000,
+      "CHANGED_DATE": 1673283675317,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 75,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 76,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": 3,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": 1673222400000,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22004.R01.00",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22004.R01.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": [
+      {
+        "CALL_HELD_REASON_ID": 11,
+        "REASON_DESCRIPTION": "Test"
+      }
+    ],
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 11,
+        "SPW_STATUS_DESC": "Pending-Approval"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "Renew",
+        "ACTION_ID": 75
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 821,
+        "ID_NUMBER": "MD-22004.R01.00"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1673283675317",
+    "ACTION_OFFICERS": [
+      {
+        "INITIALS": "A",
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3996,
+        "LAST_NAME": "Test1",
+        "EMAIL": "abc@exampl.com",
+        "FIRST_NAME": "Demo1"
+      }
+    ],
+    "SP1115": null,
+    "COMPONENTS_SP": [
+      {
+        "ALERTS_INBOX_ADDRESS": "Test#2",
+        "COMPONENT_ID": 119,
+        "COMPONENT_NAME": "Test-5"
+      }
+    ],
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P3",
+        "PRIORITY_CODE_DESCRIPTION": "Routine action test",
+        "PRIORITY_CODE_ID": 3
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": [
+      {
+        "CODE_AFTER_INIT_ASSESS_ID": 3,
+        "CODE_AFTER_INIT_ASSESS_DESC": "Same"
+      }
+    ],
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 76,
+        "COMPONENT_NAME": "Test 9"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": false,
+          "ID_NUMBER": "MD-22004.R01.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": true,
+          "ID_NUMBER": "MD-22004.R01.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22004.R01.00",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680190372828,
+    "componentType": "waiverappk",
+    "eventTimestamp": 1672417972828,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672417971464/file.docx",
+        "filename": "file.docx",
+        "title": "1915(c) Appendix K Amendment Waiver Template",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672417971464/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22101.R01.01",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672417972828,
+    "GSI1pk": "OneMAC#submitwaiverappk",
+    "convertTimestamp": 1673973225028,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672417972828",
+    "componentId": "MD-22101.R01.01",
+    "pk": "MD-22101.R01.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680190372828,
+    "componentType": "waiverappk",
+    "currentStatus": "Under Review",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672417971464/file.docx",
+        "filename": "file.docx",
+        "title": "1915(c) Appendix K Amendment Waiver Template",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672417971464/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22101.R01.01",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672417972828,
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22101.R01.01",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672418237963,
+    "pk": "MD-22101.R01.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680134400000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "0CFD70CE-32E4-4F8E-B796-48810D408EAA",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672358400000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 123,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22101.R01.01",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672418237963,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22101.R01.01",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672418237963",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 123,
+        "PLAN_TYPE_NAME": "1915(c)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915c_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22101.R01.01",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22101.R01.01",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22101.R01.01",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1682346590176,
+    "componentType": "waivernew",
+    "eventTimestamp": 1674574190176,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1674574184052/15MB.pdf",
+        "filename": "15MB.pdf",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1674574184052/15MB.pdf"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-12989.R00.00",
+    "additionalInformation": "This is just a test",
+    "submissionTimestamp": 1674574190176,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#submitwaivernew",
+    "convertTimestamp": 1674574260442,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1674574190176",
+    "componentId": "MD-12989.R00.00",
+    "pk": "MD-12989.R00.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1682346590176,
+    "componentType": "waivernew",
+    "currentStatus": "Submitted",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1674574184052/15MB.pdf",
+        "filename": "15MB.pdf",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1674574184052/15MB.pdf"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-12989.R00.00",
+    "additionalInformation": "This is just a test",
+    "submissionTimestamp": 1674574190176,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-12989.R00.00",
+    "raiResponses": [],
+    "lastEventTimestamp": 1674574190176,
+    "pk": "MD-12989.R00.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1677531133321,
+    "componentType": "waiveramendment",
+    "eventTimestamp": 1669755133321,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1669755130735/Screen Shot 2022-11-07 at 3.53.41 PM.png",
+        "filename": "Screen Shot 2022-11-07 at 3.53.41 PM.png",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "image/png",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1669755130735/Screen%20Shot%202022-11-07%20at%203.53.41%20PM.png"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-4444.R22.01",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1669755133321,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#submitwaiveramendment",
+    "convertTimestamp": 1673973227012,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1669755133321",
+    "componentId": "MD-4444.R22.01",
+    "pk": "MD-4444.R22.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1677531714638,
+    "componentType": "waiverappkrai",
+    "eventTimestamp": 1669755714638,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1669755712508/Screen Shot 2022-11-07 at 3.55.09 PM.png",
+        "filename": "Screen Shot 2022-11-07 at 3.55.09 PM.png",
+        "title": "Waiver RAI Response",
+        "contentType": "image/png",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1669755712508/Screen%20Shot%202022-11-07%20at%203.55.09%20PM.png"
+      },
+      {
+        "s3Key": "1669755712510/Screen Shot 2022-11-07 at 3.56.02 PM.png",
+        "filename": "Screen Shot 2022-11-07 at 3.56.02 PM.png",
+        "title": "Other",
+        "contentType": "image/png",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1669755712510/Screen%20Shot%202022-11-07%20at%203.56.02%20PM.png"
+      }
+    ],
+    "parentType": "waiverappk",
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-4444.R22.01",
+    "additionalInformation": "hi",
+    "submissionTimestamp": 1669755714638,
+    "GSI1pk": "OneMAC#submitwaiverappkrai",
+    "convertTimestamp": 1673973214366,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1669755714638",
+    "componentId": "MD-4444.R22.01",
+    "pk": "MD-4444.R22.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1677531940705,
+    "componentType": "waiverappk",
+    "eventTimestamp": 1669755940705,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1669755939528/Screen Shot 2022-11-08 at 8.03.52 AM.png",
+        "filename": "Screen Shot 2022-11-08 at 8.03.52 AM.png",
+        "title": "1915(c) Appendix K Amendment Waiver Template",
+        "contentType": "image/png",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1669755939528/Screen%20Shot%202022-11-08%20at%208.03.52%20AM.png"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-4444.R22.01",
+    "additionalInformation": "",
+    "submissionTimestamp": 1669755940705,
+    "GSI1pk": "OneMAC#submitwaiverappk",
+    "convertTimestamp": 1673973224722,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1669755940705",
+    "componentId": "MD-4444.R22.01",
+    "pk": "MD-4444.R22.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1677532201954,
+    "componentType": "medicaidsparai",
+    "eventTimestamp": 1669756201954,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1669756201068/Screenshot 2022-11-29 at 2.44.13 PM.png",
+        "filename": "Screenshot 2022-11-29 at 2.44.13 PM.png",
+        "title": "RAI Response",
+        "contentType": "image/png",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1669756201068/Screenshot%202022-11-29%20at%202.44.13%20PM.png"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-4444.R22.01",
+    "additionalInformation": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. In commodo urna vel laoreet posuere. In hac habitasse platea dictumst. Duis tempor nisl a purus pellentesque tristique. Fusce condimentum eget magna et auctor. Sed cursus purus eu felis bibendum, quis viverra ante luctus. Quisque venenatis lorem eget ligula dapibus, sit amet condimentum ipsum suscipit. Aliquam vehicula euismod aliquet. Duis posuere aliquet malesuada.\n\nCras sit amet dui vel nunc venenatis consequat. Vestibulum dignissim est a nisi eleifend, ut posuere ligula ultricies. Morbi non diam non quam eleifend ultricies sed sit amet est. Sed vulputate a mi et congue. Duis sed leo suscipit, suscipit felis non, iaculis enim. Curabitur faucibus metus sed orci elementum viverra. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae;\n\nFusce eleifend accumsan odio, eu vulputate metus auctor vulputate. Phasellus ut justo malesuada, scelerisque ante vel, ultricies ex. Integer consequat tellus tellus, vel viverra erat vehicula ac. Donec auctor in ante non vulputate. Sed justo tellus, aliquam non pellentesque eget, condimentum eu ligula. Pellentesque rutrum tortor sed condimentum molestie. Cras at nunc sit amet enim pulvinar pharetra.\n\nPellentesque commodo metus id leo tincidunt volutpat. Phasellus auctor nunc tellus, ac rutrum lacus aliquet sed. Nulla non fringilla est. Vestibulum ac velit non felis faucibus volutpat eget ac velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Quisque iaculis erat eu velit ultricies suscipit. Aenean nec massa nec mi tempor tincidunt. Maecenas commodo risus mi, non ultrices lorem maximus ut. Fusce faucibus, ipsum et condimentum sagittis, dolor purus tincidunt odio, a laoreet quam elit id turpis.\n\nPraesent tortor mi, tincidunt nec ligula vel, congue congue ligula. Cras euismod scelerisque ligula, quis bibendum orci vestibulum consectetur. Nam posuere neque ut turpis maximus ultrices. Pellentesque sit amet ornare sapien. Sed commodo nisi enim, et semper sem porta ut. Curabitur facilisis tincidunt lorem id congue. Sed mollis turpis non leo iaculis hendrerit. Aliquam ultricies varius ligula, eu mattis sapien venenatis a. Donec fringilla purus in convallis ornare. Sed sit amet malesuada nulla. Cras pulvinar turpis accumsan neque porta vulputate. Integer id suscipit risus. Sed sagittis felis ac rhoncus aliquet.\n\nAliquam a mollis ligula. Curabitur molestie fermentum justo ut fringilla. Nunc urna mauris, eleifend mollis venenatis quis, pretium at dolor. Quisque in pretium odio. Maecenas volutpat ultrices turpis et maximus. Nulla interdum pharetra felis. Proin dignissim arcu eget facilisis convallis. Mauris id purus justo. Aliquam lacinia lacus non magna condimentum pulvinar. Cras ac ultricies massa, at convallis lectus. Duis tincidunt neque libero, quis efficitur leo ornare sit amet. Morbi lacinia quam nec nisi mattis, vel hendrerit orci pharetra. Donec volutpat, nisi id tempus rutrum, dui sem dignissim elit, ut fermentum ante velit vel velit.\n\nPhasellus id sapien sagittis, finibus neque ac, posuere mauris. Etiam a suscipit dui. Duis elementum leo eget laoreet viverra. Vivamus egestas nunc ac leo porta imperdiet. Nullam nec ante neque. Suspendisse facilisis lectus ac lorem aliquam tristique. Donec et laoreet ante. Nam ultricies risus et dapibus eleifend.\n\nDonec id tortor a nulla tempus dapibus. Proin sit amet tincidunt lorem, ut commodo erat. Duis non magna non orci porta mollis. Fusce id nisl varius, ultricies nunc non, tincidunt enim. Praesent eu cursus neque. Etiam imperdiet eros eget velit faucibus, at porta elit cursus. Morbi eget dolor at augue vehicula aliquam.\n\nPellentesque rhoncus quis nisl in consequat. Etiam consectetur scelerisque nibh. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Duis sodales vehicula congue. Quisque ac",
+    "submissionTimestamp": 1669756201954,
+    "GSI1pk": "OneMAC#submitmedicaidsparai",
+    "convertTimestamp": 1673973217967,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1669756201954",
+    "componentId": "MD-4444.R22.01",
+    "pk": "MD-4444.R22.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1677532201954,
+    "componentType": "waiveramendment",
+    "currentStatus": "Submitted",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1669756201068/Screenshot 2022-11-29 at 2.44.13 PM.png",
+        "filename": "Screenshot 2022-11-29 at 2.44.13 PM.png",
+        "title": "RAI Response",
+        "contentType": "image/png",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1669756201068/Screenshot%202022-11-29%20at%202.44.13%20PM.png"
+      }
+    ],
+    "parentType": "waiverappk",
+    "GSI1sk": "MD-4444.R22.01",
+    "proposedEffectiveDate": "none",
+    "additionalInformation": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. In commodo urna vel laoreet posuere. In hac habitasse platea dictumst. Duis tempor nisl a purus pellentesque tristique. Fusce condimentum eget magna et auctor. Sed cursus purus eu felis bibendum, quis viverra ante luctus. Quisque venenatis lorem eget ligula dapibus, sit amet condimentum ipsum suscipit. Aliquam vehicula euismod aliquet. Duis posuere aliquet malesuada.\n\nCras sit amet dui vel nunc venenatis consequat. Vestibulum dignissim est a nisi eleifend, ut posuere ligula ultricies. Morbi non diam non quam eleifend ultricies sed sit amet est. Sed vulputate a mi et congue. Duis sed leo suscipit, suscipit felis non, iaculis enim. Curabitur faucibus metus sed orci elementum viverra. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae;\n\nFusce eleifend accumsan odio, eu vulputate metus auctor vulputate. Phasellus ut justo malesuada, scelerisque ante vel, ultricies ex. Integer consequat tellus tellus, vel viverra erat vehicula ac. Donec auctor in ante non vulputate. Sed justo tellus, aliquam non pellentesque eget, condimentum eu ligula. Pellentesque rutrum tortor sed condimentum molestie. Cras at nunc sit amet enim pulvinar pharetra.\n\nPellentesque commodo metus id leo tincidunt volutpat. Phasellus auctor nunc tellus, ac rutrum lacus aliquet sed. Nulla non fringilla est. Vestibulum ac velit non felis faucibus volutpat eget ac velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Quisque iaculis erat eu velit ultricies suscipit. Aenean nec massa nec mi tempor tincidunt. Maecenas commodo risus mi, non ultrices lorem maximus ut. Fusce faucibus, ipsum et condimentum sagittis, dolor purus tincidunt odio, a laoreet quam elit id turpis.\n\nPraesent tortor mi, tincidunt nec ligula vel, congue congue ligula. Cras euismod scelerisque ligula, quis bibendum orci vestibulum consectetur. Nam posuere neque ut turpis maximus ultrices. Pellentesque sit amet ornare sapien. Sed commodo nisi enim, et semper sem porta ut. Curabitur facilisis tincidunt lorem id congue. Sed mollis turpis non leo iaculis hendrerit. Aliquam ultricies varius ligula, eu mattis sapien venenatis a. Donec fringilla purus in convallis ornare. Sed sit amet malesuada nulla. Cras pulvinar turpis accumsan neque porta vulputate. Integer id suscipit risus. Sed sagittis felis ac rhoncus aliquet.\n\nAliquam a mollis ligula. Curabitur molestie fermentum justo ut fringilla. Nunc urna mauris, eleifend mollis venenatis quis, pretium at dolor. Quisque in pretium odio. Maecenas volutpat ultrices turpis et maximus. Nulla interdum pharetra felis. Proin dignissim arcu eget facilisis convallis. Mauris id purus justo. Aliquam lacinia lacus non magna condimentum pulvinar. Cras ac ultricies massa, at convallis lectus. Duis tincidunt neque libero, quis efficitur leo ornare sit amet. Morbi lacinia quam nec nisi mattis, vel hendrerit orci pharetra. Donec volutpat, nisi id tempus rutrum, dui sem dignissim elit, ut fermentum ante velit vel velit.\n\nPhasellus id sapien sagittis, finibus neque ac, posuere mauris. Etiam a suscipit dui. Duis elementum leo eget laoreet viverra. Vivamus egestas nunc ac leo porta imperdiet. Nullam nec ante neque. Suspendisse facilisis lectus ac lorem aliquam tristique. Donec et laoreet ante. Nam ultricies risus et dapibus eleifend.\n\nDonec id tortor a nulla tempus dapibus. Proin sit amet tincidunt lorem, ut commodo erat. Duis non magna non orci porta mollis. Fusce id nisl varius, ultricies nunc non, tincidunt enim. Praesent eu cursus neque. Etiam imperdiet eros eget velit faucibus, at porta elit cursus. Morbi eget dolor at augue vehicula aliquam.\n\nPellentesque rhoncus quis nisl in consequat. Etiam consectetur scelerisque nibh. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Duis sodales vehicula congue. Quisque ac",
+    "submissionTimestamp": 1669756201954,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-4444.R22.01",
+    "raiResponses": [],
+    "lastEventTimestamp": 1669756201954,
+    "pk": "MD-4444.R22.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680108740926,
+    "componentType": "waiverrenewal",
+    "eventTimestamp": 1672336340926,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672336339439/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672336339439/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22005.R01.00",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672336340926,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#submitwaiverrenewal",
+    "convertTimestamp": 1673973224362,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672336340926",
+    "componentId": "MD-22005.R01.00",
+    "pk": "MD-22005.R01.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680108740926,
+    "componentType": "waiverrenewal",
+    "currentStatus": "Submitted",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672336339439/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672336339439/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22005.R01.00",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672336340926,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22005.R01.00",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672336340926,
+    "pk": "MD-22005.R01.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680190535973,
+    "componentType": "waiverappk",
+    "eventTimestamp": 1672418135973,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672418134625/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "1915(c) Appendix K Amendment Waiver Template",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672418134625/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22102.R00.01",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672418135973,
+    "GSI1pk": "OneMAC#submitwaiverappk",
+    "convertTimestamp": 1673973231630,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672418135973",
+    "componentId": "MD-22102.R00.01",
+    "pk": "MD-22102.R00.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680190535973,
+    "componentType": "waiverappk",
+    "currentStatus": "Submitted",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672418134625/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "1915(c) Appendix K Amendment Waiver Template",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672418134625/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22102.R00.01",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672418135973,
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22102.R00.01",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672418135973,
+    "pk": "MD-22102.R00.01",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1668008887407,
+    "componentType": "waiverextension",
+    "eventTimestamp": 1660229287407,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "parentId": "MD-12893.R00.00",
+    "attachments": [
+      {
+        "s3Key": "1660229285982/Mr. Scott_ State of KS_SPA KS 21-0002 Signed.pdf",
+        "filename": "Mr. Scott_ State of KS_SPA KS 21-0002 Signed.pdf",
+        "title": "Waiver Extension Request",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1660229285982/Mr.%20Scott_%20State%20of%20KS_SPA%20KS%2021-0002%20Signed.pdf"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-0093.R00.TE03",
+    "additionalInformation": "",
+    "submissionTimestamp": 1660229287407,
+    "GSI1pk": "OneMAC#submitwaiverextension",
+    "convertTimestamp": 1673973225066,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1660229287407",
+    "componentId": "MD-0093.R00.TE03",
+    "pk": "MD-0093.R00.TE03",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "componentType": "waiverextension",
+    "currentStatus": "Submitted",
+    "waiverExtensions": [],
+    "parentId": "MD-12893.R00.00",
+    "attachments": [
+      {
+        "s3Key": "1660229285982/Mr. Scott_ State of KS_SPA KS 21-0002 Signed.pdf",
+        "filename": "Mr. Scott_ State of KS_SPA KS 21-0002 Signed.pdf",
+        "title": "Waiver Extension Request",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1660229285982/Mr.%20Scott_%20State%20of%20KS_SPA%20KS%2021-0002%20Signed.pdf"
+      }
+    ],
+    "GSI1sk": "MD-0093.R00.TE03",
+    "submissionTimestamp": 1660229287407,
+    "GSI2sk": "waiverextension",
+    "GSI2pk": "MD-12893.R00.00",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-0093.R00.TE03",
+    "raiResponses": [],
+    "lastEventTimestamp": 1660229287407,
+    "pk": "MD-0093.R00.TE03",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680108686375,
+    "componentType": "waiverrenewal",
+    "eventTimestamp": 1672336286375,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672336284844/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672336284844/excel.xlsx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22007.R01.00",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672336286375,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#submitwaiverrenewal",
+    "convertTimestamp": 1673973221886,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672336286375",
+    "componentId": "MD-22007.R01.00",
+    "pk": "MD-22007.R01.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680108686375,
+    "componentType": "waiverrenewal",
+    "currentStatus": "Waiver Terminated",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672336284844/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672336284844/excel.xlsx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22007.R01.00",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672336286375,
+    "waiverAuthority": "1915(b)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22007.R01.00",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672756398930,
+    "pk": "MD-22007.R01.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "4B4725F0-60B0-4C6F-A16B-23C100E56093",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672704000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22007.R01.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672756357187,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22007.R01.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672756357187",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22007.R01.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22007.R01.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22007.R01.00",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "waiver-terminated",
+      "SPW_STATUS_ID": 7,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "4B4725F0-60B0-4C6F-A16B-23C100E56093",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672704000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22007.R01.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672756398930,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 75,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22007.R01.00",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22007.R01.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 7,
+        "SPW_STATUS_DESC": "Terminated"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "Renew",
+        "ACTION_ID": 75
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-22007.R01.00"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672756398930",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22007.R01.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22007.R01.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22007.R01.00",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680021217681,
+    "componentType": "waivernew",
+    "eventTimestamp": 1672248817681,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672248815487/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672248815487/excel.xlsx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22007.R00.00",
+    "additionalInformation": "",
+    "submissionTimestamp": 1672248817681,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#submitwaivernew",
+    "convertTimestamp": 1673973228545,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672248817681",
+    "componentId": "MD-22007.R00.00",
+    "pk": "MD-22007.R00.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680021217681,
+    "componentType": "waivernew",
+    "currentStatus": "Waiver Terminated",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672248815487/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "1915(b)(4) FFS Selective Contracting (Streamlined) waiver application pre-print (Initial, Renewal, Amendment)",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672248815487/excel.xlsx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22007.R00.00",
+    "submissionTimestamp": 1672248817681,
+    "waiverAuthority": "1915(b)(4)",
+    "GSI1pk": "OneMAC#waiver",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22007.R00.00",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672248912057,
+    "pk": "MD-22007.R00.00",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1679961600000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "45B3AD27-732B-45B0-A9BA-048C11C24C00",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672185600000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672185600000,
+      "STATUS_DATE": 1672185600000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22007.R00.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672248865507,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22007.R00.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672248865507",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22007.R00.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22007.R00.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22007.R00.00",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "terminated status",
+      "SPW_STATUS_ID": 7,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1679961600000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "45B3AD27-732B-45B0-A9BA-048C11C24C00",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672185600000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672185600000,
+      "STATUS_DATE": 1672185600000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 122,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22007.R00.00",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672248912057,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 74,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22007.R00.00",
+        "SERVICE_TYPE_ID": 111
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22007.R00.00",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 7,
+        "SPW_STATUS_DESC": "Terminated"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "ACTION_NAME": "New",
+        "ACTION_ID": 74
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 820,
+        "ID_NUMBER": "MD-22007.R00.00"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672248912057",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 122,
+        "PLAN_TYPE_NAME": "1915(b)"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#1915b_waivers",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22007.R00.00",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22007.R00.00",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22007.R00.00",
+    "RO_ANALYST": null
   }
 ]

--- a/services/app-api/one-seed.json
+++ b/services/app-api/one-seed.json
@@ -1963,918 +1963,7918 @@
     "GSI1pk": "SEATool#Medicaid_SPA",
     "GSI1sk": "MD-82-0021",
     "SPW_STATUS": [
-     {
-      "SPW_STATUS_DESC": "Pending",
-      "SPW_STATUS_ID": 2
-     }
+      {
+        "SPW_STATUS_DESC": "Pending",
+        "SPW_STATUS_ID": 2
+      }
     ],
     "STATE_PLAN": {
-     "CHANGED_DATE": 1671584977662,
-     "ID_NUMBER": "MD-82-0021",
-     "STATUS_DATE": 1671584977662,
-     "SPW_STATUS_ID": 2
+      "CHANGED_DATE": 1671584977662,
+      "ID_NUMBER": "MD-82-0021",
+      "STATUS_DATE": 1671584977662,
+      "SPW_STATUS_ID": 2
     }
-   },
-     {
-      "GSI1sk": "MD-77-0003",
-      "sk": "SEATool#1664779808945",
-      "STATE_PLAN": {
-        "STATUS_DATE": 1664779808945,
-        "ID_NUMBER": "MD-77-0003",
-        "CHANGED_DATE": 1664779808945,
-        "SPW_STATUS_ID": 4
-      },
-      "GSI1pk": "SEATool#Medicaid_SPA",
-      "pk": "MD-77-0003",
-      "RAI": [
-        {
-          "RAI_WITHDRAWN_DATE": 1638921600000,
-          "ID_NUMBER": "AK-00-0885",
-          "RAI_RECEIVED_DATE": 1633478400000,
-          "RAI_REQUESTED_DATE": 1633392000000
-        }
-      ],
-      "SPW_STATUS": [
-        {
-          "SPW_STATUS_DESC": "Approved",
-          "SPW_STATUS_ID": 4
-        }
-      ],
-      "PLAN_TYPES": [
-        {
-          "PLAN_TYPE_ID": 125,
-          "PLAN_TYPE_NAME": "Medicaid SPA"
-        }
-      ]
+  },
+  {
+    "GSI1sk": "MD-77-0003",
+    "sk": "SEATool#1664779808945",
+    "STATE_PLAN": {
+      "STATUS_DATE": 1664779808945,
+      "ID_NUMBER": "MD-77-0003",
+      "CHANGED_DATE": 1664779808945,
+      "SPW_STATUS_ID": 4
     },
-    {
-      "pk": "MD-22-0013-EID",
-      "sk": "SEATool#1667219831464",
-      "GSI1pk": "SEATool#Medicaid_SPA",
-      "GSI1sk": "MD-22-0013-EID",
-      "PLAN_TYPES": [
-       {
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "pk": "MD-77-0003",
+    "RAI": [
+      {
+        "RAI_WITHDRAWN_DATE": 1638921600000,
+        "ID_NUMBER": "AK-00-0885",
+        "RAI_RECEIVED_DATE": 1633478400000,
+        "RAI_REQUESTED_DATE": 1633392000000
+      }
+    ],
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_DESC": "Approved",
+        "SPW_STATUS_ID": 4
+      }
+    ],
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_ID": 125,
         "PLAN_TYPE_NAME": "Medicaid SPA"
-       }
-      ],
-      "RAI": null,
-      "SPW_STATUS": [
-       {
+      }
+    ]
+  },
+  {
+    "pk": "MD-22-0013-EID",
+    "sk": "SEATool#1667219831464",
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "GSI1sk": "MD-22-0013-EID",
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 125,
+        "PLAN_TYPE_NAME": "Medicaid SPA"
+      }
+    ],
+    "RAI": null,
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Pending-Approval",
         "SPW_STATUS_ID": 1
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1667219831464,
-       "ID_NUMBER": "MD-22-0013-EID",
-       "SPW_STATUS_ID": 1,
-       "STATUS_DATE": 1667219831464
       }
-     },
-    {
-      "pk": "MD-22-0003",
-      "sk": "SEATool#1647913510000",
-      "GSI1pk": "SEATool#Medicaid_SPA",
-      "GSI1sk": "MD-22-0003",
-      "PLAN_TYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1667219831464,
+      "ID_NUMBER": "MD-22-0013-EID",
+      "SPW_STATUS_ID": 1,
+      "STATUS_DATE": 1667219831464
+    }
+  },
+  {
+    "pk": "MD-22-0003",
+    "sk": "SEATool#1647913510000",
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "GSI1sk": "MD-22-0003",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_ID": 125,
         "PLAN_TYPE_NAME": "Medicaid SPA"
-       }
-      ],
-      "RAI": null,
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "RAI": null,
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Disapproved",
         "SPW_STATUS_ID": 1
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1647913510000,
-       "ID_NUMBER": "MD-22-0003",
-       "SPW_STATUS_ID": 1,
-       "STATUS_DATE": 1647913510000
       }
-     },
-     {
-      "pk": "MD-22-0006",
-      "sk": "SEATool#1661999710000",
-      "ACTIONTYPES": null,
-      "ACTION_OFFICERS": null,
-      "CALLHELDREASONS": null,
-      "CODEAFTERINITACCESS": null,
-      "COMPONENTS": null,
-      "COMPONENTS_SP": null,
-      "FM_ANALYST": null,
-      "GSI1pk": "SEATool#Medicaid_SPA",
-      "GSI1sk": "MD-22-0006",
-      "LEAD_ANALYST": null,
-      "OCD_REVIEW": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1647913510000,
+      "ID_NUMBER": "MD-22-0003",
+      "SPW_STATUS_ID": 1,
+      "STATUS_DATE": 1647913510000
+    }
+  },
+  {
+    "pk": "MD-22-0006",
+    "sk": "SEATool#1661999710000",
+    "ACTIONTYPES": null,
+    "ACTION_OFFICERS": null,
+    "CALLHELDREASONS": null,
+    "CODEAFTERINITACCESS": null,
+    "COMPONENTS": null,
+    "COMPONENTS_SP": null,
+    "FM_ANALYST": null,
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "GSI1sk": "MD-22-0006",
+    "LEAD_ANALYST": null,
+    "OCD_REVIEW": [
+      {
         "OCD_REVIEW_DESCRIPTION": "No",
         "OCD_REVIEW_ID": 2
-       }
-      ],
-      "PLAN_TYPES": [
-       {
+      }
+    ],
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_ID": 125,
         "PLAN_TYPE_NAME": "Medicaid SPA"
-       }
-      ],
-      "PRIORITY_CODES": null,
-      "PRIORITY_COMPLEXITY": null,
-      "PROGRAM_ANALYST": null,
-      "RAI": [
-        {
-          "RAI_WITHDRAWN_DATE": null,
-          "ID_NUMBER": "MD-22-0006",
-          "RAI_RECEIVED_DATE": null,
-          "RAI_REQUESTED_DATE": 1654749910000
-        }
-      ],
-      "REGION": [
-       {
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "PRIORITY_COMPLEXITY": null,
+    "PROGRAM_ANALYST": null,
+    "RAI": [
+      {
+        "RAI_WITHDRAWN_DATE": null,
+        "ID_NUMBER": "MD-22-0006",
+        "RAI_RECEIVED_DATE": null,
+        "RAI_REQUESTED_DATE": 1654749910000
+      }
+    ],
+    "REGION": [
+      {
         "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov",
         "REGION_ID": "3",
         "REGION_NAME": "Philadelphia"
-       }
-      ],
-      "REVIEW_POSITION": null,
-      "RO_ANALYST": null,
-      "SP1115": null,
-      "SPA_TYPE": null,
-      "SPW_STATUS": [
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "RO_ANALYST": null,
+    "SP1115": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 8,
+        "SPW_STATUS_DESC": "Pending-Concurrence"
+      }
+    ],
+    "SP_APD": null,
+    "SP_APD_SUB_TYPE": null,
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
         {
-          "SPW_STATUS_ID": 8,
-          "SPW_STATUS_DESC": "Pending-Concurrence"
+          "ACTIVE": true,
+          "EA_DROP_DOWN_VALUES": null,
+          "EA_FIELD_ID": 11,
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "IS_APD": false,
+          "PRIORITY_CODE_ID": 1,
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_VALUE": "true"
+        },
+        {
+          "ACTIVE": true,
+          "EA_DROP_DOWN_VALUES": null,
+          "EA_FIELD_ID": 24,
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "IS_APD": null,
+          "PRIORITY_CODE_ID": 3,
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_VALUE": "true"
+        },
+        {
+          "ACTIVE": true,
+          "EA_DROP_DOWN_VALUES": "1",
+          "EA_FIELD_ID": 25,
+          "EA_LABEL": "Customary action",
+          "EA_TYPE_ID": 1,
+          "IS_APD": null,
+          "PRIORITY_CODE_ID": 2,
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_VALUE": "true"
         }
       ],
-      "SP_APD": null,
-      "SP_APD_SUB_TYPE": null,
-      "SP_EARLY_ALERTS": {
-       "ALERTFIELD": [
+      "EARLYALERT": [
         {
-         "ACTIVE": true,
-         "EA_DROP_DOWN_VALUES": null,
-         "EA_FIELD_ID": 11,
-         "EA_LABEL": "Reduced Eligibility",
-         "EA_TYPE_ID": 1,
-         "IS_APD": false,
-         "PRIORITY_CODE_ID": 1,
-         "PRIORITY_OPERATOR": null,
-         "PRIORITY_VALUE": "true"
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "ID_NUMBER": "MD-22-0006",
+          "TEXT_DD_VAL": null,
+          "YES_NO_VAL": null
         },
         {
-         "ACTIVE": true,
-         "EA_DROP_DOWN_VALUES": null,
-         "EA_FIELD_ID": 24,
-         "EA_LABEL": "Meets expedited criteria",
-         "EA_TYPE_ID": 1,
-         "IS_APD": null,
-         "PRIORITY_CODE_ID": 3,
-         "PRIORITY_OPERATOR": null,
-         "PRIORITY_VALUE": "true"
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "ID_NUMBER": "MD-22-0006",
+          "TEXT_DD_VAL": null,
+          "YES_NO_VAL": null
         },
         {
-         "ACTIVE": true,
-         "EA_DROP_DOWN_VALUES": "1",
-         "EA_FIELD_ID": 25,
-         "EA_LABEL": "Customary action",
-         "EA_TYPE_ID": 1,
-         "IS_APD": null,
-         "PRIORITY_CODE_ID": 2,
-         "PRIORITY_OPERATOR": null,
-         "PRIORITY_VALUE": "true"
+          "EA_FIELD_ID": 25,
+          "EMAIL_SENT": null,
+          "ID_NUMBER": "MD-22-0006",
+          "TEXT_DD_VAL": null,
+          "YES_NO_VAL": null
         }
-       ],
-       "EARLYALERT": [
-        {
-         "EA_FIELD_ID": 11,
-         "EMAIL_SENT": null,
-         "ID_NUMBER": "MD-22-0006",
-         "TEXT_DD_VAL": null,
-         "YES_NO_VAL": null
-        },
-        {
-         "EA_FIELD_ID": 24,
-         "EMAIL_SENT": null,
-         "ID_NUMBER": "MD-22-0006",
-         "TEXT_DD_VAL": null,
-         "YES_NO_VAL": null
-        },
-        {
-         "EA_FIELD_ID": 25,
-         "EMAIL_SENT": null,
-         "ID_NUMBER": "MD-22-0006",
-         "TEXT_DD_VAL": null,
-         "YES_NO_VAL": null
-        }
-       ]
-      },
-      "SP_IMPACT_FUNDING": null,
-      "SP_TYPE": null,
-      "STATES": [
-       {
+      ]
+    },
+    "SP_IMPACT_FUNDING": null,
+    "SP_TYPE": null,
+    "STATES": [
+      {
         "PRIORITY_FLAG": false,
         "REGION_ID": "3",
         "STATE_CODE": "MD",
         "STATE_NAME": "Maryland"
-       }
-      ],
-      "STATE_PLAN": {
-       "ACTION_TYPE": null,
-       "ACTUAL_EFFECTIVE_DATE": null,
-       "ADDED_COST": null,
-       "ALERT_90_DAYS_DATE": 1653436800000,
-       "ALERT_MILESTONE1_DAYS": null,
-       "ALERT_MILESTONE2_DAYS": null,
-       "ALERT_MILESTONE3_DAYS": null,
-       "ALERT_MILESTONE4_DAYS": null,
-       "APPROVAL_DOCS_RECEIVED": null,
-       "APPROVAL_STATUS_TYPE": null,
-       "APPROVED_EFFECTIVE_DATE": null,
-       "ATTACHED_SPA": null,
-       "BACKUP_FM_ANALYST_ID": null,
-       "BACKUP_PROGRAM_ANALYST_ID": null,
-       "BLOCKING_SPAS_MEMO": null,
-       "BUDGET_IMPACT": null,
-       "BUDGET_IMPACT_VALUE": null,
-       "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
-       "BUDGET_NEUTRALITY_STATUS_MEMO": null,
-       "CALL_HELD": null,
-       "CALL_HELD_REASON_ID": null,
-       "CHANGED_DATE": 1661999710000,
-       "CODE_AFTER_INIT_ASSESS_ID": null,
-       "COMPANION_LETTER_RECEIVED_DATE": null,
-       "COMPANION_LETTER_REQUESTED_DATE": null,
-       "COMPONENT_ID": null,
-       "CO_SUBMISSION_DATE": null,
-       "CURRENT_WAIVER_EXPIRES_DATE": null,
-       "CURRENT_WAIVER_TE": null,
-       "DATE_OF_CODING_CHANGE": null,
-       "DATE_SENT_PSCCAS": null,
-       "DAYS_EXTENSION_NUMBER": null,
-       "ELIMINATED_COST": null,
-       "END_DATE": null,
-       "FISCAL_QUARTER": null,
-       "FISCAL_YEAR": null,
-       "FRT_DATE": null,
-       "GAP": null,
-       "GAP2": null,
-       "GAP2_NA": null,
-       "GAP3": null,
-       "GAP3_NA": null,
-       "GAP_NA": null,
-       "GUIDANCE_DOCS_SUBMITTED": null,
-       "ID_NUMBER": "MD-22-0002",
-       "INITIAL_SUBMISSION_COMPLETE": null,
-       "LEAD_ANALYST_ID": null,
-       "MISSING_INFORMATION": null,
-       "MMDL_IMPORT": null,
-       "OCD_REVIEW_COMMENTS_MEMO": null,
-       "OCD_REVIEW_ID": 2,
-       "ORGANIZATION_CHANGE": null,
-       "PENDING_CONCURRENCE_DATE": null,
-       "PLAN_TYPE": 125,
-       "PRIORITY_CODE_ID": null,
-       "PRIORITY_COMMENTS_MEMO": null,
-       "PRIORITY_COMPLEXITY_ID": null,
-       "PROPOSED_DATE": null,
-       "PUBLICHEALTH_STATEEMERGENCY": null,
-       "REGION_ID": "3",
-       "REMARKS_MEMO": null,
-       "REVIEW_POSITION_ID": null,
-       "RO_ANALYST_ID": null,
-       "SPA_TYPE_ID": null,
-       "SPW_IMPORT": false,
-       "SPW_STATUS_ID": 8,
-       "START_CLOCK_DATE": 1645660800000,
-       "STATE_CODE": "MD",
-       "STATUS_DATE": 1661999710000,
-       "STATUS_MEMO": null,
-       "SUBMISSION_DATE": 1645660800000,
-       "SUBMISSION_TYPE": null,
-       "SUMMARY_MEMO": null,
-       "TEMPLATE_ISSUES": null,
-       "TEMPLATE_ISSUES_MEMO": null,
-       "TEMPLATE_ISSUES_RESOLVED": null,
-       "TE_END_DATE": null,
-       "TITLE_NAME": null,
-       "TYPE_ID": null,
-       "UPL_ACCEPTED": null,
-       "UUID": "02EB6F40-22D9-414F-A715-5CDE92BE6D70"
-      },
-      "STATE_PLAN_SERVICETYPES": null,
-      "STATE_PLAN_SERVICE_SUBTYPES": null,
-      "STOP_RESUME_DATES": null
-     },
-     {
-      "pk": "MD-0027.R01.00",
-      "sk": "SEATool#1659988588750",
-      "GSI1pk": "SEATool#1915b_waivers",
-      "GSI1sk": "MD-0027.R01.00",
-      "PLAN_TYPES": [
-       {
+      }
+    ],
+    "STATE_PLAN": {
+      "ACTION_TYPE": null,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "ADDED_COST": null,
+      "ALERT_90_DAYS_DATE": 1653436800000,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "APPROVAL_STATUS_TYPE": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "ATTACHED_SPA": null,
+      "BACKUP_FM_ANALYST_ID": null,
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "BUDGET_IMPACT": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "CALL_HELD": null,
+      "CALL_HELD_REASON_ID": null,
+      "CHANGED_DATE": 1661999710000,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "COMPONENT_ID": null,
+      "CO_SUBMISSION_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "CURRENT_WAIVER_TE": null,
+      "DATE_OF_CODING_CHANGE": null,
+      "DATE_SENT_PSCCAS": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "ELIMINATED_COST": null,
+      "END_DATE": null,
+      "FISCAL_QUARTER": null,
+      "FISCAL_YEAR": null,
+      "FRT_DATE": null,
+      "GAP": null,
+      "GAP2": null,
+      "GAP2_NA": null,
+      "GAP3": null,
+      "GAP3_NA": null,
+      "GAP_NA": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "ID_NUMBER": "MD-22-0002",
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "LEAD_ANALYST_ID": null,
+      "MISSING_INFORMATION": null,
+      "MMDL_IMPORT": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "OCD_REVIEW_ID": 2,
+      "ORGANIZATION_CHANGE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PLAN_TYPE": 125,
+      "PRIORITY_CODE_ID": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "PROPOSED_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "REGION_ID": "3",
+      "REMARKS_MEMO": null,
+      "REVIEW_POSITION_ID": null,
+      "RO_ANALYST_ID": null,
+      "SPA_TYPE_ID": null,
+      "SPW_IMPORT": false,
+      "SPW_STATUS_ID": 8,
+      "START_CLOCK_DATE": 1645660800000,
+      "STATE_CODE": "MD",
+      "STATUS_DATE": 1661999710000,
+      "STATUS_MEMO": null,
+      "SUBMISSION_DATE": 1645660800000,
+      "SUBMISSION_TYPE": null,
+      "SUMMARY_MEMO": null,
+      "TEMPLATE_ISSUES": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "TE_END_DATE": null,
+      "TITLE_NAME": null,
+      "TYPE_ID": null,
+      "UPL_ACCEPTED": null,
+      "UUID": "02EB6F40-22D9-414F-A715-5CDE92BE6D70"
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "STOP_RESUME_DATES": null
+  },
+  {
+    "pk": "MD-0027.R01.00",
+    "sk": "SEATool#1659988588750",
+    "GSI1pk": "SEATool#1915b_waivers",
+    "GSI1sk": "MD-0027.R01.00",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_ID": 122,
         "PLAN_TYPE_NAME": "1915(b)"
-       }
-      ],
-      "RAI": [
-       {
+      }
+    ],
+    "RAI": [
+      {
         "ID_NUMBER": "MD-0027.R01.00",
         "RAI_RECEIVED_DATE": null,
         "RAI_REQUESTED_DATE": 1659988588750,
         "RAI_WITHDRAWN_DATE": null
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Pending-RAI",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1659988588750,
-       "ID_NUMBER": "MD-0027.R01.00",
-       "STATUS_DATE": 1659988588750,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-0801.R00.01",
-      "sk": "SEATool#1650917395996",
-      "GSI1pk": "SEATool#1915b_waivers",
-      "GSI1sk": "MD-0801.R00.01",
-      "ACTIONTYPES": [
-         {
-           "ACTION_NAME": "Amend"
-         }
-       ],
-      "PLAN_TYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1659988588750,
+      "ID_NUMBER": "MD-0027.R01.00",
+      "STATUS_DATE": 1659988588750,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-0801.R00.01",
+    "sk": "SEATool#1650917395996",
+    "GSI1pk": "SEATool#1915b_waivers",
+    "GSI1sk": "MD-0801.R00.01",
+    "ACTIONTYPES": [
+      {
+        "ACTION_NAME": "Amend"
+      }
+    ],
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "1915(b)"
-       }
-      ],
-      "RAI": [
-       {
+      }
+    ],
+    "RAI": [
+      {
         "ID_NUMBER": "MD-0801.R00.01",
         "RAI_RECEIVED_DATE": null,
         "RAI_REQUESTED_DATE": 1650917395996,
         "RAI_WITHDRAWN_DATE": null
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Pending-RAI",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1650917395996,
-       "ID_NUMBER": "MD-0801.R00.01",
-       "STATUS_DATE": 1650917395996,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-77-0024",
-      "sk": "SEATool#1665549125264",
-      "GSI1pk": "SEATool#Medicaid_SPA",
-      "GSI1sk": "MD-77-0024",
-      "PLAN_TYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1650917395996,
+      "ID_NUMBER": "MD-0801.R00.01",
+      "STATUS_DATE": 1650917395996,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-77-0024",
+    "sk": "SEATool#1665549125264",
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "GSI1sk": "MD-77-0024",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "Medicaid SPA"
-       }
-      ],
-      "RAI": [
-       {
+      }
+    ],
+    "RAI": [
+      {
         "ID_NUMBER": "MD-77-0024",
         "RAI_RECEIVED_DATE": null,
         "RAI_REQUESTED_DATE": 1665549125264,
         "RAI_WITHDRAWN_DATE": null
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Pending-RAI",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1665549125264,
-       "ID_NUMBER": "MD-77-0024",
-       "STATUS_DATE": 1665549125264,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-1118.R00.00",
-      "sk": "SEATool#1649584977662",
-      "ACTIONTYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1665549125264,
+      "ID_NUMBER": "MD-77-0024",
+      "STATUS_DATE": 1665549125264,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-1118.R00.00",
+    "sk": "SEATool#1649584977662",
+    "ACTIONTYPES": [
+      {
         "ACTION_NAME": "New"
-       }
-      ],
-      "GSI1pk": "SEATool#1915b_waivers",
-      "GSI1sk": "MD-1118.R00.00",
-      "PLAN_TYPES": [
-       {
+      }
+    ],
+    "GSI1pk": "SEATool#1915b_waivers",
+    "GSI1sk": "MD-1118.R00.00",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "1915(b)"
-       }
-      ],
-      "RAI": [
-       {
+      }
+    ],
+    "RAI": [
+      {
         "ID_NUMBER": "MD-1118.R00.00",
         "RAI_RECEIVED_DATE": null,
         "RAI_REQUESTED_DATE": 1649584977662,
         "RAI_WITHDRAWN_DATE": null
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Pending-RAI",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1649584977662,
-       "ID_NUMBER": "MD-1118.R00.00",
-       "STATUS_DATE": 1649584977662,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-0775.R00.00",
-      "sk": "SEATool#1622584977662",
-      "ACTIONTYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1649584977662,
+      "ID_NUMBER": "MD-1118.R00.00",
+      "STATUS_DATE": 1649584977662,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-0775.R00.00",
+    "sk": "SEATool#1622584977662",
+    "ACTIONTYPES": [
+      {
         "ACTION_NAME": "New"
-       }
-      ],
-      "GSI1pk": "SEATool#1915b_waivers",
-      "GSI1sk": "MD-0775.R00.00",
-      "PLAN_TYPES": [
-       {
+      }
+    ],
+    "GSI1pk": "SEATool#1915b_waivers",
+    "GSI1sk": "MD-0775.R00.00",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "1915(b)"
-       }
-      ],
-      "RAI": [
-       {
+      }
+    ],
+    "RAI": [
+      {
         "ID_NUMBER": "MD-0775.R00.00",
         "RAI_RECEIVED_DATE": null,
         "RAI_REQUESTED_DATE": 1622584977662,
         "RAI_WITHDRAWN_DATE": null
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Pending-RAI",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1622584977662,
-       "ID_NUMBER": "MD-0775.R00.00",
-       "STATUS_DATE": 1622584977662,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-0777.R00.00",
-      "sk": "SEATool#1650584977662",
-      "ACTIONTYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1622584977662,
+      "ID_NUMBER": "MD-0775.R00.00",
+      "STATUS_DATE": 1622584977662,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-0777.R00.00",
+    "sk": "SEATool#1650584977662",
+    "ACTIONTYPES": [
+      {
         "ACTION_NAME": "New"
-       }
-      ],
-      "GSI1pk": "SEATool#1915b_waivers",
-      "GSI1sk": "MD-0777.R00.00",
-      "PLAN_TYPES": [
-       {
+      }
+    ],
+    "GSI1pk": "SEATool#1915b_waivers",
+    "GSI1sk": "MD-0777.R00.00",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "1915(b)"
-       }
-      ],
-      "RAI": [
-       {
+      }
+    ],
+    "RAI": [
+      {
         "ID_NUMBER": "MD-0777.R00.00",
         "RAI_RECEIVED_DATE": 1640584977662,
         "RAI_REQUESTED_DATE": 1630584977662,
         "RAI_WITHDRAWN_DATE": null
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Approved",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1650584977662,
-       "ID_NUMBER": "MD-0777.R00.00",
-       "STATUS_DATE": 1650584977662,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-5533.R00.00",
-      "sk": "SEATool#1650584977662",
-      "ACTIONTYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1650584977662,
+      "ID_NUMBER": "MD-0777.R00.00",
+      "STATUS_DATE": 1650584977662,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-5533.R00.00",
+    "sk": "SEATool#1650584977662",
+    "ACTIONTYPES": [
+      {
         "ACTION_NAME": "New"
-       }
-      ],
-      "GSI1pk": "SEATool#1915b_waivers",
-      "GSI1sk": "MD-5533.R00.00",
-      "PLAN_TYPES": [
-       {
+      }
+    ],
+    "GSI1pk": "SEATool#1915b_waivers",
+    "GSI1sk": "MD-5533.R00.00",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "1915(b)"
-       }
-      ],
-      "RAI": [
-       {
+      }
+    ],
+    "RAI": [
+      {
         "ID_NUMBER": "MD-5533.R00.00",
         "RAI_RECEIVED_DATE": null,
         "RAI_REQUESTED_DATE": 1650584977662,
         "RAI_WITHDRAWN_DATE": null
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Approved",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1650584977662,
-       "ID_NUMBER": "MD-5533.R00.00",
-       "STATUS_DATE": 1650584977662,
-       "SPW_STATUS_ID": 2
       }
-     },{
-      "pk": "MD-0003.R13.00",
-      "sk": "SEATool#1658708386545",
-      "ACTIONTYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1650584977662,
+      "ID_NUMBER": "MD-5533.R00.00",
+      "STATUS_DATE": 1650584977662,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-0003.R13.00",
+    "sk": "SEATool#1658708386545",
+    "ACTIONTYPES": [
+      {
         "ACTION_NAME": "Renew"
-       }
-      ],
-      "GSI1pk": "SEATool#1915b_waivers",
-      "GSI1sk": "MD-0003.R13.00",
-      "PLAN_TYPES": [
-       {
+      }
+    ],
+    "GSI1pk": "SEATool#1915b_waivers",
+    "GSI1sk": "MD-0003.R13.00",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "1915(b)"
-       }
-      ],
-      "RAI": [
-       {
+      }
+    ],
+    "RAI": [
+      {
         "ID_NUMBER": "MD-0003.R13.00",
         "RAI_RECEIVED_DATE": null,
         "RAI_REQUESTED_DATE": 1650584977662,
         "RAI_WITHDRAWN_DATE": null
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Approved",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1658708386545,
-       "ID_NUMBER": "MD-0003.R13.00",
-       "STATUS_DATE": 1658708386545,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-0148.R00.00",
-      "sk": "SEATool#1622272039453",
-      "ACTIONTYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1658708386545,
+      "ID_NUMBER": "MD-0003.R13.00",
+      "STATUS_DATE": 1658708386545,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-0148.R00.00",
+    "sk": "SEATool#1622272039453",
+    "ACTIONTYPES": [
+      {
         "ACTION_NAME": "New"
-       }
-      ],
-      "GSI1pk": "SEATool#1915b_waivers",
-      "GSI1sk": "MD-0148.R00.00",
-      "PLAN_TYPES": [
-       {
+      }
+    ],
+    "GSI1pk": "SEATool#1915b_waivers",
+    "GSI1sk": "MD-0148.R00.00",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "1915(b)"
-       }
-      ],
-      "RAI": [
-       {
+      }
+    ],
+    "RAI": [
+      {
         "ID_NUMBER": "MD-0148.R00.00",
         "RAI_RECEIVED_DATE": null,
         "RAI_REQUESTED_DATE": 1622272039453,
         "RAI_WITHDRAWN_DATE": null
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Approved",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1622272039453,
-       "ID_NUMBER": "MD-0148.R00.00",
-       "STATUS_DATE": 1622272039453,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-22-0008",
-      "sk": "SEATool#1652577796728",
-      "GSI1pk": "SEATool#Medicaid_SPA",
-      "GSI1sk": "MD-22-0008",
-      "PLAN_TYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1622272039453,
+      "ID_NUMBER": "MD-0148.R00.00",
+      "STATUS_DATE": 1622272039453,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-22-0008",
+    "sk": "SEATool#1652577796728",
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "GSI1sk": "MD-22-0008",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "Medicaid SPA"
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Disapproved",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1652577796728,
-       "ID_NUMBER": "MD-22-0008",
-       "STATUS_DATE": 1652577796728,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-2027.R01.00",
-      "sk": "SEATool#1660388588750",
-      "ACTIONTYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1652577796728,
+      "ID_NUMBER": "MD-22-0008",
+      "STATUS_DATE": 1652577796728,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-2027.R01.00",
+    "sk": "SEATool#1660388588750",
+    "ACTIONTYPES": [
+      {
         "ACTION_NAME": "Renew"
-       }
-      ],
-      "GSI1pk": "SEATool#1915b_waivers",
-      "GSI1sk": "MD-2027.R01.00",
-      "PLAN_TYPES": [
-       {
+      }
+    ],
+    "GSI1pk": "SEATool#1915b_waivers",
+    "GSI1sk": "MD-2027.R01.00",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "1915(b)"
-       }
-      ],
-      "RAI": [
-       {
+      }
+    ],
+    "RAI": [
+      {
         "ID_NUMBER": "MD-2027.R01.00",
         "RAI_RECEIVED_DATE": null,
         "RAI_REQUESTED_DATE": 1660388588750,
         "RAI_WITHDRAWN_DATE": null
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Disapproved",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1660388588750,
-       "ID_NUMBER": "MD-2027.R01.00",
-       "STATUS_DATE": 1660388588750,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-22-0001",
-      "sk": "SEATool#1652825140199",
-      "GSI1pk": "SEATool#Medicaid_SPA",
-      "GSI1sk": "MD-22-0001",
-      "PLAN_TYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1660388588750,
+      "ID_NUMBER": "MD-2027.R01.00",
+      "STATUS_DATE": 1660388588750,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-22-0001",
+    "sk": "SEATool#1652825140199",
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "GSI1sk": "MD-22-0001",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "Medicaid SPA"
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Withdrawn",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1652825140199,
-       "ID_NUMBER": "MD-22-0001",
-       "STATUS_DATE": 1652825140199,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-1029.R01.00",
-      "sk": "SEATool#1661388588750",
-      "ACTIONTYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1652825140199,
+      "ID_NUMBER": "MD-22-0001",
+      "STATUS_DATE": 1652825140199,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-1029.R01.00",
+    "sk": "SEATool#1661388588750",
+    "ACTIONTYPES": [
+      {
         "ACTION_NAME": "Renew"
-       }
-      ],
-      "GSI1pk": "SEATool#1915b_waivers",
-      "GSI1sk": "MD-1029.R01.00",
-      "PLAN_TYPES": [
-       {
+      }
+    ],
+    "GSI1pk": "SEATool#1915b_waivers",
+    "GSI1sk": "MD-1029.R01.00",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "1915(b)"
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Withdrawn",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1661388588750,
-       "ID_NUMBER": "MD-1029.R01.00",
-       "STATUS_DATE": 1661388588750,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-6777.R00.00",
-      "sk": "SEATool#1650584977662",
-      "ACTIONTYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1661388588750,
+      "ID_NUMBER": "MD-1029.R01.00",
+      "STATUS_DATE": 1661388588750,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-6777.R00.00",
+    "sk": "SEATool#1650584977662",
+    "ACTIONTYPES": [
+      {
         "ACTION_NAME": "New"
-       }
-      ],
-      "GSI1pk": "SEATool#1915b_waivers",
-      "GSI1sk": "MD-6777.R00.00",
-      "PLAN_TYPES": [
-       {
+      }
+    ],
+    "GSI1pk": "SEATool#1915b_waivers",
+    "GSI1sk": "MD-6777.R00.00",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "1915(b)"
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Unsubmitted",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1650584977662,
-       "ID_NUMBER": "MD-6777.R00.00",
-       "STATUS_DATE": 1650584977662,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-22-1018",
-      "sk": "SEATool#1665696818833",
-      "GSI1pk": "SEATool#Medicaid_SPA",
-      "GSI1sk": "MD-22-1018",
-      "PLAN_TYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1650584977662,
+      "ID_NUMBER": "MD-6777.R00.00",
+      "STATUS_DATE": 1650584977662,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-22-1018",
+    "sk": "SEATool#1665696818833",
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "GSI1sk": "MD-22-1018",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "Medicaid SPA"
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Unsubmitted",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1665696818833,
-       "ID_NUMBER": "MD-22-1018",
-       "STATUS_DATE": 1665696818833,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-22-0002",
-      "sk": "SEATool#1648825662861",
-      "GSI1pk": "SEATool#Medicaid_SPA",
-      "GSI1sk": "MD-22-0002",
-      "PLAN_TYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1665696818833,
+      "ID_NUMBER": "MD-22-1018",
+      "STATUS_DATE": 1665696818833,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-22-0002",
+    "sk": "SEATool#1648825662861",
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "GSI1sk": "MD-22-0002",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "Medicaid SPA"
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Pending",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1648825662861,
-       "ID_NUMBER": "MD-22-0002",
-       "STATUS_DATE": 1648825662861,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-0027.R01.00",
-      "sk": "SEATool#1662388588750",
-      "ACTIONTYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1648825662861,
+      "ID_NUMBER": "MD-22-0002",
+      "STATUS_DATE": 1648825662861,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-0027.R01.00",
+    "sk": "SEATool#1662388588750",
+    "ACTIONTYPES": [
+      {
         "ACTION_NAME": "Renew"
-       }
-      ],
-      "GSI1pk": "SEATool#1915b_waivers",
-      "GSI1sk": "MD-0027.R01.00",
-      "PLAN_TYPES": [
-       {
+      }
+    ],
+    "GSI1pk": "SEATool#1915b_waivers",
+    "GSI1sk": "MD-0027.R01.00",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "1915(b)"
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Pending",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1662388588750,
-       "ID_NUMBER": "MD-0027.R01.00",
-       "STATUS_DATE": 1662388588750,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-3777.R00.00",
-      "sk": "SEATool#1651584977662",
-      "ACTIONTYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1662388588750,
+      "ID_NUMBER": "MD-0027.R01.00",
+      "STATUS_DATE": 1662388588750,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-3777.R00.00",
+    "sk": "SEATool#1651584977662",
+    "ACTIONTYPES": [
+      {
         "ACTION_NAME": "New"
-       }
-      ],
-      "GSI1pk": "SEATool#1915b_waivers",
-      "GSI1sk": "MD-3777.R00.00",
-      "PLAN_TYPES": [
-       {
+      }
+    ],
+    "GSI1pk": "SEATool#1915b_waivers",
+    "GSI1sk": "MD-3777.R00.00",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_NAME": "1915(b)"
-       }
-      ],
-      "SPW_STATUS": [
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
         "SPW_STATUS_DESC": "Unsubmitted",
         "SPW_STATUS_ID": 2
-       },{
+      },
+      {
         "SPW_STATUS_DESC": "Pending",
         "SPW_STATUS_ID": 1
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1651584977662,
-       "ID_NUMBER": "MD-3777.R00.00",
-       "STATUS_DATE": 1651584977662,
-       "SPW_STATUS_ID": 2
       }
-     },
-     {
-      "pk": "MD-0339.R04.06",
-      "sk": "SEATool#1666753662081",
-      "ACTIONTYPES": [
-       {
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1651584977662,
+      "ID_NUMBER": "MD-3777.R00.00",
+      "STATUS_DATE": 1651584977662,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "pk": "MD-0339.R04.06",
+    "sk": "SEATool#1666753662081",
+    "ACTIONTYPES": [
+      {
         "ACTION_ID": 76,
         "ACTION_NAME": "Amend",
         "PLAN_TYPE_ID": 123
-       }
-      ],
-      "GSI1pk": "SEATool#1915c_waivers",
-      "GSI1sk": "MD-0339.R04.06",
-      "PLAN_TYPES": [
-       {
+      }
+    ],
+    "GSI1pk": "SEATool#1915c_waivers",
+    "GSI1sk": "MD-0339.R04.06",
+    "PLAN_TYPES": [
+      {
         "PLAN_TYPE_ID": 122,
         "PLAN_TYPE_NAME": "1915(c)"
-       }
-      ],
-      "RAI": [
-       {
+      }
+    ],
+    "RAI": [
+      {
         "ID_NUMBER": "MD-0339.R04.06",
         "RAI_RECEIVED_DATE": 1664753662081,
         "RAI_REQUESTED_DATE": 1659988588750,
         "RAI_WITHDRAWN_DATE": null
-       }
-      ],
-      "SPW_STATUS": [
-        {
-         "SPW_STATUS_DESC": "Pending",
-         "SPW_STATUS_ID": 1
-        },
-        {
-         "SPW_STATUS_DESC": "Pending-Concurrence",
-         "SPW_STATUS_ID": 8
-        },
-        {
-         "SPW_STATUS_DESC": "Pending-Approval",
-         "SPW_STATUS_ID": 11
-        },
-       {
+      }
+    ],
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_DESC": "Pending",
+        "SPW_STATUS_ID": 1
+      },
+      {
+        "SPW_STATUS_DESC": "Pending-Concurrence",
+        "SPW_STATUS_ID": 8
+      },
+      {
+        "SPW_STATUS_DESC": "Pending-Approval",
+        "SPW_STATUS_ID": 11
+      },
+      {
         "SPW_STATUS_DESC": "Approved",
         "SPW_STATUS_ID": 2
-       }
-      ],
-      "STATE_PLAN": {
-       "CHANGED_DATE": 1666753662081,
-       "ID_NUMBER": "MD-0339.R04.06",
-       "STATUS_DATE": 1666753662081,
-       "SPW_STATUS_ID": 2
       }
-     }
+    ],
+    "STATE_PLAN": {
+      "CHANGED_DATE": 1666753662081,
+      "ID_NUMBER": "MD-0339.R04.06",
+      "STATUS_DATE": 1666753662081,
+      "SPW_STATUS_ID": 2
+    }
+  },
+  {
+    "clockEndTimestamp": 1680107642909,
+    "componentType": "chipspa",
+    "eventTimestamp": 1672335242909,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672335239150/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "Current State Plan",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335239150/excel.xlsx"
+      },
+      {
+        "s3Key": "1672335239152/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Amended State Plan Language",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335239152/picture.jpg"
+      },
+      {
+        "s3Key": "1672335239152/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "Cover Letter",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335239152/excel.xlsx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2300-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672335242909,
+    "GSI1pk": "OneMAC#submitchipspa",
+    "convertTimestamp": 1673973231588,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672335242909",
+    "componentId": "MD-22-2300-VM",
+    "pk": "MD-22-2300-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680107642909,
+    "componentType": "chipspa",
+    "currentStatus": "Under Review",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672335239150/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "Current State Plan",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335239150/excel.xlsx"
+      },
+      {
+        "s3Key": "1672335239152/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Amended State Plan Language",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335239152/picture.jpg"
+      },
+      {
+        "s3Key": "1672335239152/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "Cover Letter",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335239152/excel.xlsx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2300-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672335242909,
+    "GSI1pk": "OneMAC#spa",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22-2300-VM",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672410333843,
+    "pk": "MD-22-2300-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": 59,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": 1,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "828EB7F9-8675-4FF3-82F3-6EC9147ACC0C",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 124,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2300-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672410333843,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 84,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 73,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2300-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 84
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672410333843",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "PLAN_TYPE_NAME": "CHIP SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P1",
+        "PRIORITY_CODE_DESCRIPTION": "Must go through OCD",
+        "PRIORITY_CODE_ID": 1
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#CHIP_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 73,
+        "COMPONENT_NAME": "CAHPG"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2300-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2300-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2300-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680107674878,
+    "componentType": "chipspa",
+    "eventTimestamp": 1672335274878,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672335273003/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "Current State Plan",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335273003/textnotes.txt"
+      },
+      {
+        "s3Key": "1672335273005/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Amended State Plan Language",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335273005/picture.jpg"
+      },
+      {
+        "s3Key": "1672335273006/file.docx",
+        "filename": "file.docx",
+        "title": "Cover Letter",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335273006/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2301-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672335274878,
+    "GSI1pk": "OneMAC#submitchipspa",
+    "convertTimestamp": 1673973214463,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672335274878",
+    "componentId": "MD-22-2301-VM",
+    "pk": "MD-22-2301-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680107674878,
+    "componentType": "chipspa",
+    "currentStatus": "Disapproved",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672335273003/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "Current State Plan",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335273003/textnotes.txt"
+      },
+      {
+        "s3Key": "1672335273005/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Amended State Plan Language",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335273005/picture.jpg"
+      },
+      {
+        "s3Key": "1672335273006/file.docx",
+        "filename": "file.docx",
+        "title": "Cover Letter",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335273006/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2301-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672335274878,
+    "GSI1pk": "OneMAC#spa",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22-2301-VM",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672410424223,
+    "pk": "MD-22-2301-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": 59,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": 1,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "99E061F8-7F68-4BC4-8D3F-9EEEEC6BE789",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 124,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2301-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672410370693,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 84,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 73,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2301-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 84
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672410370693",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "PLAN_TYPE_NAME": "CHIP SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P1",
+        "PRIORITY_CODE_DESCRIPTION": "Must go through OCD",
+        "PRIORITY_CODE_ID": 1
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#CHIP_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 73,
+        "COMPONENT_NAME": "CAHPG"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2301-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2301-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2301-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "disapproved status",
+      "SPW_STATUS_ID": 5,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": 59,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": 1,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "99E061F8-7F68-4BC4-8D3F-9EEEEC6BE789",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 124,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2301-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672410424223,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 84,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 73,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22-2301-VM",
+        "SERVICE_TYPE_ID": 64
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2301-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 5,
+        "SPW_STATUS_DESC": "Disapproved"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 84
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 419,
+        "ID_NUMBER": "MD-22-2301-VM"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672410424223",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "PLAN_TYPE_NAME": "CHIP SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P1",
+        "PRIORITY_CODE_DESCRIPTION": "Must go through OCD",
+        "PRIORITY_CODE_ID": 1
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#CHIP_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 73,
+        "COMPONENT_NAME": "CAHPG"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2301-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2301-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2301-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680107707229,
+    "componentType": "chipspa",
+    "eventTimestamp": 1672335307229,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672335305334/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "Current State Plan",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335305334/excel.xlsx"
+      },
+      {
+        "s3Key": "1672335305336/file.docx",
+        "filename": "file.docx",
+        "title": "Amended State Plan Language",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335305336/file.docx"
+      },
+      {
+        "s3Key": "1672335305336/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Cover Letter",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335305336/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2302-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672335307229,
+    "GSI1pk": "OneMAC#submitchipspa",
+    "convertTimestamp": 1673973215750,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672335307229",
+    "componentId": "MD-22-2302-VM",
+    "pk": "MD-22-2302-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680107707229,
+    "componentType": "chipspa",
+    "currentStatus": "Package Withdrawn",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672335305334/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "Current State Plan",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335305334/excel.xlsx"
+      },
+      {
+        "s3Key": "1672335305336/file.docx",
+        "filename": "file.docx",
+        "title": "Amended State Plan Language",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335305336/file.docx"
+      },
+      {
+        "s3Key": "1672335305336/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Cover Letter",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335305336/picture.jpg"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2302-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672335307229,
+    "GSI1pk": "OneMAC#spa",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22-2302-VM",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672757777537,
+    "pk": "MD-22-2302-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": 59,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": 1,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "41878DF2-8A35-4E8D-A94F-7A17353A5FD0",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 124,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2302-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672410448767,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 84,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 73,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2302-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 84
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672410448767",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "PLAN_TYPE_NAME": "CHIP SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P1",
+        "PRIORITY_CODE_DESCRIPTION": "Must go through OCD",
+        "PRIORITY_CODE_ID": 1
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#CHIP_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 73,
+        "COMPONENT_NAME": "CAHPG"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2302-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2302-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2302-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "withdrawn",
+      "SPW_STATUS_ID": 6,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": 59,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": 1,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "41878DF2-8A35-4E8D-A94F-7A17353A5FD0",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672704000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 124,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2302-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672757777537,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 84,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 73,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22-2302-VM",
+        "SERVICE_TYPE_ID": 64
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2302-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 6,
+        "SPW_STATUS_DESC": "Withdrawn"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 84
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 419,
+        "ID_NUMBER": "MD-22-2302-VM"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672757777537",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "PLAN_TYPE_NAME": "CHIP SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P1",
+        "PRIORITY_CODE_DESCRIPTION": "Must go through OCD",
+        "PRIORITY_CODE_ID": 1
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#CHIP_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 73,
+        "COMPONENT_NAME": "CAHPG"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2302-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2302-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2302-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680107736218,
+    "componentType": "chipspa",
+    "eventTimestamp": 1672335336218,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672335334066/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "Current State Plan",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335334066/textnotes.txt"
+      },
+      {
+        "s3Key": "1672335334068/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Amended State Plan Language",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335334068/picture.jpg"
+      },
+      {
+        "s3Key": "1672335334069/file.docx",
+        "filename": "file.docx",
+        "title": "Cover Letter",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335334069/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2303-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672335336218,
+    "GSI1pk": "OneMAC#submitchipspa",
+    "convertTimestamp": 1673973218130,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672335336218",
+    "componentId": "MD-22-2303-VM",
+    "pk": "MD-22-2303-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680107736218,
+    "componentType": "chipspa",
+    "currentStatus": "Pending - Concurrence",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672335334066/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "Current State Plan",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335334066/textnotes.txt"
+      },
+      {
+        "s3Key": "1672335334068/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Amended State Plan Language",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335334068/picture.jpg"
+      },
+      {
+        "s3Key": "1672335334069/file.docx",
+        "filename": "file.docx",
+        "title": "Cover Letter",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335334069/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "2023-03-16",
+    "GSI1sk": "MD-22-2303-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672335336218,
+    "GSI1pk": "OneMAC#spa",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22-2303-VM",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672410585820,
+    "pk": "MD-22-2303-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": 59,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": 1,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "9F0A9478-A0BF-4854-BFD9-23C393672C6C",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 124,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2303-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672410501983,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 84,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 73,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2303-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 84
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672410501983",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "PLAN_TYPE_NAME": "CHIP SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P1",
+        "PRIORITY_CODE_DESCRIPTION": "Must go through OCD",
+        "PRIORITY_CODE_ID": 1
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#CHIP_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 73,
+        "COMPONENT_NAME": "CAHPG"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2303-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2303-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2303-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": 3993,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": 11,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": false,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "pending-concurrence",
+      "SPW_STATUS_ID": 8,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": 1678924800000,
+      "ALERT_MILESTONE1_DAYS": 59,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": 3,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": 3996,
+      "GAP3": null,
+      "UUID": "9F0A9478-A0BF-4854-BFD9-23C393672C6C",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 124,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2303-VM",
+      "APPROVAL_STATUS_TYPE": "test",
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672410585820,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 84,
+      "PENDING_CONCURRENCE_DATE": 1672358400000,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 73,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22-2303-VM",
+        "SERVICE_TYPE_ID": 64
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2303-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": [
+      {
+        "CALL_HELD_REASON_ID": 11,
+        "REASON_DESCRIPTION": "Test"
+      }
+    ],
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 8,
+        "SPW_STATUS_DESC": "Pending-Concurrence"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 84
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 419,
+        "ID_NUMBER": "MD-22-2303-VM"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672410585820",
+    "ACTION_OFFICERS": [
+      {
+        "INITIALS": null,
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3993,
+        "LAST_NAME": "Test2",
+        "EMAIL": null,
+        "FIRST_NAME": "Test1"
+      }
+    ],
+    "SP1115": null,
+    "COMPONENTS_SP": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 73,
+        "COMPONENT_NAME": "CAHPG"
+      }
+    ],
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "PLAN_TYPE_NAME": "CHIP SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P1",
+        "PRIORITY_CODE_DESCRIPTION": "Must go through OCD",
+        "PRIORITY_CODE_ID": 1
+      },
+      {
+        "PRIORITY_CODE": "P3",
+        "PRIORITY_CODE_DESCRIPTION": "Routine action test",
+        "PRIORITY_CODE_ID": 3
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#CHIP_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 73,
+        "COMPONENT_NAME": "CAHPG"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": false,
+          "ID_NUMBER": "MD-22-2303-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": true,
+          "ID_NUMBER": "MD-22-2303-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2303-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680107775788,
+    "componentType": "chipspa",
+    "eventTimestamp": 1672335375788,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672335373931/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "Current State Plan",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335373931/textnotes.txt"
+      },
+      {
+        "s3Key": "1672335373932/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Amended State Plan Language",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335373932/picture.jpg"
+      },
+      {
+        "s3Key": "1672335373933/file.docx",
+        "filename": "file.docx",
+        "title": "Cover Letter",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335373933/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2304-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672335375788,
+    "GSI1pk": "OneMAC#submitchipspa",
+    "convertTimestamp": 1673973219241,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672335375788",
+    "componentId": "MD-22-2304-VM",
+    "pk": "MD-22-2304-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1681745897368,
+    "componentType": "chipsparai",
+    "eventTimestamp": 1673973497368,
+    "transmittalNumberWarningMessage": "",
+    "currentStatus": "Submitted",
+    "parentId": "MD-22-2304-VM",
+    "attachments": [
+      {
+        "s3Key": "1673973495489/adobe.pdf",
+        "filename": "adobe.pdf",
+        "title": "Revised Amended State Plan Language",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673973495489/adobe.pdf"
+      },
+      {
+        "s3Key": "1673973495490/adobe.pdf",
+        "filename": "adobe.pdf",
+        "title": "Official RAI Response",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673973495490/adobe.pdf"
+      }
+    ],
+    "parentType": "chipspa",
+    "GSI1sk": "MD-22-2304-VM",
+    "additionalInformation": "",
+    "submissionTimestamp": 1673973497368,
+    "GSI1pk": "OneMAC#submitchipsparai",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "territory": "MD",
+    "sk": "OneMAC#1673973497368",
+    "componentId": "MD-22-2304-VM",
+    "pk": "MD-22-2304-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680107775788,
+    "componentType": "chipspa",
+    "currentStatus": "Submitted",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672335373931/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "Current State Plan",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335373931/textnotes.txt"
+      },
+      {
+        "s3Key": "1672335373932/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Amended State Plan Language",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335373932/picture.jpg"
+      },
+      {
+        "s3Key": "1672335373933/file.docx",
+        "filename": "file.docx",
+        "title": "Cover Letter",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335373933/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2304-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672335375788,
+    "GSI1pk": "OneMAC#spa",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22-2304-VM",
+    "raiResponses": [
+      {
+        "additionalInformation": "",
+        "submissionTimestamp": 1673973497368,
+        "attachments": [
+          {
+            "s3Key": "1673973495489/adobe.pdf",
+            "filename": "adobe.pdf",
+            "title": "Revised Amended State Plan Language",
+            "contentType": "application/pdf",
+            "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673973495489/adobe.pdf"
+          },
+          {
+            "s3Key": "1673973495490/adobe.pdf",
+            "filename": "adobe.pdf",
+            "title": "Official RAI Response",
+            "contentType": "application/pdf",
+            "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673973495490/adobe.pdf"
+          }
+        ]
+      }
+    ],
+    "lastEventTimestamp": 1673973497368,
+    "pk": "MD-22-2304-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": 59,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": 1,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "6B3EB64A-FA6A-4327-AB78-DFDF2454342C",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 124,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2304-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672410621817,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 84,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 73,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2304-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 84
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672410621817",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "PLAN_TYPE_NAME": "CHIP SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P1",
+        "PRIORITY_CODE_DESCRIPTION": "Must go through OCD",
+        "PRIORITY_CODE_ID": 1
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#CHIP_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 73,
+        "COMPONENT_NAME": "CAHPG"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2304-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2304-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2304-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "pending-rai status",
+      "SPW_STATUS_ID": 2,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": 59,
+      "ALERT_90_DAYS_DATE": null,
+      "PRIORITY_CODE_ID": 3,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "6B3EB64A-FA6A-4327-AB78-DFDF2454342C",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 124,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2304-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672410832267,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 84,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 73,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22-2304-VM",
+        "SERVICE_TYPE_ID": 64
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2304-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 2,
+        "SPW_STATUS_DESC": "Pending-RAI"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 84
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 419,
+        "ID_NUMBER": "MD-22-2304-VM"
+      }
+    ],
+    "RAI": [
+      {
+        "RAI_WITHDRAWN_DATE": null,
+        "ID_NUMBER": "MD-22-2304-VM",
+        "RAI_RECEIVED_DATE": null,
+        "RAI_REQUESTED_DATE": 1672358400000
+      }
+    ],
+    "sk": "SEATool#1672410832267",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "PLAN_TYPE_NAME": "CHIP SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P1",
+        "PRIORITY_CODE_DESCRIPTION": "Must go through OCD",
+        "PRIORITY_CODE_ID": 1
+      },
+      {
+        "PRIORITY_CODE": "P3",
+        "PRIORITY_CODE_DESCRIPTION": "Routine action test",
+        "PRIORITY_CODE_ID": 3
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#CHIP_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 73,
+        "COMPONENT_NAME": "CAHPG"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": false,
+          "ID_NUMBER": "MD-22-2304-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": true,
+          "ID_NUMBER": "MD-22-2304-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2304-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680107865004,
+    "componentType": "chipspa",
+    "eventTimestamp": 1672335465004,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672335463082/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "Current State Plan",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335463082/textnotes.txt"
+      },
+      {
+        "s3Key": "1672335463085/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Amended State Plan Language",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335463085/picture.jpg"
+      },
+      {
+        "s3Key": "1672335463085/file.docx",
+        "filename": "file.docx",
+        "title": "Cover Letter",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335463085/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2305-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672335465004,
+    "GSI1pk": "OneMAC#submitchipspa",
+    "convertTimestamp": 1673973223901,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672335465004",
+    "componentId": "MD-22-2305-VM",
+    "pk": "MD-22-2305-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680107865004,
+    "componentType": "chipspa",
+    "currentStatus": "Pending - Approval",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672335463082/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "Current State Plan",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335463082/textnotes.txt"
+      },
+      {
+        "s3Key": "1672335463085/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Amended State Plan Language",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335463085/picture.jpg"
+      },
+      {
+        "s3Key": "1672335463085/file.docx",
+        "filename": "file.docx",
+        "title": "Cover Letter",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672335463085/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "2023-03-09",
+    "GSI1sk": "MD-22-2305-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672335465004,
+    "GSI1pk": "OneMAC#spa",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22-2305-VM",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672411182020,
+    "pk": "MD-22-2305-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": 3993,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": 11,
+      "FRT_DATE": 1672358400000,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": false,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "pending-approval",
+      "SPW_STATUS_ID": 11,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": 1678320000000,
+      "ALERT_MILESTONE1_DAYS": 59,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": 3,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": 3996,
+      "GAP3": null,
+      "UUID": "7D98F246-EFE4-4BD4-ABCE-1CFF734C119F",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 124,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2305-VM",
+      "APPROVAL_STATUS_TYPE": "test",
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": 1672358400000,
+      "CHANGED_DATE": 1672411069067,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": 1679270400000,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 84,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 119,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": 3,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": 1672358400000,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2305-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 84
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672411069067",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "PLAN_TYPE_NAME": "CHIP SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P1",
+        "PRIORITY_CODE_DESCRIPTION": "Must go through OCD",
+        "PRIORITY_CODE_ID": 1
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#CHIP_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 73,
+        "COMPONENT_NAME": "CAHPG"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2305-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2305-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2305-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": 3993,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": 11,
+      "FRT_DATE": 1672358400000,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": false,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "pending-approval",
+      "SPW_STATUS_ID": 11,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": 1678320000000,
+      "ALERT_MILESTONE1_DAYS": 59,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": 3,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": 3996,
+      "GAP3": null,
+      "UUID": "7D98F246-EFE4-4BD4-ABCE-1CFF734C119F",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672358400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672358400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 124,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2305-VM",
+      "APPROVAL_STATUS_TYPE": "test",
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": 1672358400000,
+      "CHANGED_DATE": 1672411182020,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": 1679270400000,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 84,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 119,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": 3,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": 1672358400000,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22-2305-VM",
+        "SERVICE_TYPE_ID": 64
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2305-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": [
+      {
+        "CALL_HELD_REASON_ID": 11,
+        "REASON_DESCRIPTION": "Test"
+      }
+    ],
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 11,
+        "SPW_STATUS_DESC": "Pending-Approval"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 84
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 419,
+        "ID_NUMBER": "MD-22-2305-VM"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672411182020",
+    "ACTION_OFFICERS": [
+      {
+        "INITIALS": "A",
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3996,
+        "LAST_NAME": "Test1",
+        "EMAIL": "abc@exampl.com",
+        "FIRST_NAME": "Demo1"
+      }
+    ],
+    "SP1115": null,
+    "COMPONENTS_SP": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 76,
+        "COMPONENT_NAME": "Test 9"
+      }
+    ],
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "PLAN_TYPE_NAME": "CHIP SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P1",
+        "PRIORITY_CODE_DESCRIPTION": "Must go through OCD",
+        "PRIORITY_CODE_ID": 1
+      },
+      {
+        "PRIORITY_CODE": "P3",
+        "PRIORITY_CODE_DESCRIPTION": "Routine action test",
+        "PRIORITY_CODE_ID": 3
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#CHIP_SPA",
+    "CODEAFTERINITACCESS": [
+      {
+        "CODE_AFTER_INIT_ASSESS_ID": 3,
+        "CODE_AFTER_INIT_ASSESS_DESC": "Same"
+      }
+    ],
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 73,
+        "COMPONENT_NAME": "CAHPG"
+      },
+      {
+        "ALERTS_INBOX_ADDRESS": "Test#2",
+        "COMPONENT_ID": 119,
+        "COMPONENT_NAME": "Test-5"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": false,
+          "ID_NUMBER": "MD-22-2305-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": true,
+          "ID_NUMBER": "MD-22-2305-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2305-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1681064517924,
+    "componentType": "chipspa",
+    "eventTimestamp": 1673292117924,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1673292115543/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "Current State Plan",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673292115543/textnotes.txt"
+      },
+      {
+        "s3Key": "1673292115546/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Amended State Plan Language",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673292115546/picture.jpg"
+      },
+      {
+        "s3Key": "1673292115546/file.docx",
+        "filename": "file.docx",
+        "title": "Cover Letter",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673292115546/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2306-VM",
+    "additionalInformation": "approved status",
+    "submissionTimestamp": 1673292117924,
+    "GSI1pk": "OneMAC#submitchipspa",
+    "convertTimestamp": 1673973229829,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1673292117924",
+    "componentId": "MD-22-2306-VM",
+    "pk": "MD-22-2306-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1681064517924,
+    "componentType": "chipspa",
+    "currentStatus": "Approved",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1673292115543/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "Current State Plan",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673292115543/textnotes.txt"
+      },
+      {
+        "s3Key": "1673292115546/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "Amended State Plan Language",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673292115546/picture.jpg"
+      },
+      {
+        "s3Key": "1673292115546/file.docx",
+        "filename": "file.docx",
+        "title": "Cover Letter",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673292115546/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "2023-03-08",
+    "GSI1sk": "MD-22-2306-VM",
+    "additionalInformation": "approved status",
+    "submissionTimestamp": 1673292117924,
+    "GSI1pk": "OneMAC#spa",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22-2306-VM",
+    "raiResponses": [],
+    "lastEventTimestamp": 1673293365150,
+    "pk": "MD-22-2306-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": 59,
+      "ALERT_90_DAYS_DATE": 1681084800000,
+      "PRIORITY_CODE_ID": 1,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "D2150892-0EEE-4413-A06B-1252303E334E",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1673308800000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1673222400000,
+      "STATUS_DATE": 1673222400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 124,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2306-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1673293249117,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 84,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 73,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2306-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 84
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1673293249117",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "PLAN_TYPE_NAME": "CHIP SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P1",
+        "PRIORITY_CODE_DESCRIPTION": "Must go through OCD",
+        "PRIORITY_CODE_ID": 1
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#CHIP_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 73,
+        "COMPONENT_NAME": "CAHPG"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2306-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2306-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2306-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": 3996,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": 1673222400000,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": true,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "approved status",
+      "SPW_STATUS_ID": 4,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": 1678233600000,
+      "ALERT_MILESTONE1_DAYS": 59,
+      "ALERT_90_DAYS_DATE": 1681084800000,
+      "PRIORITY_CODE_ID": 3,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": 3993,
+      "GAP3": null,
+      "UUID": "D2150892-0EEE-4413-A06B-1252303E334E",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1673308800000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1673222400000,
+      "STATUS_DATE": 1673275365093,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 1,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 124,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2306-VM",
+      "APPROVAL_STATUS_TYPE": "test",
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": 1673222400000,
+      "CHANGED_DATE": 1673293365150,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": "test",
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": 1678320000000,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": 84,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 73,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": 3,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": 1673222400000,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22-2306-VM",
+        "SERVICE_TYPE_ID": 61
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2306-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      },
+      {
+        "OCD_REVIEW_DESCRIPTION": "Yes",
+        "OCD_REVIEW_ID": 1
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 4,
+        "SPW_STATUS_DESC": "Approved"
+      }
+    ],
+    "ACTIONTYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "ACTION_NAME": "Amend",
+        "ACTION_ID": 84
+      }
+    ],
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 340,
+        "ID_NUMBER": "MD-22-2306-VM"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1673293365150",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 76,
+        "COMPONENT_NAME": "Test 9"
+      }
+    ],
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 124,
+        "PLAN_TYPE_NAME": "CHIP SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P1",
+        "PRIORITY_CODE_DESCRIPTION": "Must go through OCD",
+        "PRIORITY_CODE_ID": 1
+      },
+      {
+        "PRIORITY_CODE": "P3",
+        "PRIORITY_CODE_DESCRIPTION": "Routine action test",
+        "PRIORITY_CODE_ID": 3
+      }
+    ],
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#CHIP_SPA",
+    "CODEAFTERINITACCESS": [
+      {
+        "CODE_AFTER_INIT_ASSESS_ID": 3,
+        "CODE_AFTER_INIT_ASSESS_DESC": "Same"
+      }
+    ],
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 73,
+        "COMPONENT_NAME": "CAHPG"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": false,
+          "ID_NUMBER": "MD-22-2306-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": true,
+          "ID_NUMBER": "MD-22-2306-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2306-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1681063696466,
+    "componentType": "medicaidspa",
+    "eventTimestamp": 1673291296466,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1673291294385/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "CMS Form 179",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673291294385/excel.xlsx"
+      },
+      {
+        "s3Key": "1673291294387/file.docx",
+        "filename": "file.docx",
+        "title": "SPA Pages",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673291294387/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2206-VM",
+    "additionalInformation": "test approved status",
+    "submissionTimestamp": 1673291296466,
+    "GSI1pk": "OneMAC#submitmedicaidspa",
+    "convertTimestamp": 1673973231484,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1673291296466",
+    "componentId": "MD-22-2206-VM",
+    "pk": "MD-22-2206-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1681063696466,
+    "componentType": "medicaidspa",
+    "currentStatus": "Approved",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1673291294385/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "CMS Form 179",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673291294385/excel.xlsx"
+      },
+      {
+        "s3Key": "1673291294387/file.docx",
+        "filename": "file.docx",
+        "title": "SPA Pages",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673291294387/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "2023-03-22",
+    "GSI1sk": "MD-22-2206-VM",
+    "additionalInformation": "test approved status",
+    "submissionTimestamp": 1673291296466,
+    "GSI1pk": "OneMAC#spa",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22-2206-VM",
+    "raiResponses": [],
+    "lastEventTimestamp": 1673292051500,
+    "pk": "MD-22-2206-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680998400000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "9A387EDB-7A58-43C4-8F83-A49AB93D9A18",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1673222400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1673222400000,
+      "STATUS_DATE": 1673222400000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 125,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2206-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1673291864867,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2206-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1673291864867",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 125,
+        "PLAN_TYPE_NAME": "Medicaid SPA"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2206-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2206-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2206-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": 3996,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": 11,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": false,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "approved status",
+      "SPW_STATUS_ID": 4,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": 1679443200000,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680998400000,
+      "PRIORITY_CODE_ID": 3,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": 3993,
+      "GAP3": null,
+      "UUID": "9A387EDB-7A58-43C4-8F83-A49AB93D9A18",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1673222400000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1673222400000,
+      "STATUS_DATE": 1673274051437,
+      "COMPANION_LETTER_RECEIVED_DATE": 1673222400000,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 1,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 125,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2206-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": 1673222400000,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": 1673222400000,
+      "CHANGED_DATE": 1673292051500,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": "test",
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": 1679443200000,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 76,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": 3,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": 1673222400000,
+      "APPROVAL_DOCS_RECEIVED": true,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22-2206-VM",
+        "SERVICE_TYPE_ID": 93
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2206-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      },
+      {
+        "OCD_REVIEW_DESCRIPTION": "Yes",
+        "OCD_REVIEW_ID": 1
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": [
+      {
+        "CALL_HELD_REASON_ID": 11,
+        "REASON_DESCRIPTION": "Test"
+      }
+    ],
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 4,
+        "SPW_STATUS_DESC": "Approved"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 718,
+        "ID_NUMBER": "MD-22-2206-VM"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1673292051500",
+    "ACTION_OFFICERS": [
+      {
+        "INITIALS": "A",
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3996,
+        "LAST_NAME": "Test1",
+        "EMAIL": "abc@exampl.com",
+        "FIRST_NAME": "Demo1"
+      }
+    ],
+    "SP1115": null,
+    "COMPONENTS_SP": [
+      {
+        "ALERTS_INBOX_ADDRESS": "Test#2",
+        "COMPONENT_ID": 119,
+        "COMPONENT_NAME": "Test-5"
+      }
+    ],
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 125,
+        "PLAN_TYPE_NAME": "Medicaid SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P3",
+        "PRIORITY_CODE_DESCRIPTION": "Routine action test",
+        "PRIORITY_CODE_ID": 3
+      }
+    ],
+    "SP_IMPACT_FUNDING": [
+      {
+        "OTHER": null,
+        "ID_NUMBER": "MD-22-2206-VM",
+        "IMPACT_YEAR_2_VALUE": null,
+        "IMPACT_YEAR_3": null,
+        "PROVIDER_TAX": null,
+        "IMPACT_YEAR_2": null,
+        "IMPACT_YEAR_1": null,
+        "IGT": null,
+        "IMPACT_YEAR_3_VALUE": null,
+        "CPE": null,
+        "IMPACT_YEAR_1_VALUE": null,
+        "APPROPRIATIONS": null
+      }
+    ],
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "CODEAFTERINITACCESS": [
+      {
+        "CODE_AFTER_INIT_ASSESS_ID": 3,
+        "CODE_AFTER_INIT_ASSESS_DESC": "Same"
+      }
+    ],
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 76,
+        "COMPONENT_NAME": "Test 9"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": false,
+          "ID_NUMBER": "MD-22-2206-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": true,
+          "ID_NUMBER": "MD-22-2206-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2206-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680063221990,
+    "componentType": "medicaidspa",
+    "eventTimestamp": 1672290821990,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672290820800/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "CMS Form 179",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290820800/excel.xlsx"
+      },
+      {
+        "s3Key": "1672290820801/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "SPA Pages",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290820801/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2205-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672290821990,
+    "GSI1pk": "OneMAC#submitmedicaidspa",
+    "convertTimestamp": 1673973224526,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672290821990",
+    "componentId": "MD-22-2205-VM",
+    "pk": "MD-22-2205-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1681745936912,
+    "componentType": "medicaidsparai",
+    "eventTimestamp": 1673973536912,
+    "transmittalNumberWarningMessage": "",
+    "currentStatus": "Submitted",
+    "parentId": "MD-22-2205-VM",
+    "attachments": [
+      {
+        "s3Key": "1673973534414/adobe.pdf",
+        "filename": "adobe.pdf",
+        "title": "RAI Response",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673973534414/adobe.pdf"
+      }
+    ],
+    "parentType": "medicaidspa",
+    "GSI1sk": "MD-22-2205-VM",
+    "additionalInformation": "",
+    "submissionTimestamp": 1673973536912,
+    "GSI1pk": "OneMAC#submitmedicaidsparai",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "territory": "MD",
+    "sk": "OneMAC#1673973536912",
+    "componentId": "MD-22-2205-VM",
+    "pk": "MD-22-2205-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680063221990,
+    "componentType": "medicaidspa",
+    "currentStatus": "Submitted",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672290820800/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "CMS Form 179",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290820800/excel.xlsx"
+      },
+      {
+        "s3Key": "1672290820801/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "SPA Pages",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290820801/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2205-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672290821990,
+    "GSI1pk": "OneMAC#spa",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22-2205-VM",
+    "raiResponses": [
+      {
+        "additionalInformation": "",
+        "submissionTimestamp": 1673973536912,
+        "attachments": [
+          {
+            "s3Key": "1673973534414/adobe.pdf",
+            "filename": "adobe.pdf",
+            "title": "RAI Response",
+            "contentType": "application/pdf",
+            "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1673973534414/adobe.pdf"
+          }
+        ]
+      }
+    ],
+    "lastEventTimestamp": 1673973536912,
+    "pk": "MD-22-2205-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": 11,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": false,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "pending-rai",
+      "SPW_STATUS_ID": 2,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": null,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "87407BD3-5A62-4D9D-96A0-AE800BB31D6A",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": null,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672272000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 125,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2205-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672291818177,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22-2205-VM",
+        "SERVICE_TYPE_ID": 93
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2205-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": [
+      {
+        "CALL_HELD_REASON_ID": 11,
+        "REASON_DESCRIPTION": "Test"
+      }
+    ],
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 2,
+        "SPW_STATUS_DESC": "Pending-RAI"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 967,
+        "ID_NUMBER": "MD-22-2205-VM"
+      }
+    ],
+    "RAI": [
+      {
+        "RAI_WITHDRAWN_DATE": null,
+        "ID_NUMBER": "MD-22-2205-VM",
+        "RAI_RECEIVED_DATE": null,
+        "RAI_REQUESTED_DATE": 1672272000000
+      }
+    ],
+    "sk": "SEATool#1672291818177",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 125,
+        "PLAN_TYPE_NAME": "Medicaid SPA"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": [
+      {
+        "OTHER": null,
+        "ID_NUMBER": "MD-22-2205-VM",
+        "IMPACT_YEAR_2_VALUE": null,
+        "IMPACT_YEAR_3": null,
+        "PROVIDER_TAX": null,
+        "IMPACT_YEAR_2": null,
+        "IMPACT_YEAR_1": null,
+        "IGT": null,
+        "IMPACT_YEAR_3_VALUE": null,
+        "CPE": null,
+        "IMPACT_YEAR_1_VALUE": null,
+        "APPROPRIATIONS": null
+      }
+    ],
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2205-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2205-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2205-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680063196706,
+    "componentType": "medicaidspa",
+    "eventTimestamp": 1672290796706,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672290795534/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "CMS Form 179",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290795534/picture.jpg"
+      },
+      {
+        "s3Key": "1672290795535/file.docx",
+        "filename": "file.docx",
+        "title": "SPA Pages",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290795535/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2204-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672290796706,
+    "GSI1pk": "OneMAC#submitmedicaidspa",
+    "convertTimestamp": 1673973223881,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672290796706",
+    "componentId": "MD-22-2204-VM",
+    "pk": "MD-22-2204-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680063196706,
+    "componentType": "medicaidspa",
+    "currentStatus": "Pending - Concurrence",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672290795534/picture.jpg",
+        "filename": "picture.jpg",
+        "title": "CMS Form 179",
+        "contentType": "image/jpeg",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290795534/picture.jpg"
+      },
+      {
+        "s3Key": "1672290795535/file.docx",
+        "filename": "file.docx",
+        "title": "SPA Pages",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290795535/file.docx"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2204-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672290796706,
+    "GSI1pk": "OneMAC#spa",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22-2204-VM",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672291719007,
+    "pk": "MD-22-2204-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "pending-concurrence status",
+      "SPW_STATUS_ID": 8,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "4BB0516D-DD0E-4365-AC6D-4367604CE2EA",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672272000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 125,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2204-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672291719007,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": "test",
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": 1672272000000,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22-2204-VM",
+        "SERVICE_TYPE_ID": 93
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2204-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 8,
+        "SPW_STATUS_DESC": "Pending-Concurrence"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 967,
+        "ID_NUMBER": "MD-22-2204-VM"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672291719007",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 125,
+        "PLAN_TYPE_NAME": "Medicaid SPA"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": [
+      {
+        "OTHER": null,
+        "ID_NUMBER": "MD-22-2204-VM",
+        "IMPACT_YEAR_2_VALUE": null,
+        "IMPACT_YEAR_3": null,
+        "PROVIDER_TAX": null,
+        "IMPACT_YEAR_2": null,
+        "IMPACT_YEAR_1": null,
+        "IGT": null,
+        "IMPACT_YEAR_3_VALUE": null,
+        "CPE": null,
+        "IMPACT_YEAR_1_VALUE": null,
+        "APPROPRIATIONS": null
+      }
+    ],
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2204-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2204-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2204-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680063176021,
+    "componentType": "medicaidspa",
+    "eventTimestamp": 1672290776021,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672290770684/file.docx",
+        "filename": "file.docx",
+        "title": "CMS Form 179",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290770684/file.docx"
+      },
+      {
+        "s3Key": "1672290770685/15MB.pdf",
+        "filename": "15MB.pdf",
+        "title": "SPA Pages",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290770685/15MB.pdf"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2203-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672290776021,
+    "GSI1pk": "OneMAC#submitmedicaidspa",
+    "convertTimestamp": 1673973222365,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672290776021",
+    "componentId": "MD-22-2203-VM",
+    "pk": "MD-22-2203-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680063176021,
+    "componentType": "medicaidspa",
+    "currentStatus": "Pending - Approval",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672290770684/file.docx",
+        "filename": "file.docx",
+        "title": "CMS Form 179",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290770684/file.docx"
+      },
+      {
+        "s3Key": "1672290770685/15MB.pdf",
+        "filename": "15MB.pdf",
+        "title": "SPA Pages",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290770685/15MB.pdf"
+      }
+    ],
+    "proposedEffectiveDate": "2023-03-01",
+    "GSI1sk": "MD-22-2203-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672290776021,
+    "GSI1pk": "OneMAC#spa",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22-2203-VM",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672759184650,
+    "pk": "MD-22-2203-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "CEB54C18-C66E-47BF-B13F-184ABE39270A",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672272000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 125,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2203-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672291522867,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2203-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672291522867",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 125,
+        "PLAN_TYPE_NAME": "Medicaid SPA"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2203-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2203-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2203-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": 3993,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": 11,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": false,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "approved status",
+      "SPW_STATUS_ID": 11,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": "test",
+      "PROPOSED_DATE": 1677628800000,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": 3,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": 3996,
+      "GAP3": null,
+      "UUID": "CEB54C18-C66E-47BF-B13F-184ABE39270A",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": 3996,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672272000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 125,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": 3993,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2203-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672291635440,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": "test",
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": 1677628800000,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 76,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22-2203-VM",
+        "SERVICE_TYPE_ID": 93
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2203-VM",
+    "FM_ANALYST": [
+      {
+        "INITIALS": "A",
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3996,
+        "LAST_NAME": "Test1",
+        "EMAIL": "abc@exampl.com",
+        "FIRST_NAME": "Demo1"
+      }
+    ],
+    "LEAD_ANALYST": [
+      {
+        "INITIALS": null,
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3993,
+        "LAST_NAME": "Test2",
+        "EMAIL": null,
+        "FIRST_NAME": "Test1"
+      }
+    ],
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": [
+      {
+        "INITIALS": null,
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3993,
+        "LAST_NAME": "Test2",
+        "EMAIL": null,
+        "FIRST_NAME": "Test1"
+      }
+    ],
+    "CALLHELDREASONS": [
+      {
+        "CALL_HELD_REASON_ID": 11,
+        "REASON_DESCRIPTION": "Test"
+      }
+    ],
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 11,
+        "SPW_STATUS_DESC": "Pending-Approval"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 967,
+        "ID_NUMBER": "MD-22-2203-VM"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672291635440",
+    "ACTION_OFFICERS": [
+      {
+        "INITIALS": null,
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3993,
+        "LAST_NAME": "Test2",
+        "EMAIL": null,
+        "FIRST_NAME": "Test1"
+      }
+    ],
+    "SP1115": null,
+    "COMPONENTS_SP": [
+      {
+        "ALERTS_INBOX_ADDRESS": "Test#2",
+        "COMPONENT_ID": 119,
+        "COMPONENT_NAME": "Test-5"
+      }
+    ],
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 125,
+        "PLAN_TYPE_NAME": "Medicaid SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P3",
+        "PRIORITY_CODE_DESCRIPTION": "Routine action test",
+        "PRIORITY_CODE_ID": 3
+      }
+    ],
+    "SP_IMPACT_FUNDING": [
+      {
+        "OTHER": null,
+        "ID_NUMBER": "MD-22-2203-VM",
+        "IMPACT_YEAR_2_VALUE": null,
+        "IMPACT_YEAR_3": null,
+        "PROVIDER_TAX": null,
+        "IMPACT_YEAR_2": null,
+        "IMPACT_YEAR_1": null,
+        "IGT": null,
+        "IMPACT_YEAR_3_VALUE": null,
+        "CPE": null,
+        "IMPACT_YEAR_1_VALUE": null,
+        "APPROPRIATIONS": null
+      }
+    ],
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 76,
+        "COMPONENT_NAME": "Test 9"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": false,
+          "ID_NUMBER": "MD-22-2203-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": true,
+          "ID_NUMBER": "MD-22-2203-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2203-VM",
+    "RO_ANALYST": [
+      {
+        "INITIALS": "A",
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3996,
+        "LAST_NAME": "Test1",
+        "EMAIL": "abc@exampl.com",
+        "FIRST_NAME": "Demo1"
+      }
+    ]
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": 3993,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": 11,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": false,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "approved status",
+      "SPW_STATUS_ID": 11,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": "test",
+      "PROPOSED_DATE": 1677628800000,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": 3,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": 3996,
+      "GAP3": null,
+      "UUID": "CEB54C18-C66E-47BF-B13F-184ABE39270A",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": 3996,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672272000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 125,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": 3993,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2203-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672759184650,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": "test",
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": 1677628800000,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": 76,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": true,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22-2203-VM",
+        "SERVICE_TYPE_ID": 93
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2203-VM",
+    "FM_ANALYST": [
+      {
+        "INITIALS": "A",
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3996,
+        "LAST_NAME": "Test1",
+        "EMAIL": "abc@exampl.com",
+        "FIRST_NAME": "Demo1"
+      }
+    ],
+    "LEAD_ANALYST": [
+      {
+        "INITIALS": null,
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3993,
+        "LAST_NAME": "Test2",
+        "EMAIL": null,
+        "FIRST_NAME": "Test1"
+      }
+    ],
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": [
+      {
+        "INITIALS": null,
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3993,
+        "LAST_NAME": "Test2",
+        "EMAIL": null,
+        "FIRST_NAME": "Test1"
+      }
+    ],
+    "CALLHELDREASONS": [
+      {
+        "CALL_HELD_REASON_ID": 11,
+        "REASON_DESCRIPTION": "Test"
+      }
+    ],
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 11,
+        "SPW_STATUS_DESC": "Pending-Approval"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 967,
+        "ID_NUMBER": "MD-22-2203-VM"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672759184650",
+    "ACTION_OFFICERS": [
+      {
+        "INITIALS": null,
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3993,
+        "LAST_NAME": "Test2",
+        "EMAIL": null,
+        "FIRST_NAME": "Test1"
+      }
+    ],
+    "SP1115": null,
+    "COMPONENTS_SP": [
+      {
+        "ALERTS_INBOX_ADDRESS": "Test#2",
+        "COMPONENT_ID": 119,
+        "COMPONENT_NAME": "Test-5"
+      }
+    ],
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 125,
+        "PLAN_TYPE_NAME": "Medicaid SPA"
+      }
+    ],
+    "PRIORITY_CODES": [
+      {
+        "PRIORITY_CODE": "P3",
+        "PRIORITY_CODE_DESCRIPTION": "Routine action test",
+        "PRIORITY_CODE_ID": 3
+      }
+    ],
+    "SP_IMPACT_FUNDING": [
+      {
+        "OTHER": null,
+        "ID_NUMBER": "MD-22-2203-VM",
+        "IMPACT_YEAR_2_VALUE": null,
+        "IMPACT_YEAR_3": null,
+        "PROVIDER_TAX": null,
+        "IMPACT_YEAR_2": null,
+        "IMPACT_YEAR_1": null,
+        "IGT": null,
+        "IMPACT_YEAR_3_VALUE": null,
+        "CPE": null,
+        "IMPACT_YEAR_1_VALUE": null,
+        "APPROPRIATIONS": null
+      }
+    ],
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": [
+      {
+        "ALERTS_INBOX_ADDRESS": null,
+        "COMPONENT_ID": 76,
+        "COMPONENT_NAME": "Test 9"
+      }
+    ],
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": false,
+          "ID_NUMBER": "MD-22-2203-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": true,
+          "ID_NUMBER": "MD-22-2203-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2203-VM",
+    "RO_ANALYST": [
+      {
+        "INITIALS": "A",
+        "TELEPHONE": null,
+        "POSITION_ID": null,
+        "OFFICER_ID": 3996,
+        "LAST_NAME": "Test1",
+        "EMAIL": "abc@exampl.com",
+        "FIRST_NAME": "Demo1"
+      }
+    ]
+  },
+  {
+    "clockEndTimestamp": 1680063135716,
+    "componentType": "medicaidspa",
+    "eventTimestamp": 1672290735716,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672290728501/file.docx",
+        "filename": "file.docx",
+        "title": "CMS Form 179",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290728501/file.docx"
+      },
+      {
+        "s3Key": "1672290728501/15MB.pdf",
+        "filename": "15MB.pdf",
+        "title": "SPA Pages",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290728501/15MB.pdf"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2202-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672290735716,
+    "GSI1pk": "OneMAC#submitmedicaidspa",
+    "convertTimestamp": 1673973221240,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672290735716",
+    "componentId": "MD-22-2202-VM",
+    "pk": "MD-22-2202-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680063135716,
+    "componentType": "medicaidspa",
+    "currentStatus": "Package Withdrawn",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672290728501/file.docx",
+        "filename": "file.docx",
+        "title": "CMS Form 179",
+        "contentType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290728501/file.docx"
+      },
+      {
+        "s3Key": "1672290728501/15MB.pdf",
+        "filename": "15MB.pdf",
+        "title": "SPA Pages",
+        "contentType": "application/pdf",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290728501/15MB.pdf"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2202-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672290735716,
+    "GSI1pk": "OneMAC#spa",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22-2202-VM",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672758433560,
+    "pk": "MD-22-2202-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": "Here we are, testing again!",
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "GAP3": null,
+      "RO_ANALYST_ID": null,
+      "UUID": "A4DF931F-D3D6-400B-97A7-DF4A2669454A",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672704000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "GAP_NA": null,
+      "PLAN_TYPE": 125,
+      "SUBMISSION_TYPE": null,
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "REGION_ID": "3",
+      "DATE_SENT_PSCCAS": null,
+      "APPROVAL_STATUS_TYPE": null,
+      "ID_NUMBER": "MD-22-2202-VM",
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672758376817,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "ADDED_COST": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "COMPONENT_ID": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "DATE_OF_CODING_CHANGE": null,
+      "STATE_CODE": "MD",
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "ELIMINATED_COST": null,
+      "SPA_TYPE_ID": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2202-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_DESC": "Pending",
+        "SPW_STATUS_ID": 1
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_APD_SUB_TYPE": null,
+    "SP_TYPE": null,
+    "RAI": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "sk": "SEATool#1672758376817",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 125,
+        "PLAN_TYPE_NAME": "Medicaid SPA"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "CODEAFTERINITACCESS": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov",
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia"
+      }
+    ],
+    "STOP_RESUME_DATES": null,
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "ACTIVE": true,
+          "EA_DROP_DOWN_VALUES": null,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "ACTIVE": true,
+          "EA_DROP_DOWN_VALUES": null,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2202-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2202-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2202-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "withdrawn test",
+      "SPW_STATUS_ID": 6,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "GAP3": null,
+      "RO_ANALYST_ID": null,
+      "UUID": "A4DF931F-D3D6-400B-97A7-DF4A2669454A",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672704000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "GAP_NA": null,
+      "PLAN_TYPE": 125,
+      "SUBMISSION_TYPE": null,
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "REGION_ID": "3",
+      "DATE_SENT_PSCCAS": null,
+      "APPROVAL_STATUS_TYPE": null,
+      "ID_NUMBER": "MD-22-2202-VM",
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672758433560,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": "TEST",
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "ADDED_COST": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "COMPONENT_ID": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "DATE_OF_CODING_CHANGE": null,
+      "STATE_CODE": "MD",
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "ELIMINATED_COST": null,
+      "SPA_TYPE_ID": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22-2202-VM",
+        "SERVICE_TYPE_ID": 93
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2202-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_DESC": "Pending",
+        "SPW_STATUS_ID": 1
+      },
+      {
+        "SPW_STATUS_DESC": "Withdrawn",
+        "SPW_STATUS_ID": 6
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_APD_SUB_TYPE": null,
+    "SP_TYPE": null,
+    "RAI": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 964,
+        "ID_NUMBER": "MD-22-2202-VM"
+      }
+    ],
+    "sk": "SEATool#1672758433560",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 125,
+        "PLAN_TYPE_NAME": "Medicaid SPA"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": [
+      {
+        "OTHER": null,
+        "ID_NUMBER": "MD-22-2202-VM",
+        "IMPACT_YEAR_2_VALUE": null,
+        "IMPACT_YEAR_3": null,
+        "PROVIDER_TAX": null,
+        "IMPACT_YEAR_2": null,
+        "IGT": null,
+        "IMPACT_YEAR_1": null,
+        "IMPACT_YEAR_3_VALUE": null,
+        "CPE": null,
+        "IMPACT_YEAR_1_VALUE": null,
+        "APPROPRIATIONS": null
+      }
+    ],
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "CODEAFTERINITACCESS": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov",
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia"
+      }
+    ],
+    "STOP_RESUME_DATES": null,
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "ACTIVE": true,
+          "EA_DROP_DOWN_VALUES": null,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "ACTIVE": true,
+          "EA_DROP_DOWN_VALUES": null,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2202-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2202-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2202-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "Date_of_coding_change": null,
+    "Approval_Status_Type": null,
+    "Submission_Type": null,
+    "Submission_Date": 1672272000000,
+    "Eliminated_Cost": null,
+    "Alert_Milestone3_Days": null,
+    "Changed_Date": 1673563103150,
+    "Template_Issues_Memo": null,
+    "UUID": "AC5EC7B4-DAF5-49DB-BED4-816B748BD2EF",
+    "Alert_90_Days_Date": 1680048000000,
+    "GAP3": null,
+    "Alert_Milestone4_Days": null,
+    "GAP2": null,
+    "Initial_submission_complete": null,
+    "GAP": null,
+    "Code_after_init_assess_ID": null,
+    "Current_Waiver_Expires_Date": null,
+    "SPW_Import": 0,
+    "sk": "SEATool#State_Plan#10596",
+    "Backup_FM_Analyst_ID": null,
+    "Guidance_Docs_Submitted": null,
+    "Attached_SPA": null,
+    "Priority_Code_ID": null,
+    "UPL_Accepted": null,
+    "Fiscal_Quarter": null,
+    "Status_Memo": "TEST AGAIN",
+    "Template_Issues_Resolved": null,
+    "Component_ID": null,
+    "End_Date": null,
+    "Remarks_Memo": null,
+    "PublicHealth_StateEmergency": null,
+    "Companion_Letter_Requested_Date": null,
+    "TE_End_Date": null,
+    "Blocking_SPAs_Memo": null,
+    "Template_Issues": null,
+    "Priority_Complexity_ID": null,
+    "Organization_Change": null,
+    "Lead_Analyst_ID": null,
+    "Budget_Neutrality_Established_Flag": 0,
+    "pk": "MD-22-2202-VM",
+    "Added_Cost": null,
+    "Pending_Concurrence_Date": null,
+    "Missing_information": null,
+    "SPW_Status_ID": 1,
+    "Start_Clock_Date": 1672272000000,
+    "replica_id": 12392,
+    "Budget_Impact_Value": null,
+    "Days_Extension_Number": null,
+    "Budget_Neutrality_Status_Memo": null,
+    "Alert_Milestone1_Days": null,
+    "Summary_Memo": null,
+    "Plan_Type": 125,
+    "Date_Sent_PSCCAS": null,
+    "GAP2_NA": null,
+    "State_Code": "MD",
+    "MMDL_Import": null,
+    "CO_Submission_Date": null,
+    "GAP_NA": null,
+    "Call_Held": null,
+    "Proposed_Date": null,
+    "Status_Date": 1673481600000,
+    "SPA_Type_ID": null,
+    "Type_Id": null,
+    "FRT_Date": null,
+    "Title_Name": null,
+    "Alert_Milestone2_Days": null,
+    "Fiscal_Year": null,
+    "ID_Number": "MD-22-2202-VM",
+    "OCD_Review_Comments_Memo": null,
+    "Budget_Impact": null,
+    "Actual_Effective_Date": null,
+    "Call_Held_Reason_ID": null,
+    "Priority_Comments_Memo": null,
+    "Region_ID": "3",
+    "Action_Type": null,
+    "Current_Waiver_TE": null,
+    "GAP3_NA": null,
+    "OCD_Review_ID": 2,
+    "RO_Analyst_ID": null,
+    "Approval_Docs_Received": null,
+    "Approved_Effective_Date": null,
+    "Backup_Program_Analyst_ID": null,
+    "Companion_Letter_Received_Date": null,
+    "Review_Position_ID": null
+  },
+  {
+    "Date_of_coding_change": null,
+    "Submission_Type": null,
+    "Approval_Status_Type": null,
+    "Submission_Date": 1672272000000,
+    "Eliminated_Cost": null,
+    "Alert_Milestone3_Days": null,
+    "Changed_Date": 1673563146807,
+    "Template_Issues_Memo": null,
+    "UUID": "AC5EC7B4-DAF5-49DB-BED4-816B748BD2EF",
+    "Alert_90_Days_Date": 1680048000000,
+    "GAP3": null,
+    "Initial_submission_complete": null,
+    "GAP2": null,
+    "Alert_Milestone4_Days": null,
+    "GAP": null,
+    "Code_after_init_assess_ID": null,
+    "Current_Waiver_Expires_Date": null,
+    "SPW_Import": 0,
+    "sk": "SEATool#State_Plan#10597",
+    "Backup_FM_Analyst_ID": null,
+    "Guidance_Docs_Submitted": null,
+    "Attached_SPA": null,
+    "Priority_Code_ID": null,
+    "UPL_Accepted": null,
+    "Fiscal_Quarter": null,
+    "Template_Issues_Resolved": null,
+    "Status_Memo": null,
+    "Component_ID": null,
+    "End_Date": null,
+    "Remarks_Memo": null,
+    "PublicHealth_StateEmergency": null,
+    "TE_End_Date": null,
+    "Companion_Letter_Requested_Date": null,
+    "Blocking_SPAs_Memo": null,
+    "Template_Issues": null,
+    "Priority_Complexity_ID": null,
+    "Organization_Change": null,
+    "Lead_Analyst_ID": null,
+    "Budget_Neutrality_Established_Flag": 0,
+    "pk": "MD-22-2202-VM",
+    "Added_Cost": null,
+    "Pending_Concurrence_Date": null,
+    "Missing_information": null,
+    "SPW_Status_ID": 6,
+    "replica_id": 12392,
+    "Start_Clock_Date": 1672272000000,
+    "Budget_Impact_Value": null,
+    "Days_Extension_Number": null,
+    "Budget_Neutrality_Status_Memo": null,
+    "Summary_Memo": "withdrawn status",
+    "Alert_Milestone1_Days": null,
+    "Plan_Type": 125,
+    "Date_Sent_PSCCAS": null,
+    "State_Code": "MD",
+    "GAP2_NA": null,
+    "MMDL_Import": null,
+    "CO_Submission_Date": null,
+    "GAP_NA": null,
+    "Proposed_Date": null,
+    "Call_Held": null,
+    "Status_Date": 1673481600000,
+    "SPA_Type_ID": null,
+    "Type_Id": null,
+    "FRT_Date": null,
+    "Title_Name": "OneMac Connection test",
+    "Alert_Milestone2_Days": null,
+    "Fiscal_Year": null,
+    "ID_Number": "MD-22-2202-VM",
+    "OCD_Review_Comments_Memo": null,
+    "Budget_Impact": null,
+    "Actual_Effective_Date": null,
+    "Call_Held_Reason_ID": null,
+    "Priority_Comments_Memo": "test",
+    "Region_ID": "3",
+    "Current_Waiver_TE": null,
+    "Action_Type": null,
+    "GAP3_NA": null,
+    "OCD_Review_ID": 2,
+    "RO_Analyst_ID": null,
+    "Approval_Docs_Received": 0,
+    "Backup_Program_Analyst_ID": null,
+    "Approved_Effective_Date": null,
+    "Companion_Letter_Received_Date": null,
+    "Review_Position_ID": null
+  },  {
+    "clockEndTimestamp": 1680063108524,
+    "componentType": "medicaidspa",
+    "eventTimestamp": 1672290708524,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672290707318/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "CMS Form 179",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290707318/excel.xlsx"
+      },
+      {
+        "s3Key": "1672290707319/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "SPA Pages",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290707319/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2201-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672290708524,
+    "GSI1pk": "OneMAC#submitmedicaidspa",
+    "convertTimestamp": 1673973219323,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672290708524",
+    "componentId": "MD-22-2201-VM",
+    "pk": "MD-22-2201-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680063108524,
+    "componentType": "medicaidspa",
+    "currentStatus": "Disapproved",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672290707318/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "CMS Form 179",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290707318/excel.xlsx"
+      },
+      {
+        "s3Key": "1672290707319/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "SPA Pages",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290707319/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2201-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672290708524,
+    "GSI1pk": "OneMAC#spa",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22-2201-VM",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672291355540,
+    "pk": "MD-22-2201-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": null,
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "B5F9E349-836E-4E3F-AAE6-90C62C453BAA",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672272000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 125,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2201-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672291318100,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2201-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": null,
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": null,
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672291318100",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 125,
+        "PLAN_TYPE_NAME": "Medicaid SPA"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": null,
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2201-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2201-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2201-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "disapproved status",
+      "SPW_STATUS_ID": 5,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "B5F9E349-836E-4E3F-AAE6-90C62C453BAA",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672272000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 125,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2201-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672291355540,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22-2201-VM",
+        "SERVICE_TYPE_ID": 93
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2201-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      },
+      {
+        "SPW_STATUS_ID": 5,
+        "SPW_STATUS_DESC": "Disapproved"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 967,
+        "ID_NUMBER": "MD-22-2201-VM"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672291355540",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 125,
+        "PLAN_TYPE_NAME": "Medicaid SPA"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": [
+      {
+        "OTHER": null,
+        "ID_NUMBER": "MD-22-2201-VM",
+        "IMPACT_YEAR_2_VALUE": null,
+        "IMPACT_YEAR_3": null,
+        "PROVIDER_TAX": null,
+        "IMPACT_YEAR_2": null,
+        "IMPACT_YEAR_1": null,
+        "IGT": null,
+        "IMPACT_YEAR_3_VALUE": null,
+        "CPE": null,
+        "IMPACT_YEAR_1_VALUE": null,
+        "APPROPRIATIONS": null
+      }
+    ],
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2201-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2201-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2201-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "clockEndTimestamp": 1680063073531,
+    "componentType": "medicaidspa",
+    "eventTimestamp": 1672290673531,
+    "currentStatus": "Submitted",
+    "originallyFrom": "cms-spa-form-develop-change-requests",
+    "attachments": [
+      {
+        "s3Key": "1672290671436/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "CMS Form 179",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290671436/excel.xlsx"
+      },
+      {
+        "s3Key": "1672290671438/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "SPA Pages",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290671438/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2200-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672290673531,
+    "GSI1pk": "OneMAC#submitmedicaidspa",
+    "convertTimestamp": 1673973218320,
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "OneMAC#1672290673531",
+    "componentId": "MD-22-2200-VM",
+    "pk": "MD-22-2200-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "clockEndTimestamp": 1680063073531,
+    "componentType": "medicaidspa",
+    "currentStatus": "Under Review",
+    "waiverExtensions": [],
+    "attachments": [
+      {
+        "s3Key": "1672290671436/excel.xlsx",
+        "filename": "excel.xlsx",
+        "title": "CMS Form 179",
+        "contentType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290671436/excel.xlsx"
+      },
+      {
+        "s3Key": "1672290671438/textnotes.txt",
+        "filename": "textnotes.txt",
+        "title": "SPA Pages",
+        "contentType": "text/plain",
+        "url": "https://uploads-develop-attachments-116229642442.s3.us-east-1.amazonaws.com/protected/us-east-1%3A86a190fe-b195-42bf-9685-9761bf0ff14b/1672290671438/textnotes.txt"
+      }
+    ],
+    "proposedEffectiveDate": "none",
+    "GSI1sk": "MD-22-2200-VM",
+    "additionalInformation": "test",
+    "submissionTimestamp": 1672290673531,
+    "GSI1pk": "OneMAC#spa",
+    "submitterEmail": "statesubmitter@nightwatch.test",
+    "sk": "Package",
+    "componentId": "MD-22-2200-VM",
+    "raiResponses": [],
+    "lastEventTimestamp": 1672291290683,
+    "pk": "MD-22-2200-VM",
+    "submitterName": "Statesubmitter Nightwatch"
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": null,
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "01686843-7867-4BCC-B0A2-81CB3C9C2281",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672272000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 125,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2200-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": null,
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672291244320,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": null,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": null,
+      "PRIORITY_COMMENTS_MEMO": null,
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": null,
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2200-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": null,
+    "RAI": null,
+    "sk": "SEATool#1672291244320",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 125,
+        "PLAN_TYPE_NAME": "Medicaid SPA"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": null,
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2200-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2200-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2200-VM",
+    "RO_ANALYST": null
+  },
+  {
+    "PRIORITY_COMPLEXITY": null,
+    "STATES": [
+      {
+        "REGION_ID": "3",
+        "STATE_NAME": "Maryland",
+        "PRIORITY_FLAG": false,
+        "STATE_CODE": "MD"
+      }
+    ],
+    "STATE_PLAN": {
+      "LEAD_ANALYST_ID": null,
+      "TEMPLATE_ISSUES": null,
+      "BLOCKING_SPAS_MEMO": null,
+      "CALL_HELD_REASON_ID": null,
+      "FRT_DATE": null,
+      "CURRENT_WAIVER_EXPIRES_DATE": null,
+      "END_DATE": null,
+      "CALL_HELD": null,
+      "TEMPLATE_ISSUES_RESOLVED": null,
+      "ALERT_MILESTONE2_DAYS": null,
+      "SUMMARY_MEMO": "pending status",
+      "SPW_STATUS_ID": 1,
+      "BUDGET_NEUTRALITY_ESTABLISHED_FLAG": false,
+      "FISCAL_QUARTER": null,
+      "STATUS_MEMO": null,
+      "PROPOSED_DATE": null,
+      "ALERT_MILESTONE1_DAYS": null,
+      "ALERT_90_DAYS_DATE": 1680048000000,
+      "PRIORITY_CODE_ID": null,
+      "BUDGET_IMPACT": null,
+      "RO_ANALYST_ID": null,
+      "GAP3": null,
+      "UUID": "01686843-7867-4BCC-B0A2-81CB3C9C2281",
+      "GAP2": null,
+      "ATTACHED_SPA": null,
+      "BUDGET_NEUTRALITY_STATUS_MEMO": null,
+      "START_CLOCK_DATE": 1672272000000,
+      "BACKUP_FM_ANALYST_ID": null,
+      "SUBMISSION_DATE": 1672272000000,
+      "STATUS_DATE": 1672272000000,
+      "COMPANION_LETTER_RECEIVED_DATE": null,
+      "GAP3_NA": null,
+      "REMARKS_MEMO": null,
+      "TYPE_ID": null,
+      "TE_END_DATE": null,
+      "GAP": null,
+      "DAYS_EXTENSION_NUMBER": null,
+      "OCD_REVIEW_ID": 2,
+      "ACTUAL_EFFECTIVE_DATE": null,
+      "FISCAL_YEAR": null,
+      "PLAN_TYPE": 125,
+      "GAP_NA": null,
+      "SUBMISSION_TYPE": null,
+      "REGION_ID": "3",
+      "BACKUP_PROGRAM_ANALYST_ID": null,
+      "DATE_SENT_PSCCAS": null,
+      "ID_NUMBER": "MD-22-2200-VM",
+      "APPROVAL_STATUS_TYPE": null,
+      "COMPANION_LETTER_REQUESTED_DATE": null,
+      "TITLE_NAME": "OneMac Connection test",
+      "ALERT_MILESTONE4_DAYS": null,
+      "CO_SUBMISSION_DATE": null,
+      "CHANGED_DATE": 1672291290683,
+      "UPL_ACCEPTED": null,
+      "GAP2_NA": null,
+      "OCD_REVIEW_COMMENTS_MEMO": null,
+      "MMDL_IMPORT": null,
+      "TEMPLATE_ISSUES_MEMO": null,
+      "GUIDANCE_DOCS_SUBMITTED": null,
+      "APPROVED_EFFECTIVE_DATE": null,
+      "INITIAL_SUBMISSION_COMPLETE": true,
+      "ADDED_COST": null,
+      "MISSING_INFORMATION": null,
+      "PRIORITY_COMPLEXITY_ID": null,
+      "ACTION_TYPE": null,
+      "PENDING_CONCURRENCE_DATE": null,
+      "PUBLICHEALTH_STATEEMERGENCY": null,
+      "COMPONENT_ID": null,
+      "BUDGET_IMPACT_VALUE": null,
+      "ALERT_MILESTONE3_DAYS": null,
+      "CODE_AFTER_INIT_ASSESS_ID": null,
+      "STATE_CODE": "MD",
+      "DATE_OF_CODING_CHANGE": null,
+      "APPROVAL_DOCS_RECEIVED": false,
+      "PRIORITY_COMMENTS_MEMO": "test",
+      "ORGANIZATION_CHANGE": null,
+      "SPW_IMPORT": false,
+      "REVIEW_POSITION_ID": null,
+      "SPA_TYPE_ID": null,
+      "ELIMINATED_COST": null,
+      "CURRENT_WAIVER_TE": null
+    },
+    "STATE_PLAN_SERVICETYPES": [
+      {
+        "ID_NUMBER": "MD-22-2200-VM",
+        "SERVICE_TYPE_ID": 93
+      }
+    ],
+    "REVIEW_POSITION": null,
+    "GSI1sk": "MD-22-2200-VM",
+    "FM_ANALYST": null,
+    "LEAD_ANALYST": null,
+    "SP_APD": null,
+    "OCD_REVIEW": [
+      {
+        "OCD_REVIEW_DESCRIPTION": "No",
+        "OCD_REVIEW_ID": 2
+      }
+    ],
+    "PROGRAM_ANALYST": null,
+    "CALLHELDREASONS": null,
+    "SPA_TYPE": null,
+    "SPW_STATUS": [
+      {
+        "SPW_STATUS_ID": 1,
+        "SPW_STATUS_DESC": "Pending"
+      }
+    ],
+    "ACTIONTYPES": null,
+    "SP_TYPE": null,
+    "SP_APD_SUB_TYPE": null,
+    "STATE_PLAN_SERVICE_SUBTYPES": [
+      {
+        "SERVICE_SUBTYPE_ID": 967,
+        "ID_NUMBER": "MD-22-2200-VM"
+      }
+    ],
+    "RAI": null,
+    "sk": "SEATool#1672291290683",
+    "ACTION_OFFICERS": null,
+    "SP1115": null,
+    "COMPONENTS_SP": null,
+    "PLAN_TYPES": [
+      {
+        "PLAN_TYPE_ID": 125,
+        "PLAN_TYPE_NAME": "Medicaid SPA"
+      }
+    ],
+    "PRIORITY_CODES": null,
+    "SP_IMPACT_FUNDING": [
+      {
+        "OTHER": null,
+        "ID_NUMBER": "MD-22-2200-VM",
+        "IMPACT_YEAR_2_VALUE": null,
+        "IMPACT_YEAR_3": null,
+        "PROVIDER_TAX": null,
+        "IMPACT_YEAR_2": null,
+        "IMPACT_YEAR_1": null,
+        "IGT": null,
+        "IMPACT_YEAR_3_VALUE": null,
+        "CPE": null,
+        "IMPACT_YEAR_1_VALUE": null,
+        "APPROPRIATIONS": null
+      }
+    ],
+    "GSI1pk": "SEATool#Medicaid_SPA",
+    "CODEAFTERINITACCESS": null,
+    "STOP_RESUME_DATES": null,
+    "COMPONENTS": null,
+    "REGION": [
+      {
+        "REGION_ID": "3",
+        "REGION_NAME": "Philadelphia",
+        "ALERTS_INBOX_ADDRESS": "SPA_Waivers_Philadelphia_R03@cms.hhs.gov"
+      }
+    ],
+    "SP_EARLY_ALERTS": {
+      "ALERTFIELD": [
+        {
+          "EA_LABEL": "Reduced Eligibility",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 11,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 1,
+          "IS_APD": false
+        },
+        {
+          "EA_LABEL": "Meets expedited criteria",
+          "EA_TYPE_ID": 1,
+          "EA_DROP_DOWN_VALUES": null,
+          "ACTIVE": true,
+          "EA_FIELD_ID": 24,
+          "PRIORITY_VALUE": "true",
+          "PRIORITY_OPERATOR": null,
+          "PRIORITY_CODE_ID": 3,
+          "IS_APD": null
+        }
+      ],
+      "EARLYALERT": [
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2200-VM",
+          "EA_FIELD_ID": 11,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        },
+        {
+          "YES_NO_VAL": null,
+          "ID_NUMBER": "MD-22-2200-VM",
+          "EA_FIELD_ID": 24,
+          "EMAIL_SENT": null,
+          "TEXT_DD_VAL": null
+        }
+      ]
+    },
+    "pk": "MD-22-2200-VM",
+    "RO_ANALYST": null
+  }
 ]


### PR DESCRIPTION
Story: none
Endpoint: See github-actions bot comment

### Details
We've really manipulated the data model and need to sort out the seed data to get the automated tests working again... getPackageItems is a small utility function to output as json all items for a package.  Should make building the seed data easier...

### Changes
- added the getPackageItems lambda

### Test Plan
1. Log into the AWS console
2. Find a package in the database
3. Navigate to Lambdas/Functions  and select the getPackageItems
4. run the lambda with { "packageId": "<the id>" } as the event
5. Verify that all items for that package are included in the output json.
