### PR TITLE
Oy2 22595 - always use seatool proposed effective date to backfill event data

### DIFF
--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -129,6 +129,16 @@ export const buildAnyPackage = async (packageId, config) => {
           lmTimestamp
         );
 
+        //always use seatool data to overwrite -- this will have to change if edit in onemac is allowed
+        if (
+          anEvent.STATE_PLAN.PROPOSED_DATE &&
+          typeof anEvent.STATE_PLAN.PROPOSED_DATE === "number"
+        )
+          putParams.Item.proposedEffectiveDate = DateTime.fromMillis(
+            anEvent.STATE_PLAN.PROPOSED_DATE
+          ).toFormat("yyyy-LL-dd");
+        else putParams.Item.proposedEffectiveDate = "none";
+
         if (timestamp < lmTimestamp) return;
 
         const seaToolStatus = anEvent.SPW_STATUS.map((oneStatus) =>
@@ -146,14 +156,7 @@ export const buildAnyPackage = async (packageId, config) => {
           SEATOOL_TO_ONEMAC_STATUS[seaToolStatus] &&
           (putParams.Item.currentStatus =
             SEATOOL_TO_ONEMAC_STATUS[seaToolStatus]);
-        if (
-          anEvent.STATE_PLAN.PROPOSED_DATE &&
-          typeof anEvent.STATE_PLAN.PROPOSED_DATE === "number"
-        )
-          putParams.Item.proposedEffectiveDate = DateTime.fromMillis(
-            anEvent.STATE_PLAN.PROPOSED_DATE
-          ).toFormat("yyyy-LL-dd");
-        else putParams.Item.proposedEffectiveDate = "none";
+
         return;
       }
 

--- a/services/one-stream/package/buildAnyPackage.js
+++ b/services/one-stream/package/buildAnyPackage.js
@@ -167,12 +167,20 @@ export const buildAnyPackage = async (packageId, config) => {
           }
 
           // update the attribute if this is the latest event
-          // OR if there is currently no value for the attribute
-          if (timestamp === lmTimestamp || !putParams.Item[attributeName])
+          if (timestamp === lmTimestamp)
             putParams.Item[attributeName] = anEvent[attributeName];
         }
       });
     });
+
+    //if any attribute was not yet populated from current event; then populate from currentPackage
+    if (currentPackage) {
+      config.theAttributes.forEach((attributeName) => {
+        if (!putParams.Item[attributeName] && currentPackage[attributeName]) {
+          putParams.Item[attributeName] = currentPackage[attributeName];
+        }
+      });
+    }
 
     // use GSI1 to show package on dashboard
     if (showPackageOnDashboard) {


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-22595
Endpoint: See github-actions bot comment

### Details

Due to order of data processing when building packages, older ONEMAC events were being used to populate proposed effective date rather than the newer SEATOOL event.

### Changes

- Updated logic in buildAnyPackage

### Implementation Notes

- First attempt was to backfill all data from previous package record; however since ONEMAC records are processed first due to sk order the ONEMAC records were being used to populate proposed effective date and the newest status chane ONEMAC event had a later event timestamp than the SEATOOL event. Therefore the SEATOOL event was not used. For now since editing of a onemac package is not possible, assume any data other than status from SEATOOL can always be applied (currently only proposed effective date) regardless if its the latest event.

### Test Plan

1. Submit a package.
2. Submit a seatool event (or insert event into DB) to set a proposed effective date and PENDING status on the submitted package.
3. Withdraw package.
4. Verify pakcage retains proposed effective date set in seatool event.
