### PR TITLE
OY2 21088: remove auto-migration, fix attachments null check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,15 +157,16 @@ jobs:
       - name: Load Test Users
         if: ${{ env.branch_name != 'production'}}
         run: ./loadTestUsers.py $STAGE_PREFIX$branch_name
-      - name: Reset One Table Data
-        if: ${{ env.branch_name != 'production'}}
-        run: cd ./services/admin && sls invoke -s $STAGE_PREFIX$branch_name -f resetOneTable -p ./handlers/workflowResetOneTable.json
-      - name: Convert Change Requests
-        if: ${{ env.branch_name != 'production'}}
-        run: cd ./services/admin && sls invoke -s $STAGE_PREFIX$branch_name -f convertChangeRequests -p ./handlers/workflowConvertChangeRequests.json
-      - name: Verify Change Requests
-        if: ${{ env.branch_name != 'production'}}
-        run: cd ./services/admin && sls invoke -s $STAGE_PREFIX$branch_name -f verifyChangeRequests -p ./handlers/workflowVerifyChangeRequests.json
+  # use the workflow to migrate from change requests to one table 
+      # - name: Reset One Table Data
+      #   if: ${{ env.branch_name != 'production'}}
+      #   run: cd ./services/admin && sls invoke -s $STAGE_PREFIX$branch_name -f resetOneTable -p ./handlers/workflowResetOneTable.json
+      # - name: Convert Change Requests
+      #   if: ${{ env.branch_name != 'production'}}
+      #   run: cd ./services/admin && sls invoke -s $STAGE_PREFIX$branch_name -f convertChangeRequests -p ./handlers/workflowConvertChangeRequests.json
+      # - name: Verify Change Requests
+      #   if: ${{ env.branch_name != 'production'}}
+      #   run: cd ./services/admin && sls invoke -s $STAGE_PREFIX$branch_name -f verifyChangeRequests -p ./handlers/workflowVerifyChangeRequests.json
       - name: Migrate Data
         if: ${{ env.branch_name != 'production'}}
         run: cd ./services/app-api && sls invoke -s $STAGE_PREFIX$branch_name -f migrate

--- a/services/ui-src/src/page/section/DetailSection.tsx
+++ b/services/ui-src/src/page/section/DetailSection.tsx
@@ -110,7 +110,7 @@ export const DetailSection = ({
           )}
         </section>
         <section className="detail-section ds-u-margin-bottom--7">
-          {detail.attachments.length > 0 ? (
+          {detail.attachments?.length > 0 ? (
             <FileList
               heading={pageConfig.attachmentsHeading}
               infoText={downloadInfoText}
@@ -133,7 +133,7 @@ export const DetailSection = ({
             </>
           )}
         </section>
-        {detail.raiResponses.length > 0 && (
+        {detail.raiResponses?.length > 0 && (
           <section className="detail-section">
             <h2>Formal RAI Responses</h2>
             <Accordion>


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-21088
Endpoint: See github-actions bot comment

### Details
production branch Data Migration was run successfully - need to remove the migration steps from the workflow.  Also, a null condition in the data is causing UI to error out on some details pages.  Remove dependency on the attachments attribute from the UI.

### Changes
- null check for attachments attribute
- null check for raiResponses attribute
- removed resetOneTable, convertChangeRequests, and verifyChangeRequests from deploy workflow
- DetailSection now treats null attachments the same as 0 attachments (shows the default text)

### Test Plan
1. Login as a submitting user
2. Navigate to Submission Dashboard
3. Select New Submission-> State Plan Amendment -> Respond to Medicaid SPA RAI
4. Use MD-10-2073 or MD-10-7530 to create a new response to RAI (or use the AWS console to find another valid SEATool entry that is not yet in OneMAC)
5. Wait at most 15 minutes (or trigger the convertChangeRequests in the console)
6. Navigate to Package Dashboard
7. Click on newly created Package
8. Verify page loads and displays correct information.
9. Can also test other RAI Response types, but in global code, so should not need to.
