### PR TITLE
OY2 22417: OneMAC should not distinguish between upper and lower case SEA Tool ID's.

### DIFF
--- a/services/admin/handlers/createOneMacPackage.js
+++ b/services/admin/handlers/createOneMacPackage.js
@@ -31,17 +31,18 @@ export const createOneMacPackage = async (item) => {
   const submissionTimestamp = convertDateToSeaToolTimestamp(
     item.submissionDate
   );
+  const theID = item.componentId.toUpperCase();
   if (!item.territory)
     item.territory = item.componentId.toString().substring(0, 2);
   const putParams = {
     TableName: process.env.oneMacTableName,
     Item: {
-      pk: item.componentId,
+      pk: theID,
       sk: `OneMAC#${submissionTimestamp}`,
       GSI1pk: `OneMAC#create${TYPE_MAP[item.componentType]}`,
-      GSI1sk: item.componentId,
+      GSI1sk: theID,
       eventTimestamp: submissionTimestamp,
-      componentId: item.componentId,
+      componentId: theID,
       componentType: TYPE_MAP[item.componentType],
       territory: item.territory,
       submissionTimestamp,
@@ -60,7 +61,7 @@ export const createOneMacPackage = async (item) => {
   try {
     await dynamoDb.put(putParams).promise();
   } catch (e) {
-    console.log("%s error received: ", item.componentId, e);
+    console.log("%s error received: ", theID, e);
   }
 };
 

--- a/services/seatool-sink/handlers/seaToolEvent.js
+++ b/services/seatool-sink/handlers/seaToolEvent.js
@@ -1,76 +1,28 @@
 const AWS = require("aws-sdk");
-//const { ChangeRequest } = require("cmscommonlib");
-//const { Workflow } = require("cmscommonlib");
-//const { ONEMAC_STATUS } = Workflow;
 
 AWS.config.update({ region: "us-east-1" });
 const ddb = new AWS.DynamoDB.DocumentClient({ apiVersion: "2012-08-10" });
 
 const topicPrefix = "aws.ksqldb.seatool.agg.StatePlan_";
 
-// const SEATOOL_PLAN_TYPE = {
-//   CHIP_SPA: "124",
-//   SPA: "125",
-//   WAIVER: "122",
-//   WAIVER_APP_K: "123",
-// };
-
-// const SEATOOL_STATUS = {
-//   PENDING: "1",
-//   PENDING_RAI: "2",
-//   PENDING_OFF_THE_CLOCK: "3",
-//   APPROVED: "4",
-//   DISAPPROVED: "5",
-//   WITHDRAWN: "6",
-//   TERMINATED: "7",
-//   PENDING_CONCURRENCE: "8",
-//   UNSUBMITTED: "9",
-//   PENDING_FINANCE: "10",
-//   PENDING_APPROVAL: "11",
-//   UNKNOWN: "unknown",
-// };
-
-// check if the SEATool updates should be reflected in OneMAC
-// const SEATOOL_TO_ONEMAC_STATUS = {
-//   [SEATOOL_STATUS.PENDING]: ONEMAC_STATUS.IN_REVIEW,
-//   [SEATOOL_STATUS.PENDING_RAI]: ONEMAC_STATUS.RAI_ISSUED,
-//   [SEATOOL_STATUS.PENDING_OFF_THE_CLOCK]: ONEMAC_STATUS.PAUSED,
-//   [SEATOOL_STATUS.APPROVED]: ONEMAC_STATUS.APPROVED,
-//   [SEATOOL_STATUS.DISAPPROVED]: ONEMAC_STATUS.DISAPPROVED,
-//   [SEATOOL_STATUS.WITHDRAWN]: ONEMAC_STATUS.WITHDRAWN,
-//   [SEATOOL_STATUS.TERMINATED]: ONEMAC_STATUS.TERMINATED,
-//   [SEATOOL_STATUS.PENDING_CONCURRENCE]: ONEMAC_STATUS.IN_REVIEW,
-//   [SEATOOL_STATUS.UNSUBMITTED]: ONEMAC_STATUS.UNSUBMITTED,
-//   [SEATOOL_STATUS.PENDING_FINANCE]: ONEMAC_STATUS.IN_REVIEW,
-//   [SEATOOL_STATUS.PENDING_APPROVAL]: ONEMAC_STATUS.IN_REVIEW,
-//   [SEATOOL_STATUS.UNKNOWN]: ONEMAC_STATUS.SUBMITTED,
-// };
-
-// const SEATOOL_TO_ONEMAC_PLAN_TYPE_IDS = {
-//   [SEATOOL_PLAN_TYPE.CHIP_SPA]: ChangeRequest.TYPE.CHIP_SPA,
-//   [SEATOOL_PLAN_TYPE.SPA]: ChangeRequest.TYPE.SPA,
-//   [SEATOOL_PLAN_TYPE.WAIVER]: ChangeRequest.TYPE.WAIVER_INITIAL,
-//   [SEATOOL_PLAN_TYPE.WAIVER_APP_K]: ChangeRequest.TYPE.WAIVER_APP_K,
-// };
-
 function myHandler(event) {
   if (event.source == "serverless-plugin-warmup") {
     return null;
   }
   console.log("Received event:", JSON.stringify(event, null, 2));
-  const componentType = event.topic.replace(topicPrefix, "");
+  const topicName = event.topic.replace(topicPrefix, "");
   const value = JSON.parse(event.value);
-  console.log(`Type: ${componentType} Topic: ${event.topic}`);
+  console.log(`Type: ${topicName} Topic: ${event.topic}`);
 
-  const pk = value.STATE_PLAN.ID_NUMBER;
+  const pk = value.STATE_PLAN.ID_NUMBER.toUpperCase();
   const changedDate = value.STATE_PLAN.CHANGED_DATE;
   if (!pk || !changedDate) return;
 
   // use the offset as a version number/event tracker... highest id is most recent
   const sk = `SEATool#${changedDate}`;
 
-  const GSI1pk = `SEATool#${componentType}`;
-  const GSI1sk = value.STATE_PLAN.ID_NUMBER;
+  const GSI1pk = `SEATool#${topicName}`;
+  const GSI1sk = value.STATE_PLAN.ID_NUMBER.toUpperCase();
 
   // put the SEATool Entry - don't bother if already exists
   const updateSEAToolParams = {
@@ -84,7 +36,7 @@ function myHandler(event) {
     ReturnValues: "ALL_OLD", // ReturnValues for put can only be NONE or ALL_OLD
   };
 
-  console.log("Params: ", updateSEAToolParams);
+  console.log("%s Params: ", pk, updateSEAToolParams);
 
   ddb.put(updateSEAToolParams, function (err, data) {
     if (err) {


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-22417
Endpoint: See github-actions bot comment

### Details
SEA Tool has a level of case insensitivity that is unsupported by DynamoDB.  OneMAC upper-cases all IDs (per business requirements), but needs to also see the ones that have lower cased characters in SEA Tool.

### Changes
- Upper case the ID_NUMBER value when put into the pk and GSI1sk attributes.
- Removed old commented out mappings so we don't accidentally think they should be used.
- Upper case the ids sent in the createOneMacPackage lambda

### Test Plan
1. Login to AWS console
2. Navigate to logs for Lambda: seatool-sink-oy2-22417-seaToolEvent
3. Select a SEA Tool event to copy (I used a MD one in Pending-RAI status)
4. copy the event from the event logged
5. edit the event and use lower case letters in the ID_NUMBER field where ever it is (15 times in the one I used)
6. use the Test feature to submit the event to the lambda
7. Verify that the event was saved with the upper case pk and GSI1sk
8. Use Lambda: admin-oy2-22417-createOneMacPackage to create a OneMAC package for the ID (use some lower case) (make sure to put the Submission Date as a date BEFORE the SEA Tool event)
9. Login to the OneMAC application as a submitting user
10. Navigate to package view and look for the package
11. Verify details are correct
12. Verify actions taken on the package work as expected.
