### PR TITLE
remove override of actionLabel for amendments

### DIFF
--- a/services/ui-src/src/page/waiver-amendment/WaiverAmendmentDetail.tsx
+++ b/services/ui-src/src/page/waiver-amendment/WaiverAmendmentDetail.tsx
@@ -10,7 +10,6 @@ import { waiverAmendment } from "cmscommonlib";
 export const waiverAmendmentDetail: OneMACDetail = {
   ...defaultDetail,
   ...waiverAmendment,
-  actionLabel: "Amendment Actions",
   detailHeader: "Waiver Amendment Package",
   detailSection: [...defaultWaiverDetailSectionItems],
 };

--- a/services/ui-src/src/page/waiver-appendix-k/WaiverAppendixKDetail.tsx
+++ b/services/ui-src/src/page/waiver-appendix-k/WaiverAppendixKDetail.tsx
@@ -18,7 +18,6 @@ const appendixKWaiverAuthority = {
 export const waiverAppendixKDetail: OneMACDetail = {
   ...defaultDetail,
   ...waiverAppendixK,
-  actionLabel: "Package Actions",
   detailHeader: "Appendix K Amendment",
   attachmentsHeading: "Attachments",
   detailSection: [


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-22594
Endpoint: See github-actions bot comment

### Details

Remove override of title for amendments. Keep default "Package Actions"

### Changes

- Removed "actionLabel" property from waiverAmendment config
- Removed redundant "actionLabel" property from waiverAppendixKDetail as it was same as in defaultDetail


### Test Plan

1. Login as any user with package view access
2. Navigate to any waiver package details page
3. Verify Label change
