### PR TITLE
oy2-22685 - created new method to update packageID

### DIFF
--- a/services/admin/handlers/updatePackageId.js
+++ b/services/admin/handlers/updatePackageId.js
@@ -49,7 +49,7 @@ async function getOneMacEventRecords(fromPackageId) {
 function formatPutRequests(toPackageId, addlInfo, records) {
   const putRequests = records.map((item) => {
     const auditArray = item.auditArray
-      ? [...item.auditArray, addlInfo]
+      ? [addlInfo, ...item.auditArray]
       : [addlInfo];
     const requestItem = {
       ...item,

--- a/services/admin/handlers/updatePackageId.js
+++ b/services/admin/handlers/updatePackageId.js
@@ -1,0 +1,114 @@
+import AWS from "aws-sdk";
+
+const dynamoDb = new AWS.DynamoDB.DocumentClient(
+  process.env.IS_OFFLINE
+    ? {
+        endpoint: "http://localhost:8000",
+      }
+    : {}
+);
+
+function validateEvent(event) {
+  //validate required input params
+  let missingParams = "";
+
+  if (!event.fromPackageId) {
+    missingParams += " fromPackageId ";
+  }
+  if (!event.toPackageId) {
+    missingParams += " toPackageId ";
+  }
+  if (!event.prependAdditionalInfo) {
+    missingParams += " prependAdditionalInfo ";
+  }
+  if (missingParams.trim().length != 0) {
+    throw new Error("Missing event parameters - " + missingParams);
+  }
+
+  console.log("event passed validation");
+}
+
+async function updateByPK(event) {
+  const tableName = process.env.oneMacTableName;
+  try {
+    // query just the onemac events for this package
+    const params = {
+      TableName: tableName,
+      KeyConditionExpression: "pk = :pkValue and begins_with(sk, :skValue)",
+      ExpressionAttributeValues: {
+        ":pkValue": event.fromPackageId,
+        ":skValue": "OneMAC#",
+      },
+    };
+    const data = await dynamoDb.query(params).promise();
+
+    //if more than one onemac event then throw an error
+    if (data.Count !== 1) {
+      throw new Error(
+        "Expected 1 item with pk " +
+          event.fromPackageId +
+          " but found " +
+          data.Count +
+          " items."
+      );
+    }
+    const item = data.Items[0];
+    console.log("OneMAC event found:", item);
+
+    if (!event.testRun) {
+      // Delete the old onemac event
+      const deleteParams = {
+        TableName: tableName,
+        Key: { pk: item.pk, sk: item.sk },
+      };
+      await dynamoDb.delete(deleteParams).promise();
+      console.log("Deleted Original OneMAC event");
+
+      // Insert the new event with new id
+      const newItem = {
+        ...item,
+        pk: event.toPackageId,
+        componentId: event.toPackageId,
+        GSI1pk: event.toPackageId,
+        additionalInformation:
+          event.prependAdditionalInfo + "\n\n" + item.additionalInformation,
+      };
+      const putParams = {
+        TableName: tableName,
+        Item: newItem,
+      };
+      await dynamoDb.put(putParams).promise();
+      console.log("Added new event with updated id:", newItem);
+
+      // delete the old package item
+      const deletePackageParams = {
+        TableName: tableName,
+        Key: { pk: item.pk, sk: "Package" },
+      };
+      await dynamoDb.delete(deletePackageParams).promise();
+      console.log("Deleted old package record");
+    } else {
+      console.log("testRun only, package not updated");
+    }
+  } catch (err) {
+    console.log("Error updating item:", err);
+    throw err;
+  }
+}
+
+/**
+ * Update a given packageId based on its current packageId (pk), type, and submittedAt timestamp.
+ *
+ * @param {string} event.fromPackageid The package id (pk,componentId) to update
+ * @param {string} event.toPackageId the new package id (pk,componentId)
+ * @param {string} event.prependAdditionalInfo is any text that should be prepended to the summary (additional info) to explain the update
+ * @param {string} event.testRun an optional boolean that if true indicates that the final update should not occur
+ * @returns {string} Confirmation message
+ */
+exports.main = async function (event) {
+  console.log("updateChangeRequestId.main", event);
+
+  validateEvent(event);
+
+  await updateByPK(event);
+};

--- a/services/admin/serverless.yml
+++ b/services/admin/serverless.yml
@@ -86,3 +86,7 @@ functions:
   batchCreateOMP:
     handler: ./handlers/batchCreateOMP.main
     timeout: 180
+
+  updatePackageId:
+    handler: ./handlers/updatePackageId.main
+    timeout: 180


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-22685
Endpoint: See github-actions bot comment

### Details

Create new method to update a onemac package with a new package id

### Changes

- created updatePackageId

### Implementation Notes

- This new admin function will update all OneMAC events for a given package id
- Since we are updating the pk, we have to delete the original onemac event record and the package record then recreate the onemac event records (the new package record will be auto built by the event stream)
- only the original create event will get the additional info added (skip rai)
- a new field named auditArray to track updates has been added and is a simple string array with the prependAdditionalInfo data passed into this update method added as an element

### Test Plan

1. Login as a statesubmitter
2. Submit a new package
3. Run the lambda using the package as the "fromPackageId" property
4. Verify old package is gone and package with new id retained all properties with the updated additional information
