### PR TITLE
Oy2 22943

### DIFF
--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -393,6 +393,7 @@ resources:
         MetricName: ConnectorEventReceivedCount
         AlarmActions:
           - Ref ConnectorMonitorTopic
+        ComparisonOperator: LessThanThreshold
         Statistic: Sum
         Period: 86400
         EvaluationPeriods: 1

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -390,7 +390,7 @@ resources:
       Properties:
         Type: String
         Description: The period of evaluation in seconds for the connector monitor alarm
-        Name: !Sub /configuration/connectorAlarmPeriod"
+        Name: connectorAlarmPeriod
         Value: "86400"
     ConnectorLogsMonitorAlarm:
       Type: AWS::CloudWatch::Alarm

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -377,11 +377,12 @@ resources:
       Type: AWS::Logs::MetricFilter
       Properties:
         LogGroupName:
-          Ref: "KafkaConnectWorkerLogGroup"
+          Ref: KafkaConnectWorkerLogGroup
         FilterName: ConnectorEventReceivedCount
         FilterPattern: "Received event"
         MetricTransformations:
-          - MetricValue: "1"
+          - MetricValue: 1
+            DefaultValue: 0
             MetricNamespace: ${self:service}-${self:custom.stage}/Connector/Monitor
             MetricName: "ConnectorEventReceivedCount"
             Unit: Count

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -388,7 +388,7 @@ resources:
     ConnectorLogsMonitorAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:
-        AlarmName: ${self:service}-${sls:stage}-ConnectorLogsMonitorAlarm
+        AlarmName: ${self:service}-${self:custom.stage}-ConnectorLogsMonitorAlarm
         AlarmDescription: "Notify ConnectorMonitorTopic when ConnectorEventReceivedCount is < 1 over 24 hours"
         MetricName: ConnectorEventReceivedCount
         AlarmActions:
@@ -397,4 +397,4 @@ resources:
         Period: 86400
         EvaluationPeriods: 1
         Threshold: 1
-        Namespace: ${self:service}-${self:stage}/Connector/Monitor
+        Namespace: ${self:service}-${self:custom.stage}/Connector/Monitor

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -376,12 +376,11 @@ resources:
     ConnectorEventReceivedCount:
       Type: AWS::Logs::MetricFilter
       Properties:
-        LogGroupName:
-          Ref: KafkaConnectWorkerLogGroup
+        LogGroupName: !Sub '/aws/lambda/${self:service}-${self:custom.stage}-seaToolEvent'
         FilterName: ConnectorEventReceivedCount
         FilterPattern: "Received event"
         MetricTransformations:
-          - MetricValue: 1
+          - MetricValue: "1"
             DefaultValue: 0
             MetricNamespace: ${self:service}-${self:custom.stage}/Connector/Monitor
             MetricName: "ConnectorEventReceivedCount"

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -379,7 +379,7 @@ resources:
         LogGroupName:
           Ref: "KafkaConnectWorkerLogGroup"
         FilterName: ConnectorEventReceivedCount
-        FilterPattern: "Received event:"
+        FilterPattern: "Received event"
         MetricTransformations:
           - MetricValue: "1"
             MetricNamespace: ${self:service}-${self:custom.stage}/Connector/Monitor

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -402,7 +402,7 @@ resources:
           - Ref: ConnectorMonitorTopic
         ComparisonOperator: LessThanThreshold
         Statistic: Sum
-        Period: 86400
+        Period: !GetAtt ConnectorMonitorAlarmPeriod.Value
         EvaluationPeriods: 1
         Threshold: 1
         Namespace: ${self:service}-${self:custom.stage}/Connector/Monitor

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -385,6 +385,12 @@ resources:
             MetricNamespace: ${self:service}-${self:custom.stage}/Connector/Monitor
             MetricName: "ConnectorEventReceivedCount"
             Unit: Count
+    ConnectorMonitorAlarmPeriod:
+      Type: AWS::SSM::Parameter
+      Properties:
+        Type: String
+        Name: !Sub /configuration/${self:custom.stage}/connectorAlarmPeriod"
+        Value: "86400"
     ConnectorLogsMonitorAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:
@@ -392,10 +398,11 @@ resources:
         AlarmDescription: "Notify ConnectorMonitorTopic when ConnectorEventReceivedCount is < 1 over 24 hours"
         MetricName: ConnectorEventReceivedCount
         AlarmActions:
-          - Ref ConnectorMonitorTopic
+          - Ref: ConnectorMonitorTopic
         ComparisonOperator: LessThanThreshold
         Statistic: Sum
-        Period: 86400
+        Period:
+          - Ref: ConnectorMonitorAlarmPeriod
         EvaluationPeriods: 1
         Threshold: 1
         Namespace: ${self:service}-${self:custom.stage}/Connector/Monitor

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -388,9 +388,9 @@ resources:
     ConnectorMonitorAlarmPeriod:
       Type: AWS::SSM::Parameter
       Properties:
-        Type: String
-        Description: The period of evaluation in seconds for the connector monitor alarm
         Name: connectorAlarmPeriod
+        Description: The period of evaluation in seconds for the connector monitor alarm
+        Type: String
         Value: "86400"
     ConnectorLogsMonitorAlarm:
       Type: AWS::CloudWatch::Alarm
@@ -402,8 +402,7 @@ resources:
           - Ref: ConnectorMonitorTopic
         ComparisonOperator: LessThanThreshold
         Statistic: Sum
-        Period:
-          - Ref: ConnectorMonitorAlarmPeriod
+        Period: 86400
         EvaluationPeriods: 1
         Threshold: 1
         Namespace: ${self:service}-${self:custom.stage}/Connector/Monitor

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -389,7 +389,8 @@ resources:
       Type: AWS::SSM::Parameter
       Properties:
         Type: String
-        Name: !Sub /configuration/${self:custom.stage}/connectorAlarmPeriod"
+        Description: The period of evaluation in seconds for the connector monitor alarm
+        Name: !Sub /configuration/connectorAlarmPeriod"
         Value: "86400"
     ConnectorLogsMonitorAlarm:
       Type: AWS::CloudWatch::Alarm

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -401,7 +401,7 @@ resources:
         AlarmActions:
           - Ref: ConnectorMonitorTopic
         ComparisonOperator: LessThanThreshold
-        Statistic: Sum
+        Statistic: SampleCount
         Period: !GetAtt ConnectorMonitorAlarmPeriod.Value
         EvaluationPeriods: 1
         Threshold: 1

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -369,3 +369,32 @@ resources:
                   Action:
                     - lambda:InvokeFunction
                   Resource: '*'
+    ConnectorMonitorTopic:
+      Type: AWS::SNS::Topic
+      Properties:
+        DisplayName: SNS Topic for Monitoring Kafka Connector Events
+    ConnectorEventReceivedCount:
+      Type: AWS::Logs::MetricFilter
+      Properties:
+        LogGroupName:
+          Ref: "KafkaConnectWorkerLogGroup"
+        FilterName: ConnectorEventReceivedCount
+        FilterPattern: "Received event:"
+        MetricTransformations:
+          - MetricValue: "1"
+            MetricNamespace: ${self:service}-${self:custom.stage}/Connector/Monitor
+            MetricName: "ConnectorEventReceivedCount"
+            Unit: Count
+    ConnectorLogsMonitorAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: ${self:service}-${sls:stage}-ConnectorLogsMonitorAlarm
+        AlarmDescription: "Notify ConnectorMonitorTopic when ConnectorEventReceivedCount is < 1 over 24 hours"
+        MetricName: ConnectorEventReceivedCount
+        AlarmActions:
+          - Ref ConnectorMonitorTopic
+        Statistic: Sum
+        Period: 86400
+        EvaluationPeriods: 1
+        Threshold: 1
+        Namespace: ${self:service}-${self:stage}/Connector/Monitor

--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -388,9 +388,9 @@ resources:
     ConnectorMonitorAlarmPeriod:
       Type: AWS::SSM::Parameter
       Properties:
-        Name: connectorAlarmPeriod
-        Description: The period of evaluation in seconds for the connector monitor alarm
         Type: String
+        Description: The period of evaluation in seconds for the connector monitor alarm
+        Name: !Sub /configuration/${self:custom.stage}/connectorAlarmPeriod
         Value: "86400"
     ConnectorLogsMonitorAlarm:
       Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-22943
Endpoint: See github-actions bot comment

### Details

Create new cloudwatch alarm when no seatool event has been received after a given period of time.

### Changes

- Create new SNS topic
- Create new cloudwatch metric filter
- Create new cloudwatch alarm

### Implementation Notes

- The alarm will notify the SNS topic but there wont be any subscribers, we will want to subscribe the slack channel email to the VAL and Prod topics (and anywhere else desired)
