### PR TITLE
Oy2 22177 - excel export

### DIFF
--- a/services/ui-src/src/components/PortalTable.tsx
+++ b/services/ui-src/src/components/PortalTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, useEffect } from "react";
 import {
   HeaderGroup,
   TableInstance,
@@ -34,6 +34,7 @@ export type TableProps<V extends {}> = {
   searchBarTitle?: ReactNode;
   withSearchBar?: boolean;
   TEMP_onReset?: () => void;
+  onVisibleDataChange: (rows: Row<V>[]) => void;
 } & Pick<SearchFilterProps<V>, "pageContentRef"> &
   TableOptions<V>;
 
@@ -48,6 +49,7 @@ export default function PortalTable<V extends {} = {}>({
   searchBarTitle,
   withSearchBar,
   TEMP_onReset = noop,
+  onVisibleDataChange,
   ...props
 }: TableProps<V>) {
   const {
@@ -80,6 +82,12 @@ export default function PortalTable<V extends {} = {}>({
     UseFiltersInstanceProps<V> &
     UseGlobalFiltersInstanceProps<V> &
     UseSortByInstanceProps<V>;
+
+  useEffect(() => {
+    if (onVisibleDataChange) {
+      onVisibleDataChange(rows);
+    }
+  }, [rows, onVisibleDataChange]);
 
   return (
     <>

--- a/services/ui-src/src/containers/PackageList.js
+++ b/services/ui-src/src/containers/PackageList.js
@@ -33,7 +33,7 @@ import PackageAPI from "../utils/PackageApi";
 import ActionPopup from "../components/ActionPopup";
 import { useAppContext } from "../libs/contextLib";
 import { pendingMessage, deniedOrRevokedMessage } from "../libs/userLib";
-import { tableListExportToCSV } from "../utils/tableListExportToCSV";
+import { portalTableExportToCSV } from "../utils/portalTableExportToCSV";
 
 const renderDate = ({ value }) =>
   typeof value === "number" && value > 0
@@ -49,6 +49,7 @@ export const getState = ({ componentId }) =>
 const PackageList = () => {
   const dashboardRef = useRef();
   const [packageList, setPackageList] = useState([]);
+  const [visibleRows, setVisibleRows] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const {
     userStatus,
@@ -156,6 +157,10 @@ const PackageList = () => {
     [tellPackageListAboutAction]
   );
 
+  const exportTransformMap = {
+    submissionTimestamp: renderDate,
+  };
+
   const columns = useMemo(
     () =>
       [
@@ -239,7 +244,7 @@ const PackageList = () => {
       className="new-submission-button"
       onClick={(e) => {
         e.preventDefault();
-        tableListExportToCSV("package-dashboard", packageList, `${tab}List`);
+        portalTableExportToCSV(visibleRows, exportTransformMap, `${tab}List`);
       }}
       inversed
     >
@@ -326,6 +331,7 @@ const PackageList = () => {
             searchBarTitle="Search by Package ID or Submitter Name"
             withSearchBar
             TEMP_onReset={TEMP_onReset}
+            onVisibleDataChange={setVisibleRows}
           />
         ) : (
           <EmptyList message="You have no packages yet." />

--- a/services/ui-src/src/containers/PackageList.test.js
+++ b/services/ui-src/src/containers/PackageList.test.js
@@ -3,7 +3,6 @@ import React from "react";
 import {
   render,
   screen,
-  waitFor,
   waitForElementToBeRemoved,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -16,7 +15,7 @@ import {
   helpDeskActiveInitialAuthState,
 } from "../libs/testDataAppContext";
 import { packageList } from "../libs/testDataPackages";
-import { tableListExportToCSV } from "../utils/tableListExportToCSV";
+import { portalTableExportToCSV } from "../utils/portalTableExportToCSV";
 
 import PackageApi from "../utils/PackageApi";
 import PackageList, { getState } from "./PackageList";
@@ -26,8 +25,8 @@ import { LOADER_TEST_ID } from "../components/LoadingScreen";
 jest.mock("../utils/PackageApi");
 window.HTMLElement.prototype.scrollIntoView = jest.fn();
 
-jest.mock("../utils/tableListExportToCSV");
-tableListExportToCSV.mockImplementation(() => null);
+jest.mock("../utils/portalTableExportToCSV");
+portalTableExportToCSV.mockImplementation(() => null);
 
 const ContextWrapper = ({ children }) => {
   return (
@@ -81,7 +80,7 @@ it("helpdesk user renders with an Export button", async () => {
 
   const exportButton = await screen.findByText("Export to Excel(CSV)");
   userEvent.click(exportButton);
-  expect(tableListExportToCSV).toBeCalled();
+  expect(portalTableExportToCSV).toBeCalled();
 });
 
 it("passes a retrieval error up", async () => {

--- a/services/ui-src/src/utils/portalTableExportToCSV.js
+++ b/services/ui-src/src/utils/portalTableExportToCSV.js
@@ -1,0 +1,49 @@
+const tableToCSV = (rows, transformMap) => {
+  if (rows.length === 0) {
+    return "";
+  }
+
+  let CSV = rows[0].cells.map((cell) => cell.column.Header).join(",");
+
+  CSV += "\r\n";
+
+  const transformedData = rows.map((row) =>
+    row.cells.map((cell) => {
+      if (transformMap[cell.column.id]) {
+        return '"' + transformMap[cell.column.id](cell) + '"';
+      }
+      return '"' + cell.value + '"';
+    })
+  );
+
+  for (const item of transformedData) {
+    CSV += Object.values(item).join(",") + "\r\n";
+  }
+
+  return CSV;
+};
+
+export const portalTableExportToCSV = (rows, transformMap, reportTitle) => {
+  const CSV = tableToCSV(rows, transformMap);
+
+  if (CSV === "") {
+    alert("Invalid data");
+    return;
+  }
+
+  var fileName = "Report_";
+
+  fileName += reportTitle.replace(/ /g, "_");
+
+  var uri = "data:text/csv;charset=utf-8," + escape(CSV);
+
+  var link = document.createElement("a");
+  link.href = uri;
+
+  link.style = "visibility:hidden";
+  link.download = fileName + ".csv";
+
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};

--- a/services/ui-src/src/utils/portalTableExportToCSV.test.js
+++ b/services/ui-src/src/utils/portalTableExportToCSV.test.js
@@ -1,0 +1,83 @@
+import { portalTableExportToCSV } from "./portalTableExportToCSV";
+
+const mockRows = [
+  {
+    cells: [
+      { column: { Header: "SPA ID", id: "SPA ID" }, value: "123" },
+      { column: { Header: "State", id: "State" }, value: "CA" },
+      { column: { Header: "Type", id: "Type" }, value: "Residential" },
+      { column: { Header: "Status", id: "Status" }, value: "Active" },
+      {
+        column: {
+          Header: "Initial Submission Date",
+          id: "Initial Submission Date",
+        },
+        value: 1646275200000,
+      },
+    ],
+  },
+];
+
+const transformMap = {
+  "Initial Submission Date": (cell) =>
+    new Date(cell.value).toLocaleDateString("en-US", {
+      month: "short",
+      day: "2-digit",
+      year: "numeric",
+      timeZone: "UTC",
+    }),
+};
+
+describe("portalTableExportToCSV", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("should export CSV with correct data and format", () => {
+    const createElementSpy = jest.spyOn(document, "createElement");
+    const appendChildSpy = jest.spyOn(document.body, "appendChild");
+    const removeChildSpy = jest.spyOn(document.body, "removeChild");
+    const clickSpy = jest.fn();
+
+    const linkMock = document.createElement("a");
+    linkMock.click = clickSpy;
+    createElementSpy.mockReturnValue(linkMock);
+
+    portalTableExportToCSV(mockRows, transformMap, "Test Report");
+
+    expect(createElementSpy).toHaveBeenCalledWith("a");
+    expect(appendChildSpy).toHaveBeenCalledWith(linkMock);
+    expect(linkMock.href).toBe(
+      "data:text/csv;charset=utf-8,SPA%20ID%2CState%2CType%2CStatus%2CInitial%20Submission%20Date%0D%0A%22123%22%2C%22CA%22%2C%22Residential%22%2C%22Active%22%2C%22Mar%2003%2C%202022%22%0D%0A"
+    );
+    expect(linkMock.download).toBe("Report_Test_Report.csv");
+    expect(clickSpy).toHaveBeenCalled();
+    expect(removeChildSpy).toHaveBeenCalledWith(linkMock);
+  });
+
+  it("should display an alert when the generated CSV is empty", () => {
+    const createElementSpy = jest.spyOn(document, "createElement");
+    const appendChildSpy = jest.spyOn(document.body, "appendChild");
+    const removeChildSpy = jest.spyOn(document.body, "removeChild");
+    const clickSpy = jest.fn();
+    const linkMock = {
+      href: "",
+      style: "",
+      download: "",
+      click: clickSpy,
+    };
+    createElementSpy.mockReturnValue(linkMock);
+
+    const alertSpy = jest.spyOn(window, "alert").mockImplementation(() => {});
+
+    portalTableExportToCSV([], transformMap, "Empty Report");
+
+    expect(alertSpy).toHaveBeenCalledWith("Invalid data");
+    expect(createElementSpy).not.toHaveBeenCalled();
+    expect(appendChildSpy).not.toHaveBeenCalled();
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(removeChildSpy).not.toHaveBeenCalled();
+
+    alertSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-22177
Endpoint: See github-actions bot comment

### Details

Export only columns currently visible on screen.

### Changes

- Added useEffect in portal table to watch change in row data and send to new parameter function for outside consumption
- Updated package list 
-- store as state var  an array of current rows which is set by a parameter function into PortalTable
-- call new export function
- created new export function which is specific to portal table (react-table) and exports based off react-table `row` data structures

### Implementation Notes

- When creating the new export function I had to do something I didnt entirely like and this create another set of transform functions for data that is not held in the row the way we would like it to be. I tried using the method defined on the columns object of the table but this results in a JSX object being returned for rendering in a page and while this would have worked for our lone use case here (date formatting) it wouldnt necessarily work as a blanket operation. Therefore I created an map of id=>function to pass into export for it to transform any cell having that header id. Also the transformed value is wrapped in quotes to prevent commas in the data acting like seperate values in the resulting CSV file

### Test Plan

1. Login as state system admin
2. Navigate to package view (default view)
3. Export to Excel and verify all data is included
4. Hide some columns and filter some data to limit the displayed data set
5. Export to Excel and verify only data displayed is in the excel. Anything column hidden or row filtered out of view will not be in the report.
