### PR TITLE
OY2 22419: Change '-- --' to 'Requested'

### DIFF
--- a/services/app-api/libs/status-lib.js
+++ b/services/app-api/libs/status-lib.js
@@ -25,7 +25,7 @@ export const cmsStatusUIMap = {
   [Workflow.ONEMAC_STATUS.APPROVED]: "Approved",
   [Workflow.ONEMAC_STATUS.DISAPPROVED]: "Disapproved",
   [Workflow.ONEMAC_STATUS.WITHDRAWAL_REQUESTED]: "Submitted - Intake Needed",
-  [Workflow.ONEMAC_STATUS.TE_REQUESTED]: "-- --",
+  [Workflow.ONEMAC_STATUS.TE_REQUESTED]: "Requested",
   [Workflow.ONEMAC_STATUS.WITHDRAWN]: "Package Withdrawn",
   [Workflow.ONEMAC_STATUS.TERMINATED]: "Waiver Terminated",
   [Workflow.ONEMAC_STATUS.UNKNOWN]: "-- --",

--- a/tests/cypress/cypress/integration/Package_Details_Temporary_Extension_CMS_User.spec.feature
+++ b/tests/cypress/cypress/integration/Package_Details_Temporary_Extension_CMS_User.spec.feature
@@ -14,7 +14,7 @@ Feature: Waiver Package Details View: Temporary Extension for a CMS User
         And click the Waiver Number link in the first row
         And verify the package details page is visible
         And verify action card exists
-        And verify the status on the card is "-- --"
+        And verify the status on the card is "Requested"
         And verify the package actions section is unavailable
         And verify the details section exists
         #And verify there is a Type header in the details section

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -1952,7 +1952,7 @@ And("click Submitted checkbox", () => {
 And("click Submitted - Intake Needed checkbox", () => {
   OneMacPackagePage.clickSubmittedIntakeNeededCheckbox();
 });
-And("click -- -- checkbox", () => {
+And("click Requested checkbox", () => {
   OneMacPackagePage.clickDoubleDashCheckbox();
 });
 And("click the Pending checkbox", () => {

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -186,7 +186,7 @@ const submittedCheckbox =
 const submittedIntakeNeededCheckbox =
   "//label[contains(@for,'checkbox_packageStatus-Submitted - Intake Needed')]";
 const doubleDashCheckbox =
-  "//label[contains(@for,'checkbox_packageStatus--- --')]";
+  "//label[contains(@for,'checkbox_packageStatus-Requested')]";
 const pendingCheckbox =
   "//label[contains(@for,'checkbox_packageStatus-Pending')]/span[text()='Pending']";
 const unsubmittedCheckbox =


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-22419 - take 2!
Endpoint: See github-actions bot comment

### Details
Missed that Product asked to change -- -- to Requested

### Changes
- TE_REQUESTED status for CMS Users now says "Requested"

### Test Plan
1. Login as a State user
2. Navigate to Dashboard->Waivers tab
3. Verify that Temporary Extension packages are visible and show "Submitted" status.
4. Click into a Temporary Extension details page
5. Verify the status is "Submitted"
6. Return to dashboard and Submit a New Temporary Extension
7. Verify the new Temporary Extension shows "Submitted" status
8. Logout
9. Login as CMS user
10. Navigate to Dashboard-> Waivers tab
11. Verify that Temporary Extension packages are visible and show "Requested" status.
12. Click into a Temporary Extension details page
13. Verify the status is "Requested"