### PR TITLE
Locks design system to 2.7.1 version

### DIFF
--- a/services/ui-src/package-lock.json
+++ b/services/ui-src/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@babel/polyfill": "^7.12.1",
-        "@cmsgov/design-system": "^2.7.0",
+        "@cmsgov/design-system": "2.7.1",
         "@material-ui/core": "^4.11.3",
         "@material-ui/data-grid": "^4.0.0-alpha.22",
         "@react-spring/web": "^9.4.2",
@@ -7758,26 +7758,39 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "node_modules/@cmsgov/design-system": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@cmsgov/design-system/-/design-system-2.13.0.tgz",
-      "integrity": "sha512-5/rNspXZvMXOov3PqTgksZPOKV5dnh0WpyuFtSOW6ulNXa9eWNIa1Tq26eL1fD5uJsf7Lz8LqKrsZi1Mr8NbMw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@cmsgov/design-system/-/design-system-2.7.1.tgz",
+      "integrity": "sha512-cQ6E/IDg14uz5QSiAB/kOzHrDRW8rVK+G10M37zBN4EA20TOO4VosTb7J4pW+5R+9PlCKKow7l2zntmbFWM2wQ==",
       "dependencies": {
         "@popperjs/core": "^2.4.4",
-        "@types/react": "^17.0.10",
-        "@types/react-dom": "^17.0.10",
         "classnames": "^2.2.5",
         "core-js": "^3.6.5",
         "downshift": "^3.2.10",
         "ev-emitter": "^1.1.1",
         "focus-trap-react": "^6.0.0",
-        "lodash": "^4.17.21",
+        "lodash.uniqueid": "^4.0.1",
         "prop-types": "^15.7.2",
         "react-aria-modal": "^2.11.1",
-        "react-transition-group": "^4.4.2"
+        "react-transition-group": "^2.9.0"
       },
       "peerDependencies": {
         "react": ">=16.0.0",
         "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@cmsgov/design-system/node_modules/react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "dependencies": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0",
+        "react-dom": ">=15.0.0"
       }
     },
     "node_modules/@csstools/normalize.css": {
@@ -11190,6 +11203,7 @@
       "version": "17.0.19",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.19.tgz",
       "integrity": "sha512-PiYG40pnQRdPHnlf7tZnp0aQ6q9tspYr72vD61saO6zFCybLfMqwUCN0va1/P+86DXn18ZWeW30Bk7xlC5eEAQ==",
+      "dev": true,
       "dependencies": {
         "@types/react": "^17"
       }
@@ -21770,6 +21784,11 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+    },
+    "node_modules/lodash.uniqueid": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
+      "integrity": "sha512-GQQWaIeGlL6DIIr06kj1j6sSmBxyNMwI8kaX9aKpHR/XsMTiaXDVPNPAkiboOTK9OJpTJF/dXT3xYoFQnj386Q=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -34675,22 +34694,33 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
     "@cmsgov/design-system": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@cmsgov/design-system/-/design-system-2.13.0.tgz",
-      "integrity": "sha512-5/rNspXZvMXOov3PqTgksZPOKV5dnh0WpyuFtSOW6ulNXa9eWNIa1Tq26eL1fD5uJsf7Lz8LqKrsZi1Mr8NbMw==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@cmsgov/design-system/-/design-system-2.7.1.tgz",
+      "integrity": "sha512-cQ6E/IDg14uz5QSiAB/kOzHrDRW8rVK+G10M37zBN4EA20TOO4VosTb7J4pW+5R+9PlCKKow7l2zntmbFWM2wQ==",
       "requires": {
         "@popperjs/core": "^2.4.4",
-        "@types/react": "^17.0.10",
-        "@types/react-dom": "^17.0.10",
         "classnames": "^2.2.5",
         "core-js": "^3.6.5",
         "downshift": "^3.2.10",
         "ev-emitter": "^1.1.1",
         "focus-trap-react": "^6.0.0",
-        "lodash": "^4.17.21",
+        "lodash.uniqueid": "^4.0.1",
         "prop-types": "^15.7.2",
         "react-aria-modal": "^2.11.1",
-        "react-transition-group": "^4.4.2"
+        "react-transition-group": "^2.9.0"
+      },
+      "dependencies": {
+        "react-transition-group": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+          "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        }
       }
     },
     "@csstools/normalize.css": {
@@ -37157,6 +37187,7 @@
       "version": "17.0.19",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.19.tgz",
       "integrity": "sha512-PiYG40pnQRdPHnlf7tZnp0aQ6q9tspYr72vD61saO6zFCybLfMqwUCN0va1/P+86DXn18ZWeW30Bk7xlC5eEAQ==",
+      "dev": true,
       "requires": {
         "@types/react": "^17"
       }
@@ -45043,6 +45074,11 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+    },
+    "lodash.uniqueid": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.uniqueid/-/lodash.uniqueid-4.0.1.tgz",
+      "integrity": "sha512-GQQWaIeGlL6DIIr06kj1j6sSmBxyNMwI8kaX9aKpHR/XsMTiaXDVPNPAkiboOTK9OJpTJF/dXT3xYoFQnj386Q=="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/services/ui-src/package.json
+++ b/services/ui-src/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "dependencies": {
     "@babel/polyfill": "^7.12.1",
-    "@cmsgov/design-system": "^2.7.0",
+    "@cmsgov/design-system": "2.7.1",
     "@material-ui/core": "^4.11.3",
     "@material-ui/data-grid": "^4.0.0-alpha.22",
     "@react-spring/web": "^9.4.2",


### PR DESCRIPTION
### Details

Fixes the design issues introduced after updating our design system package.

| Version | Active | Focused |
| ------- | ------- | -------- |
| Broken | <img width="68" alt="Screen Shot 2023-03-31 at 8 40 32 AM" src="https://user-images.githubusercontent.com/4022304/229122829-77d3e85c-e260-426b-9046-304db0672509.png"> | <img width="86" alt="Screen Shot 2023-03-31 at 8 40 38 AM" src="https://user-images.githubusercontent.com/4022304/229122869-0aed5c8b-e02f-483b-ad65-bc6d1d8b9951.png"> |
| Fixed | <img width="76" alt="Screen Shot 2023-03-31 at 8 40 44 AM" src="https://user-images.githubusercontent.com/4022304/229122923-6bd23e19-c0d2-408b-862c-ea12dfee7461.png"> | <img width="87" alt="Screen Shot 2023-03-31 at 8 40 48 AM" src="https://user-images.githubusercontent.com/4022304/229122935-ceef66f8-8d05-43fd-be4c-2f0faa636d08.png">


### Test Plan

Before testing, ensure you run `npm install --legacy-peer-deps` to update your package-lock.json
