### PR TITLE
Fix `onemac-form` flex direction and alignment

### DIFF
--- a/services/ui-src/src/index.scss
+++ b/services/ui-src/src/index.scss
@@ -590,6 +590,8 @@ input[type="file"] {
   @extend .app-bar;
   @extend .ds-u-padding-top--5;
   @extend .ds-u-justify-content--center;
+  flex-direction: column;
+  align-items: center;
 
   form {
     @include max-width-ultra-wide;


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-23406

### Details

Adjusts styles in the `onemac-form` class used in the OneMacForm component so that the two items in the flex box are in a single column at all screen sizes.

### Changes

- Flex direction was row, now is column
- Added center alignment to fix positioning once flex direction was changed

### Implementation Notes

- N/A

### Test Plan

1. Log in using a dev account
2. Navigate to the Dashboard
3. Click the "New Package" button
4. Ensure each form can scale to a 4K or higher resolution without breaking styles (use browser dev tools or CMD/CTRL and `-` to downsize the screen in your browser to emulate higher resolutions.
