### PR TITLE
Oy2 22141tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -321,6 +321,12 @@ jobs:
             Dashboard_Under_Review_Actions.spec.feature,
             Dashboard_Approved_Actions.spec.feature,
             Dashboard_Filter_CMS.spec.feature,
+            Withdraw_Package_Form_App_K_Amendment.spec.feature,
+            Withdraw_Package_Form_CHIP_SPA.spec.feature,
+            Withdraw_Package_Form_Initial_Waiver.spec.feature,
+            Withdraw_Package_Form_Medicaid_SPA.spec.feature,
+            Withdraw_Package_Form_Waiver_Amendment.spec.feature,
+            Withdraw_Package_Form_Waiver_Renewal.spec.feature,
             
           ]
     steps:

--- a/services/app-api/one-seed.json
+++ b/services/app-api/one-seed.json
@@ -14394,7 +14394,7 @@
   },
   {
     "clockEndTimestamp": 1681930575838,
-    "componentType": "waivernew",
+    "componentType": "waiverappk",
     "currentStatus": "Under Review",
     "waiverExtensions": [],
     "attachments": [
@@ -14559,13 +14559,13 @@
     "COMPONENTS_SP": null,
     "PLAN_TYPES": [
       {
-        "PLAN_TYPE_ID": 122,
-        "PLAN_TYPE_NAME": "1915(b)"
+        "PLAN_TYPE_ID": 123,
+        "PLAN_TYPE_NAME": "1915(c)"
       }
     ],
     "PRIORITY_CODES": null,
     "SP_IMPACT_FUNDING": null,
-    "GSI1pk": "SEATool#1915b_waivers",
+    "GSI1pk": "SEATool#1915c_waivers",
     "CODEAFTERINITACCESS": null,
     "STOP_RESUME_DATES": null,
     "COMPONENTS": null,

--- a/tests/cypress/cypress.json
+++ b/tests/cypress/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "https://dku1cpj363e48.cloudfront.net",
+  "baseUrl": "https://d2dr7dgo9g0124.cloudfront.net",
   "redirectionLimit": 20,
   "retries": 2,
   "watchForFileChanges": true,

--- a/tests/cypress/cypress/integration/Dashboard_RAI_Issued_Actions.spec.feature
+++ b/tests/cypress/cypress/integration/Dashboard_RAI_Issued_Actions.spec.feature
@@ -5,18 +5,18 @@ Feature: Verify package actions in RAI Issued Status in the package dashboard
         When Login with state submitter user
         And click on Packages
 
-    # Need seed data / reset data update
-    # Scenario: Demonstrate withdraw package and respond to rai are available for CHIP SPA in RAI Issued Status
-    #     And Click on Filter Button
-    #     And click on Status
-    #     And uncheck all of the status checkboxes
-    #     And click RAI Issued checkbox
-    #     And click on Type
-    #     And uncheck all of the type checkboxes
-    #     And click CHIP SPA check box
-    #     And click the actions button in row one
-    #     And verify withdraw package button is visible for package in package dashboard
-    #     And verify the Respond to RAI button is displayed
+
+    Scenario: Demonstrate withdraw package and respond to rai are available for CHIP SPA in RAI Issued Status
+        And Click on Filter Button
+        And click on Status
+        And uncheck all of the status checkboxes
+        And click RAI Issued checkbox
+        And click on Type
+        And uncheck all of the type checkboxes
+        And click CHIP SPA check box
+        And click the actions button in row one
+        And verify withdraw package button is visible for package in package dashboard
+        And verify the Respond to RAI button is displayed
 
     Scenario: Demonstrate withdraw package and respond to rai are available for Medicaid SPA in RAI Issued Status
         And Click on Filter Button

--- a/tests/cypress/cypress/integration/Request_A_Role_Change.spec.feature
+++ b/tests/cypress/cypress/integration/Request_A_Role_Change.spec.feature
@@ -12,7 +12,7 @@ Feature: OY2-12679 Users can request a role change in OneMAC
         And click on the SSA role
         And verify the user role is "State System Admin"
         And verify the error message says "Please select a state."
-        And verify the submit button is disabled
+        And verify the submit button is disabled on request a role page
         And select "Alabama" for state access
         And verify the submit button is enabled
         And verify there is no error message
@@ -33,7 +33,7 @@ Feature: OY2-12679 Users can request a role change in OneMAC
         And click on the State Submitter role
         And verify the user role is "State Submitter"
         And verify the error message says "Please select at least one state."
-        And verify the submit button is disabled
+        And verify the submit button is disabled on request a role page
         And select "Alabama" for state access
         And verify the submit button is enabled
         And verify there is no error message

--- a/tests/cypress/cypress/integration/Withdraw_Package_Form_App_K_Amendment.spec.feature
+++ b/tests/cypress/cypress/integration/Withdraw_Package_Form_App_K_Amendment.spec.feature
@@ -1,0 +1,71 @@
+Feature: Verify user can withdraw a package in Under Review Status in the package dashboard 
+    Background: Reoccurring steps
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And click on the Waivers tab
+        And Click on Filter Button
+        And click on Status
+        And uncheck all of the status checkboxes
+        And click Under Review checkbox
+        And click on Type
+        And uncheck all of the type checkboxes
+        And click 1915c Appendix K Amendment check box
+
+    Scenario: Screen Enhance - Validate 1915C Appendix K Amendment Withdrawal Page from dashboard
+        And click the actions button in row one
+        And click withdraw package button
+        And verify the header is "Withdraw Waiver" on the withdrawal form
+        And verify the form intro exists on the withdrawal form
+        And verify the Waiver number header exists on the withdrawal form
+        And verify the Waiver number exists on the withdrawal form
+        And verify the Type header exists on the withdrawal form
+        And verify the type is "Appendix K Amendment"
+        And verify the Upload Supporting Documentation header exists on the withdrawal form
+        And verify the Additional Info header exists on the withdrawal form
+        And verify the submit button is disabled
+        And verify form cancel button exists
+        And click form cancel button
+        And click Stay on Page
+        And click form cancel button
+        And click Leave Anyway form button
+        Then Click on My Account
+        And click the logout button
+
+    Scenario: Screen Enhance - Validate 1915C Appendix K Amendment Withdrawal Page from details page
+        And click the Waiver Number link in the first row
+        And verify the package details page is visible
+        And click withdraw button
+        And verify the header is "Withdraw Waiver" on the withdrawal form
+        And verify the form intro exists on the withdrawal form
+        And verify the Waiver number header exists on the withdrawal form
+        And verify the Waiver number exists on the withdrawal form
+        And verify the Type header exists on the withdrawal form
+        And verify the type is "Appendix K Amendment"
+        And verify the Upload Supporting Documentation header exists on the withdrawal form
+        And verify the Additional Info header exists on the withdrawal form
+        And verify the submit button is disabled
+        And verify form cancel button exists
+        And click form cancel button
+        And click Stay on Page
+        And click form cancel button
+        And click Leave Anyway form button
+        Then Click on My Account
+        And click the logout button
+    
+    Scenario: Screen Enhance - Validate Form logic
+        And click the actions button in row one
+        And click withdraw package button
+        And verify the submit button is disabled
+        And add additional info comment in the withdrawal form
+        And verify the submit button is not disabled
+        And upload withdrawal documentation
+        And verify the submit button is not disabled
+        And clear additional info comment in the withdrawal form
+        And verify the submit button is not disabled
+        And Click the Submit Button without waiting
+        And verify yes, withdraw package button exists
+        And click modal cancel button
+        Then Click on My Account
+        And click the logout button

--- a/tests/cypress/cypress/integration/Withdraw_Package_Form_CHIP_SPA.spec.feature
+++ b/tests/cypress/cypress/integration/Withdraw_Package_Form_CHIP_SPA.spec.feature
@@ -1,0 +1,68 @@
+Feature: Verify user can withdraw a package in Under Review Status in the package dashboard 
+    Background: Reoccurring steps
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And Click on Filter Button
+        And click on Status
+        And uncheck all of the status checkboxes
+        And click Under Review checkbox
+        And click on Type
+        And uncheck all of the type checkboxes
+        And click CHIP SPA check box
+
+    Scenario: Screen Enhance - Validate CHIP Withdrawal Page from the dashboard
+        And click the actions button in row one
+        And click withdraw package button
+        And verify the header is "Withdraw CHIP SPA Package" on the withdrawal form
+        And verify the form intro exists on the withdrawal form
+        And verify the SPA ID header exists on the withdrawal form
+        And verify the SPA ID exists on the withdrawal form
+        And verify the Type header exists on the withdrawal form
+        And verify the type is "CHIP SPA"
+        And verify the Upload Supporting Documentation header exists on the withdrawal form
+        And verify the Additional Info header exists on the withdrawal form
+        And verify the submit button is disabled
+        And verify form cancel button exists
+        And click form cancel button
+        And click Stay on Page
+        And click form cancel button
+        And click Leave Anyway form button
+
+    Scenario: Screen Enhance - Validate CHIP Withdrawal Page from the details page
+        And click the SPA ID link in the first row
+        And verify the package details page is visible
+        And verify the header is "Withdraw CHIP SPA Package" on the withdrawal form
+        And verify the form intro exists on the withdrawal form
+        And verify the SPA ID header exists on the withdrawal form
+        And verify the SPA ID exists on the withdrawal form
+        And verify the Type header exists on the withdrawal form
+        And verify the type is "CHIP SPA"
+        And verify the Upload Supporting Documentation header exists on the withdrawal form
+        And verify the Additional Info header exists on the withdrawal form
+        And verify the submit button is disabled
+        And verify form cancel button exists
+        And click form cancel button
+        And click Stay on Page
+        And click form cancel button
+        And click Leave Anyway form button
+    
+    Scenario: Screen Enhance - Validate Form logic
+        And click the actions button in row one
+        And click withdraw package button
+        And add additional info comment in the withdrawal form
+        And verify the submit button is disabled
+        And upload withdrawal documentation
+        And verify the submit button is not disabled
+        And clear additional info comment in the withdrawal form
+        And verify the submit button is not disabled
+        And Click the Submit Button without waiting
+        And verify yes, withdraw package button exists
+        And click modal cancel button
+
+    # Scenario: Demonstrate withdraw package for CHIP SPA in Under Review Status
+    #     And upload withdrawal documentation
+    #     And verify the submit button is not disabled
+    #     And Click the Submit Button without waiting
+    #     And click yes, withdraw package button

--- a/tests/cypress/cypress/integration/Withdraw_Package_Form_CHIP_SPA.spec.feature
+++ b/tests/cypress/cypress/integration/Withdraw_Package_Form_CHIP_SPA.spec.feature
@@ -33,6 +33,7 @@ Feature: Verify user can withdraw a package in Under Review Status in the packag
     Scenario: Screen Enhance - Validate CHIP Withdrawal Page from the details page
         And click the SPA ID link in the first row
         And verify the package details page is visible
+        And click withdraw button
         And verify the header is "Withdraw CHIP SPA Package" on the withdrawal form
         And verify the form intro exists on the withdrawal form
         And verify the SPA ID header exists on the withdrawal form

--- a/tests/cypress/cypress/integration/Withdraw_Package_Form_Initial_Waiver.spec.feature
+++ b/tests/cypress/cypress/integration/Withdraw_Package_Form_Initial_Waiver.spec.feature
@@ -1,0 +1,71 @@
+Feature: Verify user can withdraw a package in Under Review Status in the package dashboard 
+    Background: Reoccurring steps
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And click on the Waivers tab
+        And Click on Filter Button
+        And click on Status
+        And uncheck all of the status checkboxes
+        And click Under Review checkbox
+        And click on Type
+        And uncheck all of the type checkboxes
+        And click 1915b Initial Waiver check box
+
+    Scenario: Screen Enhance - Validate Initial Waiver Withdrawal Page from dashboard
+        And click the actions button in row one
+        And click withdraw package button
+        And verify the header is "Withdraw Waiver" on the withdrawal form
+        And verify the form intro exists on the withdrawal form
+        And verify the Waiver number header exists on the withdrawal form
+        And verify the Waiver number exists on the withdrawal form
+        And verify the Type header exists on the withdrawal form
+        And verify the type is "Initial Waiver"
+        And verify the Upload Supporting Documentation header exists on the withdrawal form
+        And verify the Additional Info header exists on the withdrawal form
+        And verify the submit button is disabled
+        And verify form cancel button exists
+        And click form cancel button
+        And click Stay on Page
+        And click form cancel button
+        And click Leave Anyway form button
+        Then Click on My Account
+        And click the logout button
+
+    Scenario: Screen Enhance - Validate Initial Waiver Withdrawal Page from details page
+        And click the Waiver Number link in the first row
+        And verify the package details page is visible
+        And click withdraw button
+        And verify the header is "Withdraw Waiver" on the withdrawal form
+        And verify the form intro exists on the withdrawal form
+        And verify the Waiver number header exists on the withdrawal form
+        And verify the Waiver number exists on the withdrawal form
+        And verify the Type header exists on the withdrawal form
+        And verify the type is "Initial Waiver"
+        And verify the Upload Supporting Documentation header exists on the withdrawal form
+        And verify the Additional Info header exists on the withdrawal form
+        And verify the submit button is disabled
+        And verify form cancel button exists
+        And click form cancel button
+        And click Stay on Page
+        And click form cancel button
+        And click Leave Anyway form button
+        Then Click on My Account
+        And click the logout button
+    
+    Scenario: Screen Enhance - Validate Form logic
+        And click the actions button in row one
+        And click withdraw package button
+        And verify the submit button is disabled
+        And add additional info comment in the withdrawal form
+        And verify the submit button is not disabled
+        And upload withdrawal documentation
+        And verify the submit button is not disabled
+        And clear additional info comment in the withdrawal form
+        And verify the submit button is not disabled
+        And Click the Submit Button without waiting
+        And verify yes, withdraw package button exists
+        And click modal cancel button
+        Then Click on My Account
+        And click the logout button

--- a/tests/cypress/cypress/integration/Withdraw_Package_Form_Medicaid_SPA.spec.feature
+++ b/tests/cypress/cypress/integration/Withdraw_Package_Form_Medicaid_SPA.spec.feature
@@ -1,0 +1,69 @@
+Feature: Verify user can withdraw a package in Under Review Status in the package dashboard 
+    Background: Reoccurring steps
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And Click on Filter Button
+        And click on Status
+        And uncheck all of the status checkboxes
+        And click Under Review checkbox
+        And click on Type
+        And uncheck all of the type checkboxes
+        And click Medicaid SPA check box
+
+       Scenario: Screen Enhance - Validate Medicaid Withdrawal Page from dashboard
+        And click the actions button in row one
+        And click withdraw package button
+        And verify the header is "Withdraw Medicaid SPA Package" on the withdrawal form
+        And verify the form intro exists on the withdrawal form
+        And verify the SPA ID header exists on the withdrawal form
+        And verify the SPA ID exists on the withdrawal form
+        And verify the Type header exists on the withdrawal form
+        And verify the type is "Medicaid SPA"
+        And verify the Upload Supporting Documentation header exists on the withdrawal form
+        And verify the Additional Info header exists on the withdrawal form
+        And verify the submit button is disabled
+        And verify form cancel button exists
+        And click form cancel button
+        And click Stay on Page
+        And click form cancel button
+        And click Leave Anyway form button
+        Then Click on My Account
+        And click the logout button
+
+    Scenario: Screen Enhance - Validate Medicaid Withdrawal Page from details page
+        And click the SPA ID link in the first row
+        And verify the package details page is visible
+        And verify the header is "Withdraw Medicaid SPA Package" on the withdrawal form
+        And verify the form intro exists on the withdrawal form
+        And verify the SPA ID header exists on the withdrawal form
+        And verify the SPA ID exists on the withdrawal form
+        And verify the Type header exists on the withdrawal form
+        And verify the type is "Medicaid SPA"
+        And verify the Upload Supporting Documentation header exists on the withdrawal form
+        And verify the Additional Info header exists on the withdrawal form
+        And verify the submit button is disabled
+        And verify form cancel button exists
+        And click form cancel button
+        And click Stay on Page
+        And click form cancel button
+        And click Leave Anyway form button
+        Then Click on My Account
+        And click the logout button
+    
+    Scenario: Screen Enhance - Validate Form logic
+        And click the actions button in row one
+        And click withdraw package button
+        And verify the submit button is disabled
+        And add additional info comment in the withdrawal form
+        And verify the submit button is not disabled
+        And upload withdrawal documentation
+        And verify the submit button is not disabled
+        And clear additional info comment in the withdrawal form
+        And verify the submit button is not disabled
+        And Click the Submit Button without waiting
+        And verify yes, withdraw package button exists
+        And click modal cancel button
+        Then Click on My Account
+        And click the logout button

--- a/tests/cypress/cypress/integration/Withdraw_Package_Form_Medicaid_SPA.spec.feature
+++ b/tests/cypress/cypress/integration/Withdraw_Package_Form_Medicaid_SPA.spec.feature
@@ -35,6 +35,7 @@ Feature: Verify user can withdraw a package in Under Review Status in the packag
     Scenario: Screen Enhance - Validate Medicaid Withdrawal Page from details page
         And click the SPA ID link in the first row
         And verify the package details page is visible
+        And click withdraw button
         And verify the header is "Withdraw Medicaid SPA Package" on the withdrawal form
         And verify the form intro exists on the withdrawal form
         And verify the SPA ID header exists on the withdrawal form

--- a/tests/cypress/cypress/integration/Withdraw_Package_Form_Waiver_Amendment.spec.feature
+++ b/tests/cypress/cypress/integration/Withdraw_Package_Form_Waiver_Amendment.spec.feature
@@ -1,0 +1,71 @@
+Feature: Verify user can withdraw a package in Under Review Status in the package dashboard 
+    Background: Reoccurring steps
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And click on the Waivers tab
+        And Click on Filter Button
+        And click on Status
+        And uncheck all of the status checkboxes
+        And click Under Review checkbox
+        And click on Type
+        And uncheck all of the type checkboxes
+        And click 1915b Waiver Amendment check box
+
+    Scenario: Screen Enhance - Validate 1915B Waiver Amendment Withdrawal Page from dashboard
+        And click the actions button in row one
+        And click withdraw package button
+        And verify the header is "Withdraw Waiver" on the withdrawal form
+        And verify the form intro exists on the withdrawal form
+        And verify the Waiver number header exists on the withdrawal form
+        And verify the Waiver number exists on the withdrawal form
+        And verify the Type header exists on the withdrawal form
+        And verify the type is "Waiver Amendment"
+        And verify the Upload Supporting Documentation header exists on the withdrawal form
+        And verify the Additional Info header exists on the withdrawal form
+        And verify the submit button is disabled
+        And verify form cancel button exists
+        And click form cancel button
+        And click Stay on Page
+        And click form cancel button
+        And click Leave Anyway form button
+        Then Click on My Account
+        And click the logout button
+
+    Scenario: Screen Enhance - Validate 1915B Waiver Amendment Withdrawal Page from details page
+        And click the Waiver Number link in the first row
+        And verify the package details page is visible
+        And click withdraw button
+        And verify the header is "Withdraw Waiver" on the withdrawal form
+        And verify the form intro exists on the withdrawal form
+        And verify the Waiver number header exists on the withdrawal form
+        And verify the Waiver number exists on the withdrawal form
+        And verify the Type header exists on the withdrawal form
+        And verify the type is "Waiver Amendment"
+        And verify the Upload Supporting Documentation header exists on the withdrawal form
+        And verify the Additional Info header exists on the withdrawal form
+        And verify the submit button is disabled
+        And verify form cancel button exists
+        And click form cancel button
+        And click Stay on Page
+        And click form cancel button
+        And click Leave Anyway form button
+        Then Click on My Account
+        And click the logout button
+    
+    Scenario: Screen Enhance - Validate Form logic
+        And click the actions button in row one
+        And click withdraw package button
+        And verify the submit button is disabled
+        And add additional info comment in the withdrawal form
+        And verify the submit button is not disabled
+        And upload withdrawal documentation
+        And verify the submit button is not disabled
+        And clear additional info comment in the withdrawal form
+        And verify the submit button is not disabled
+        And Click the Submit Button without waiting
+        And verify yes, withdraw package button exists
+        And click modal cancel button
+        Then Click on My Account
+        And click the logout button

--- a/tests/cypress/cypress/integration/Withdraw_Package_Form_Waiver_Renewal.spec.feature
+++ b/tests/cypress/cypress/integration/Withdraw_Package_Form_Waiver_Renewal.spec.feature
@@ -1,0 +1,71 @@
+Feature: Verify user can withdraw a package in Under Review Status in the package dashboard 
+    Background: Reoccurring steps
+        Given I am on Login Page
+        When Clicking on Development Login
+        When Login with state submitter user
+        And click on Packages
+        And click on the Waivers tab
+        And Click on Filter Button
+        And click on Status
+        And uncheck all of the status checkboxes
+        And click Under Review checkbox
+        And click on Type
+        And uncheck all of the type checkboxes
+        And click 1915b Waiver Renewal check box
+
+    Scenario: Screen Enhance - Validate Renewal Waiver Withdrawal Page from the dashboard
+        And click the actions button in row one
+        And click withdraw package button
+        And verify the header is "Withdraw Waiver" on the withdrawal form
+        And verify the form intro exists on the withdrawal form
+        And verify the Waiver number header exists on the withdrawal form
+        And verify the Waiver number exists on the withdrawal form
+        And verify the Type header exists on the withdrawal form
+        And verify the type is "Waiver Renewal"
+        And verify the Upload Supporting Documentation header exists on the withdrawal form
+        And verify the Additional Info header exists on the withdrawal form
+        And verify the submit button is disabled
+        And verify form cancel button exists
+        And click form cancel button
+        And click Stay on Page
+        And click form cancel button
+        And click Leave Anyway form button
+        Then Click on My Account
+        And click the logout button
+
+    Scenario: Screen Enhance - Validate Renewal Waiver Withdrawal Page from the details page
+        And click the Waiver Number link in the first row
+        And verify the package details page is visible
+        And click withdraw button
+        And verify the header is "Withdraw Waiver" on the withdrawal form
+        And verify the form intro exists on the withdrawal form
+        And verify the Waiver number header exists on the withdrawal form
+        And verify the Waiver number exists on the withdrawal form
+        And verify the Type header exists on the withdrawal form
+        And verify the type is "Waiver Renewal"
+        And verify the Upload Supporting Documentation header exists on the withdrawal form
+        And verify the Additional Info header exists on the withdrawal form
+        And verify the submit button is disabled
+        And verify form cancel button exists
+        And click form cancel button
+        And click Stay on Page
+        And click form cancel button
+        And click Leave Anyway form button
+        Then Click on My Account
+        And click the logout button
+    
+    Scenario: Screen Enhance - Validate Form logic
+        And click the actions button in row one
+        And click withdraw package button
+        And verify the submit button is disabled
+        And add additional info comment in the withdrawal form
+        And verify the submit button is not disabled
+        And upload withdrawal documentation
+        And verify the submit button is not disabled
+        And clear additional info comment in the withdrawal form
+        And verify the submit button is not disabled
+        And Click the Submit Button without waiting
+        And verify yes, withdraw package button exists
+        And click modal cancel button
+        Then Click on My Account
+        And click the logout button

--- a/tests/cypress/cypress/integration/common/steps.js
+++ b/tests/cypress/cypress/integration/common/steps.js
@@ -17,6 +17,7 @@ import oneMacRequestARoleChangePage from "../../../support/pages/oneMacRequestAR
 import oneMacPackageDetailsPage from "../../../support/pages/oneMacPackageDetailsPage";
 import oneMacRespondToRAIPage from "../../../support/pages/oneMacRespondToRAIPage";
 import oneMacDefaultForms from "../../../support/pages/oneMacDefaultForms";
+import withdrawPackagePage from "../../../support/pages/WithdrawPackagePage";
 
 const medicaidSPARAIResponsePage = new MedicaidSPARAIResponsePage();
 const OneMacDashboardPage = new oneMacDashboardPage();
@@ -37,6 +38,7 @@ const OneMacRequestARoleChangePage = new oneMacRequestARoleChangePage();
 const OneMacPackageDetailsPage = new oneMacPackageDetailsPage();
 const OneMacRespondToRAIPage = new oneMacRespondToRAIPage();
 const OneMacDefaultForms = new oneMacDefaultForms();
+const WithdrawPackagePage = new withdrawPackagePage();
 
 Given("I am on Login Page", () => {
   OneMacHomePage.launch();
@@ -1815,7 +1817,7 @@ And("verify the error message says {string}", (string) => {
   OneMacRequestARoleChangePage.verifyErrorMessageTextIs(string);
 });
 
-And("verify the submit button is disabled", () => {
+And("verify the submit button is disabled on request a role page", () => {
   OneMacRequestARoleChangePage.verifySubmitBtnIsDisabled();
 });
 And("verify the submit button is disabled via class", () => {
@@ -1896,6 +1898,9 @@ And("click withdraw package button", () => {
 });
 And("click yes, withdraw package button", () => {
   OneMacPackagePage.clickConfirmWithdrawPackageBtn();
+});
+And("verify yes, withdraw package button exists", () => {
+  OneMacPackagePage.verifyConfirmWithdrawPackageBtnExists();
 });
 And("verify the package details page is visible", () => {
   OneMacPackageDetailsPage.verifyPackageDetailsPageIsVisible();
@@ -2714,4 +2719,46 @@ And("select the 1915b Temporary Extension Type button", () => {
 });
 And("select the 1915c Temporary Extension Type button", () => {
   OneMacRequestWaiverTemporaryExtension.selectOption1915cInTempExtensionType();
+});
+And("verify the header is {string} on the withdrawal form", (string) => {
+  WithdrawPackagePage.verifyWithdrawPageHeader(string);
+});
+And("verify the form intro exists on the withdrawal form", () => {
+  WithdrawPackagePage.verifyFormIntroIsVisible();
+});
+And("verify the SPA ID header exists on the withdrawal form", () => {
+  WithdrawPackagePage.verifySPAIDHeaderExists();
+});
+And("verify the SPA ID exists on the withdrawal form", () => {
+  WithdrawPackagePage.verifySPAIDExists();
+});
+And("verify the Waiver number header exists on the withdrawal form", () => {
+  WithdrawPackagePage.verifyWaiverIDHeaderExists();
+});
+And("verify the Waiver number exists on the withdrawal form", () => {
+  WithdrawPackagePage.verifyWaiverIDExists();
+});
+And("verify the Type header exists on the withdrawal form", () => {
+  WithdrawPackagePage.verifyTypeHeaderExists();
+});
+And("verify the type is {string}", (string) => {
+  WithdrawPackagePage.verifyTypeIs(string);
+});
+And(
+  "verify the Upload Supporting Documentation header exists on the withdrawal form",
+  () => {
+    WithdrawPackagePage.verifyUploadSupportingDocumentationHeaderExists();
+  }
+);
+And("upload withdrawal documentation", () => {
+  WithdrawPackagePage.uploadWithdrawalLetterAddFile();
+});
+And("verify the Additional Info header exists on the withdrawal form", () => {
+  WithdrawPackagePage.verifyAdditionalInfoHeaderExists();
+});
+And("add additional info comment in the withdrawal form", () => {
+  WithdrawPackagePage.addWithdrawalComment();
+});
+And("clear additional info comment in the withdrawal form", () => {
+  WithdrawPackagePage.clearWithdrawalComment();
 });

--- a/tests/cypress/package-lock.json
+++ b/tests/cypress/package-lock.json
@@ -8494,7 +8494,8 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
       "integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -9335,7 +9336,8 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-0.14.0.tgz",
       "integrity": "sha512-7Rdjnko0MjggCmndc1wECAkvQBIhuy+DRtjF7bd5YPZRFvubfMNvrxfqD8PWQmxm7MZE0ffS4Xr43V6ZmvLopg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "cypress-cucumber-preprocessor": {
       "version": "4.3.1",
@@ -9374,7 +9376,8 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz",
       "integrity": "sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "cypress-xpath": {
       "version": "1.8.0",

--- a/tests/cypress/support/pages/WithdrawPackagePage.js
+++ b/tests/cypress/support/pages/WithdrawPackagePage.js
@@ -1,0 +1,58 @@
+const withdrawPageHeader = "//form//h2";
+const formDetails = "#form-intro";
+const spaIDHeader = "//h3[text()='SPA ID']";
+const waiverIDHeader = "//h3[contains(text(),'Waiver')]";
+const typeHeader = "//h3[text()='Type']";
+const uploadSupportingDocumentationHeader =
+  "//h3[text()='Upload Supporting Documentation']";
+const addFileBtn = "#uploader-input-0";
+const additionalInfoHeader = "#additional-information-label";
+const additionalInfoTextArea = "#additional-information";
+
+export class WithdrawPackagePage {
+  verifyWithdrawPageHeader(s) {
+    cy.xpath(withdrawPageHeader).contains(s);
+  }
+  verifyFormIntroIsVisible() {
+    cy.get(formDetails)
+      .should("be.visible")
+      .contains(
+        "Complete this form to withdraw a package. Once complete, you will not be able to resubmit this package. CMS will be notified and will use this content to review your request, and you will not be able to edit this form. If CMS needs any additional information, they will follow up by email."
+      );
+  }
+  verifySPAIDHeaderExists() {
+    cy.xpath(spaIDHeader).should("be.visible");
+  }
+  verifySPAIDExists() {
+    cy.xpath(spaIDHeader).next().should("be.visible");
+  }
+  verifyWaiverIDHeaderExists() {
+    cy.xpath(waiverIDHeader).should("be.visible");
+  }
+  verifyWaiverIDExists() {
+    cy.xpath(waiverIDHeader).next().should("be.visible");
+  }
+  verifyTypeHeaderExists() {
+    cy.xpath(typeHeader).should("be.visible");
+  }
+  verifyTypeIs(s) {
+    cy.xpath(typeHeader).next().contains(s);
+  }
+  verifyUploadSupportingDocumentationHeaderExists() {
+    cy.xpath(uploadSupportingDocumentationHeader).should("be.visible");
+  }
+  uploadWithdrawalLetterAddFile() {
+    const filePath = "/files/adobe.pdf";
+    cy.get(addFileBtn).attachFile(filePath);
+  }
+  verifyAdditionalInfoHeaderExists() {
+    cy.get(additionalInfoHeader).should("be.visible");
+  }
+  addWithdrawalComment() {
+    cy.get(additionalInfoTextArea).type("Withdrawal test.");
+  }
+  clearWithdrawalComment() {
+    cy.get(additionalInfoTextArea).clear();
+  }
+}
+export default WithdrawPackagePage;

--- a/tests/cypress/support/pages/oneMacPackagePage.js
+++ b/tests/cypress/support/pages/oneMacPackagePage.js
@@ -968,6 +968,9 @@ export class oneMacPackagePage {
   clickConfirmWithdrawPackageBtn() {
     cy.xpath(withdrawPackageConfirmBtn).click();
   }
+  verifyConfirmWithdrawPackageBtnExists() {
+    cy.xpath(withdrawPackageConfirmBtn).should("be.visible");
+  }
   verifyChildRowStatusIs(status) {
     cy.get(packageRowTwoStatus).should("contain.text", status);
   }


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-22141
Endpoint: See github-actions bot comment

### Details

Adding withdraw page tests and test updates.

### Test Plan
Like so, for each package type.
```
Feature: Verify user can withdraw a package in Under Review Status in the package dashboard 
    Background: Reoccurring steps
        Given I am on Login Page
        When Clicking on Development Login
        When Login with state submitter user
        And click on Packages
        And Click on Filter Button
        And click on Status
        And uncheck all of the status checkboxes
        And click Under Review checkbox
        And click on Type
        And uncheck all of the type checkboxes
        And click Medicaid SPA check box

       Scenario: Screen Enhance - Validate Medicaid Withdrawal Page from dashboard
        And click the actions button in row one
        And click withdraw package button
        And verify the header is "Withdraw Medicaid SPA Package" on the withdrawal form
        And verify the form intro exists on the withdrawal form
        And verify the SPA ID header exists on the withdrawal form
        And verify the SPA ID exists on the withdrawal form
        And verify the Type header exists on the withdrawal form
        And verify the type is "Medicaid SPA"
        And verify the Upload Supporting Documentation header exists on the withdrawal form
        And verify the Additional Info header exists on the withdrawal form
        And verify the submit button is disabled
        And verify form cancel button exists
        And click form cancel button
        And click Stay on Page
        And click form cancel button
        And click Leave Anyway form button
        Then Click on My Account
        And click the logout button

    Scenario: Screen Enhance - Validate Medicaid Withdrawal Page from details page
        And click the SPA ID link in the first row
        And verify the package details page is visible
        And click withdraw button
        And verify the header is "Withdraw Medicaid SPA Package" on the withdrawal form
        And verify the form intro exists on the withdrawal form
        And verify the SPA ID header exists on the withdrawal form
        And verify the SPA ID exists on the withdrawal form
        And verify the Type header exists on the withdrawal form
        And verify the type is "Medicaid SPA"
        And verify the Upload Supporting Documentation header exists on the withdrawal form
        And verify the Additional Info header exists on the withdrawal form
        And verify the submit button is disabled
        And verify form cancel button exists
        And click form cancel button
        And click Stay on Page
        And click form cancel button
        And click Leave Anyway form button
        Then Click on My Account
        And click the logout button
    
    Scenario: Screen Enhance - Validate Form logic
        And click the actions button in row one
        And click withdraw package button
        And verify the submit button is disabled
        And add additional info comment in the withdrawal form
        And verify the submit button is not disabled
        And upload withdrawal documentation
        And verify the submit button is not disabled
        And clear additional info comment in the withdrawal form
        And verify the submit button is not disabled
        And Click the Submit Button without waiting
        And verify yes, withdraw package button exists
        And click modal cancel button
        Then Click on My Account
        And click the logout button
```
