### PR TITLE
OY2 23777: Adjust Lambda timeout value to prevent loss of email notifications.

### DIFF
--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -98,6 +98,7 @@ functions:
   submitInitialWaiver:
     handler: form/submitInitialWaiver.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: submitInitialWaiver
@@ -108,6 +109,7 @@ functions:
   submitMedicaidSpa:
     handler: form/submitMedicaidSPA.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: submitMedicaidSPA
@@ -118,6 +120,7 @@ functions:
   submitMedicaidSpaRaiResponse:
     handler: form/submitMedicaidSPARAIResponse.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: submitMedicaidSPARAIResponse
@@ -128,6 +131,7 @@ functions:
   submitChipSpa:
     handler: form/submitCHIPSPA.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: submitCHIPSPA
@@ -138,6 +142,7 @@ functions:
   submitCHIPSPARAIResponse:
     handler: form/submitCHIPSPARAIResponse.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: submitCHIPSPARAIResponse
@@ -148,6 +153,7 @@ functions:
   submitWaiverExtension:
     handler: form/submitWaiverExtension.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: submitWaiverExtension
@@ -158,6 +164,7 @@ functions:
   submitWaiverRaiResponse:
     handler: form/submitWaiverRAIResponse.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: submitWaiverRAIResponse
@@ -168,6 +175,7 @@ functions:
   submitWaiverRenewal:
     handler: form/submitWaiverRenewal.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: submitWaiverRenewal
@@ -178,6 +186,7 @@ functions:
   submitWaiverAmendment:
     handler: form/submitWaiverAmendment.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: submitWaiverAmendment
@@ -188,6 +197,7 @@ functions:
   submitWaiverAppendixK:
     handler: form/submitWaiverAppendixK.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: submitWaiverAppendixK
@@ -198,6 +208,7 @@ functions:
   submitWaiverAppendixKRAIResponse:
     handler: form/submitWaiverAppendixKRAIResponse.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: submitWaiverAppendixKRAIResponse
@@ -318,6 +329,7 @@ functions:
   withdrawInitialWaiver:
     handler: form/withdrawInitialWaiver.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: withdrawInitialWaiver
@@ -328,6 +340,7 @@ functions:
   withdrawMedicaidSPA:
     handler: form/withdrawMedicaidSPA.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: withdrawMedicaidSPA
@@ -338,6 +351,7 @@ functions:
   withdrawCHIPSPA:
     handler: form/withdrawCHIPSPA.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: withdrawCHIPSPA
@@ -348,6 +362,7 @@ functions:
   withdrawWaiverRenewal:
     handler: form/withdrawWaiverRenewal.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: withdrawWaiverRenewal
@@ -358,6 +373,7 @@ functions:
   withdrawWaiverAmendment:
     handler: form/withdrawWaiverAmendment.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: withdrawWaiverAmendment
@@ -368,6 +384,7 @@ functions:
   withdrawWaiverAppendixK:
     handler: form/withdrawWaiverAppendixK.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: withdrawWaiverAppendixK
@@ -468,6 +485,7 @@ functions:
   updateUserStatus:
     handler: updateUserStatus.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: updateUserStatus
@@ -478,6 +496,7 @@ functions:
   setUserPhoneNumber:
     handler: putPhoneNumber.main
     role: LambdaApiRole
+    timeout: 30
     events:
       - http:
           path: phoneNumber


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-23777
Endpoint: See github-actions bot comment

### Details
Form submission lambdas use the standard lambda timeout of 6 seconds for processing.  This is plenty of time for most operations, but there were 2 times when sufficient load on the dynamodb table resulted in a timeout.  Analyzing the logs suggests a timeout of 15 seconds should be sufficient, so might as well go for 30!  Care should be taken to observe if increasing the timeout has side effects.

### Changes
- added `timeout: 30` to any lambda with a database-to-email dependency

### Test Plan
1. Successful Deployment
2. Verify all lambdas with database-to-email dependencies have the new timeout value.
3. Login as a submitting user
4. Navigate to any new submission
5. Submit a new Medicaid SPA, CHIP SPA, or waiver
6. Verify the lambda completes
7. Verify the email is sent (can be done through console)
