### PR TITLE
[DO NOT MERGE] - feat(iam): Changes to support bigmac IAM auth.

### DIFF
--- a/services/seatool-sink/serverless.yml
+++ b/services/seatool-sink/serverless.yml
@@ -72,7 +72,7 @@ functions:
         - KafkaConnectWorkerRole
         - Arn
       sessionName: ${self:custom.stage}-sink-role
-      topics: aws.ksqldb.seatool.agg.StatePlan_Medicaid_SPA,aws.ksqldb.seatool.agg.StatePlan_CHIP_SPA,aws.ksqldb.seatool.agg.StatePlan_1915b_waivers,aws.ksqldb.seatool.agg.StatePlan_1915c_waivers,aws.ksqldb.seatool.agg.StatePlan_1915c_Indep_Plus,aws.ksqldb.seatool.agg.StatePlan_1115,aws.ksqldb.seatool.agg.StatePlan_UPL
+      topics: --seatool--iam--aws.ksqldb.seatool.agg.StatePlan_Medicaid_SPA,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_CHIP_SPA,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1915b_waivers,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1915c_waivers,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1915c_Indep_Plus,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1115,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_UPL
       sinkPrefix: onemac-${self:custom.stage}-v4
     maximumRetryAttempts: 2
     timeout: 120


### PR DESCRIPTION
## Details
This changeset represents what's needed to preserve all project functionality when Bigmac IAM Auth is enabled.

## Changes
The connector ECS task was modified to accomodate IAM. An msk iam auth jar is installed as part of the bootstrapping process. The environment variables passed to the container are also expanded and modified, with the appropriate config for IAM auth. In particular, in these env variables is where we say "assume this role".

## Implementation Notes
NB: We added --seatool--iam-- as a prfix to the topics. Please remove the prefix from all topics before merging.

--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_Medicaid_SPA,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_CHIP_SPA,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1915b_waivers,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1915c_waivers,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1915c_Indep_Plus,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_1115,--seatool--iam--aws.ksqldb.seatool.agg.StatePlan_UPL