### PR TITLE
OY2 24198: BUG - Filter returning blank screen on dashboard

### DIFF
--- a/services/ui-src/src/components/SearchAndFilter.tsx
+++ b/services/ui-src/src/components/SearchAndFilter.tsx
@@ -352,7 +352,6 @@ function DateFilter({
 
   const theValues: [Date, Date] = useMemo(() => {
     if (filterValue && typeof filterValue[0] === "string") {
-      console.log("filterValue[0] is a string: ", filterValue);
       filterValue[0] = new Date(filterValue[0]);
       filterValue[1] = new Date(filterValue[1]);
     }


### PR DESCRIPTION
Story: https://qmacbis.atlassian.net/browse/OY2-24198
Endpoint: See github-actions bot comment

### Details
Users were experiencing issues with returning to the Dashboard from the Details page if a date filter was set.  Turns out the filter state is saved as a Date object, but when stored in the Session, is converted to a date/time string.  Solution: when setting a date range, convert any date/time strings to Date objects.

### Changes
- "disabledDate" is a deprecated property on DateRangePicker - converted to "shouldDisableDate"
- Convert date/time strings from the sessions into Date objects - decided not to do this at the session level, but rather as a feature of the DateRangePicker and at time of filtering the data.

### Test Plan
1. Login as any user with access to package dashboard
2. Click the Filter button and add a date filter to the dashboard's results
3. Verify the results are properly filtered
4. Click into a package details
5. return to Dashboard
6. Verify that the dashboard is visible and maintains all filters.
